### PR TITLE
feat: in-app update check + notification (Phase 1)

### DIFF
--- a/Project/main.py
+++ b/Project/main.py
@@ -18,6 +18,7 @@ from controllers.pump_controller import PumpController
 from models.relay_unit_manager import RelayUnitManager
 from ui.SettingsTab import SettingsTab
 from ui.style.theme import StyleManager
+from version import __version__
 
 # =============================================================================
 # Global exception hook and stream redirection (unchanged)
@@ -364,7 +365,7 @@ def run_program(schedule, mode, window_start, window_end):
     except Exception as e:
         print(f"Failed to run program: {e}")
         if notification_handler:
-            notification_handler.send_slack_notification(f"Program error: {e}")
+            notification_handler.send_slack_notification(f"[RRR v{__version__}] Program error: {e}")
 
 # =============================================================================
 # Centralized cleanup() – called once when the worker finishes.
@@ -691,7 +692,7 @@ def _main_with_splash(app, instance_key):
         # Check for updates
         try:
             from ui.update_notifier import UpdateNotifier
-            UpdateNotifier.check_for_updates()
+            UpdateNotifier.check_for_updates(gui)
         except Exception:
             pass
         

--- a/Project/ui/SettingsTab.py
+++ b/Project/ui/SettingsTab.py
@@ -14,6 +14,7 @@ from datetime import datetime
 import pandas as pd
 from models.animal import Animal
 from ui.PrimingControlWidget import PrimingControlWidget
+from ui.UpdatesTab import UpdatesTab
 # CageManagerWidget removed - cage management moved to Projects Section (CagesVisualizationTab)
 from PyQt5.QtWidgets import QApplication
 
@@ -57,6 +58,7 @@ class SettingsTab(QWidget):
         self.calibration_tab = self._create_calibration_tab()  # NEW
         self.priming_control = self._create_priming_control()
         self.general_tab = self._create_general_tab()
+        self.updates_tab = UpdatesTab()
         
         # Add sub-tabs to settings
         # Note: Cage management moved to Projects Section (CagesVisualizationTab)
@@ -64,6 +66,7 @@ class SettingsTab(QWidget):
         self.tab_widget.addTab(self.calibration_tab, "Calibration")
         self.tab_widget.addTab(self.priming_control, "Priming")
         self.tab_widget.addTab(self.general_tab, "General")
+        self.tab_widget.addTab(self.updates_tab, "Updates")
         
         layout.addWidget(self.tab_widget)
         

--- a/Project/ui/UpdatesTab.py
+++ b/Project/ui/UpdatesTab.py
@@ -1,0 +1,104 @@
+"""Settings -> Updates sub-tab.
+
+Shows the installed version and lets the operator check for a newer release on
+demand. Phase 1 of the update system is notify-only: this tab reports whether
+an update exists and links to the release page; it does not install anything.
+See docs/UPDATE_SYSTEM.md.
+"""
+
+from PyQt5.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QGroupBox, QLabel, QPushButton, QTextEdit
+)
+from PyQt5.QtCore import QUrl, pyqtSlot
+from PyQt5.QtGui import QDesktopServices
+
+from version import __version__
+from utils.updater import run_check
+
+
+class UpdatesTab(QWidget):
+    """A read-only update panel: installed version + 'Check for updates'."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._latest = None
+        self._build_ui()
+
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+
+        box = QGroupBox("Software updates")
+        box_layout = QVBoxLayout(box)
+
+        self.current_label = QLabel(f"Installed version:  {__version__}")
+        self.status_label = QLabel(
+            "Press “Check for updates” to see whether a newer "
+            "version is available."
+        )
+        self.status_label.setWordWrap(True)
+
+        button_row = QHBoxLayout()
+        self.check_button = QPushButton("Check for updates")
+        self.check_button.clicked.connect(self.check)
+        self.view_button = QPushButton("View release")
+        self.view_button.setVisible(False)
+        self.view_button.clicked.connect(self._open_release)
+        button_row.addWidget(self.check_button)
+        button_row.addWidget(self.view_button)
+        button_row.addStretch()
+
+        self.notes = QTextEdit()
+        self.notes.setReadOnly(True)
+        self.notes.setVisible(False)
+
+        box_layout.addWidget(self.current_label)
+        box_layout.addWidget(self.status_label)
+        box_layout.addLayout(button_row)
+        box_layout.addWidget(self.notes)
+
+        layout.addWidget(box)
+        layout.addStretch()
+
+    def check(self):
+        """Start a background check for a newer release."""
+        self.check_button.setEnabled(False)
+        self.status_label.setText("Checking…")
+        try:
+            run_check(self, self._on_result)
+        except Exception:
+            self._on_result(None)
+
+    @pyqtSlot(object)
+    def _on_result(self, info):
+        """Receive the check result (on the GUI thread; see updater.run_check)."""
+        self.check_button.setEnabled(True)
+
+        if info is None:
+            self.status_label.setText(
+                "Couldn’t check for updates — no internet "
+                "connection, or GitHub could not be reached."
+            )
+            self.view_button.setVisible(False)
+            self.notes.setVisible(False)
+            return
+
+        self._latest = info
+        if info.available:
+            self.status_label.setText(
+                f"Version {info.version} is available "
+                f"(you have {__version__})."
+            )
+            self.view_button.setVisible(True)
+            if info.notes:
+                self.notes.setPlainText(info.notes)
+                self.notes.setVisible(True)
+        else:
+            self.status_label.setText(
+                f"You’re up to date (version {__version__})."
+            )
+            self.view_button.setVisible(False)
+            self.notes.setVisible(False)
+
+    def _open_release(self):
+        if self._latest is not None:
+            QDesktopServices.openUrl(QUrl(self._latest.url))

--- a/Project/ui/gui.py
+++ b/Project/ui/gui.py
@@ -2,9 +2,10 @@
 
 from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QScrollArea,
-    QPushButton, QPlainTextEdit, QLabel, QMessageBox, QSizePolicy, QTabWidget
+    QPushButton, QPlainTextEdit, QLabel, QMessageBox, QSizePolicy, QTabWidget, QFrame
 )
-from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot, QUrl
+from PyQt5.QtGui import QDesktopServices
 import traceback
 from .run_stop_section import RunStopSection
 from .projects_section import ProjectsSection
@@ -16,6 +17,7 @@ from utils.volume_calculator import VolumeCalculator
 from .login_gate_widget import LoginGateWidget
 from .SettingsTab import SettingsTab
 from .HelpTab import HelpTab
+from version import __version__
 
 class RodentRefreshmentGUI(QWidget):
     system_message_signal = pyqtSignal(str)
@@ -55,7 +57,7 @@ class RodentRefreshmentGUI(QWidget):
         self.init_ui()
 
     def init_ui(self):
-        self.setWindowTitle("Rodent Refreshment Regulator")
+        self.setWindowTitle(f"Rodent Refreshment Regulator  —  v{__version__}")
         self.setMinimumSize(1200, 800)
 
         # Use centralized app-level QSS (StyleManager). No per-widget styles here.
@@ -213,6 +215,66 @@ class RodentRefreshmentGUI(QWidget):
         self.load_animals_tab()
         self.showMaximized()
     
+    def show_update_banner(self, version, url):
+        """Show a dismissable banner announcing an available software update.
+
+        Inserted at the top of the main window. Non-modal — it never blocks
+        the operator. See docs/UPDATE_SYSTEM.md (Phase 1).
+        """
+        try:
+            # Replace any banner already shown.
+            existing = getattr(self, "_update_banner", None)
+            if existing is not None:
+                existing.setParent(None)
+                existing.deleteLater()
+
+            banner = QFrame()
+            banner.setObjectName("updateBanner")
+            banner.setFrameShape(QFrame.StyledPanel)
+            row = QHBoxLayout(banner)
+            row.setContentsMargins(12, 8, 12, 8)
+
+            label = QLabel(f"A new version of RRR is available  —  v{version}")
+            font = label.font()
+            font.setBold(True)
+            label.setFont(font)
+
+            view_button = QPushButton("View release")
+            view_button.clicked.connect(
+                lambda: QDesktopServices.openUrl(QUrl(url))
+            )
+            dismiss_button = QPushButton("Dismiss")
+            dismiss_button.clicked.connect(self._dismiss_update_banner)
+
+            row.addWidget(label)
+            row.addStretch()
+            row.addWidget(view_button)
+            row.addWidget(dismiss_button)
+
+            self.layout().insertWidget(0, banner)
+            self._update_banner = banner
+        except Exception:
+            # A failed banner must never take down the GUI.
+            pass
+
+    def _dismiss_update_banner(self):
+        """Remove the update banner when the operator dismisses it."""
+        banner = getattr(self, "_update_banner", None)
+        if banner is not None:
+            banner.setParent(None)
+            banner.deleteLater()
+            self._update_banner = None
+
+    @pyqtSlot(object)
+    def _on_update_check_result(self, info):
+        """Receive the startup update-check result (see utils.updater.run_check).
+
+        Runs on the GUI thread. Shows the banner only when a newer release
+        exists; does nothing on no-result (offline) or already up-to-date.
+        """
+        if info is not None and getattr(info, "available", False):
+            self.show_update_banner(info.version, info.url)
+
     def _apply_right_stretch(self):
         """Adjust right column stretches based on active tab and settings sub-tab."""
         current = self.main_tab_widget.currentWidget()

--- a/Project/ui/update_notifier.py
+++ b/Project/ui/update_notifier.py
@@ -1,53 +1,87 @@
-"""UI Update Notifier Module
+"""Update notifications.
 
-This module handles checking for UI updates and displaying notifications to users.
+Two things live here:
+
+1. The startup *update check* (Phase 1 of the update system) — on launch it
+   asks GitHub whether a newer release exists and, if so, shows a dismissable
+   banner on the main window. See docs/UPDATE_SYSTEM.md.
+
+2. A legacy local "UI Improvements Applied" dialog driven by a ``ui_updated.json``
+   file. This predates the update system; it is kept for backward
+   compatibility and is a candidate for removal once unused.
+
+main.py calls :meth:`UpdateNotifier.check_for_updates` (with the main window)
+after the GUI is created.
 """
 
 import os
 import json
-from PyQt5.QtWidgets import QMessageBox, QDialog, QVBoxLayout, QLabel, QPushButton, QScrollArea, QWidget
-from PyQt5.QtCore import Qt
+
+from PyQt5.QtWidgets import (
+    QDialog, QVBoxLayout, QLabel, QPushButton, QScrollArea, QWidget
+)
+
+from utils.updater import run_check
+
 
 class UpdateNotifier:
-    """Class to handle UI update notifications."""
-    
-    @staticmethod
-    def check_for_updates():
-        """Checks if UI has been updated and shows notification if needed."""
-        update_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'ui_updated.json')
-        
+    """Update notifications: GitHub release check + legacy local changelog."""
+
+    @classmethod
+    def check_for_updates(cls, gui=None):
+        """Run update checks. Safe to call unconditionally.
+
+        - Always runs the legacy local-changelog check.
+        - When ``gui`` is given, also starts a background GitHub release
+          check; if a newer version exists, ``gui`` shows an update banner.
+          An offline device silently gets no banner.
+        """
+        cls._check_local_changelog()
+
+        if gui is None:
+            return
+        try:
+            run_check(gui, gui._on_update_check_result)
+        except Exception:
+            # An update check must never interfere with app startup.
+            pass
+
+    # ------------------------------------------------------------------
+    # Legacy: local "UI Improvements Applied" dialog (pre-update-system).
+    # ------------------------------------------------------------------
+    @classmethod
+    def _check_local_changelog(cls):
+        """Show the legacy changelog dialog if ui_updated.json flags an update."""
+        update_file = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)), 'ui_updated.json'
+        )
         if not os.path.exists(update_file):
-            return False
-            
+            return
+
         try:
             with open(update_file, 'r') as f:
                 update_data = json.load(f)
-                
+
             if update_data.get('updated', False):
-                # Show notification
-                UpdateNotifier.show_update_notification(update_data)
-                
-                # Reset the update flag so notification shows only once
+                cls.show_update_notification(update_data)
+
+                # Reset the flag so the dialog shows only once.
                 update_data['updated'] = False
                 with open(update_file, 'w') as f:
                     json.dump(update_data, f, indent=4)
-                    
-                return True
         except Exception as e:
             print(f"Error checking for UI updates: {e}")
-            
-        return False
-        
+
     @staticmethod
     def show_update_notification(update_data):
-        """Shows a nicely formatted dialog with update information."""
+        """Show a nicely formatted dialog with legacy update information."""
         dialog = QDialog()
         dialog.setWindowTitle("UI Improvements Applied")
         dialog.setMinimumWidth(400)
         dialog.setMinimumHeight(300)
-        
+
         layout = QVBoxLayout()
-        
+
         # Title
         title_label = QLabel("UI Improvements Applied")
         title_label.setStyleSheet("""
@@ -57,32 +91,32 @@ class UpdateNotifier:
             margin-bottom: 10px;
         """)
         layout.addWidget(title_label)
-        
+
         # Date
         date_label = QLabel(f"Updated on: {update_data.get('date', 'Unknown')}")
         date_label.setStyleSheet("font-style: italic; color: #5f6368;")
         layout.addWidget(date_label)
-        
+
         # Create scrollable area for changes
         scroll_area = QScrollArea()
         scroll_area.setWidgetResizable(True)
         scroll_content = QWidget()
         scroll_layout = QVBoxLayout(scroll_content)
-        
+
         # Add change list
         changes_label = QLabel("Changes:")
         changes_label.setStyleSheet("font-weight: bold; margin-top: 10px;")
         scroll_layout.addWidget(changes_label)
-        
+
         for change in update_data.get('changes', []):
             change_item = QLabel(f"• {change}")
             change_item.setWordWrap(True)
             scroll_layout.addWidget(change_item)
-        
+
         scroll_layout.addStretch()
         scroll_area.setWidget(scroll_content)
         layout.addWidget(scroll_area)
-        
+
         # OK button
         ok_button = QPushButton("OK")
         ok_button.clicked.connect(dialog.accept)
@@ -100,6 +134,6 @@ class UpdateNotifier:
             }
         """)
         layout.addWidget(ok_button)
-        
+
         dialog.setLayout(layout)
-        dialog.exec_() 
+        dialog.exec_()

--- a/Project/utils/updater.py
+++ b/Project/utils/updater.py
@@ -1,0 +1,135 @@
+"""Update checking for RRR.
+
+Phase 1 of the update system (notify-only): this module asks GitHub whether a
+newer release exists and reports the result. It does not download or apply
+anything — see docs/UPDATE_SYSTEM.md for the full design and later phases.
+
+The network call always runs on a background thread (see ``run_check``) so the
+GUI never blocks, and every failure path is swallowed: offline devices simply
+get "no result", never an error.
+"""
+
+import re
+
+import requests
+from PyQt5.QtCore import QObject, QThread, pyqtSignal
+
+from version import __version__ as CURRENT_VERSION
+
+# The repository whose Releases are the update channel.
+GITHUB_REPO = "Corticomics/rodRefReg"
+_LATEST_RELEASE_API = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+_RELEASES_PAGE = f"https://github.com/{GITHUB_REPO}/releases"
+_REQUEST_TIMEOUT_S = 10
+
+
+def _version_tuple(text):
+    """Parse ``v1.2.3`` / ``1.2.3`` / ``1.2.3-beta`` into a comparable tuple.
+
+    Returns ``(1, 2, 3)`` or ``None`` if the string is not a recognisable
+    MAJOR.MINOR.PATCH version. The pre-release suffix is ignored.
+    """
+    match = re.match(r"v?(\d+)\.(\d+)\.(\d+)", (text or "").strip())
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
+
+
+def is_newer(candidate, current=CURRENT_VERSION):
+    """True when ``candidate`` is a strictly higher version than ``current``."""
+    parsed_candidate = _version_tuple(candidate)
+    parsed_current = _version_tuple(current)
+    if parsed_candidate is None or parsed_current is None:
+        return False
+    return parsed_candidate > parsed_current
+
+
+class UpdateInfo:
+    """The outcome of a successful update check."""
+
+    def __init__(self, version, url, notes, available):
+        self.version = version      # e.g. "1.1.0" (no leading "v")
+        self.url = url              # GitHub release page URL
+        self.notes = notes          # release notes / changelog text
+        self.available = available  # True if `version` is newer than CURRENT_VERSION
+
+
+def fetch_latest():
+    """Query GitHub for the latest stable release.
+
+    Returns an :class:`UpdateInfo`, or ``None`` if the check could not be
+    completed — offline, rate-limited, or no releases published yet. Never
+    raises. Pre-releases (``v*-beta``) are excluded by the GitHub endpoint.
+    """
+    try:
+        response = requests.get(
+            _LATEST_RELEASE_API,
+            timeout=_REQUEST_TIMEOUT_S,
+            headers={"Accept": "application/vnd.github+json"},
+        )
+        response.raise_for_status()
+        data = response.json()
+    except Exception:
+        return None
+
+    tag = data.get("tag_name", "")
+    version = tag[1:] if tag.startswith("v") else tag
+    if _version_tuple(version) is None:
+        return None
+
+    return UpdateInfo(
+        version=version,
+        url=data.get("html_url") or _RELEASES_PAGE,
+        notes=(data.get("body") or "").strip(),
+        available=is_newer(version),
+    )
+
+
+class UpdateCheckWorker(QObject):
+    """Runs :func:`fetch_latest` off the GUI thread."""
+
+    finished = pyqtSignal(object)  # emits an UpdateInfo, or None
+
+    def run(self):
+        self.finished.emit(fetch_latest())
+
+
+def run_check(parent, on_done):
+    """Run an update check on a background thread.
+
+    ``on_done(info)`` is called when the check finishes, with an
+    :class:`UpdateInfo` or ``None``.
+
+    IMPORTANT: ``on_done`` must be a bound method of a QObject that lives on
+    the GUI thread (e.g. ``some_widget._on_result``). PyQt then delivers the
+    result via a queued connection, so ``on_done`` runs safely on the GUI
+    thread. A plain function/closure would run on the worker thread instead.
+
+    ``parent`` (a QObject, typically the calling widget) holds strong
+    references to the thread and worker until the check completes, so neither
+    is garbage-collected mid-flight.
+    """
+    thread = QThread()
+    worker = UpdateCheckWorker()
+    worker.moveToThread(thread)
+
+    holder = getattr(parent, "_rrr_update_checks", None)
+    if holder is None:
+        holder = []
+        parent._rrr_update_checks = holder
+    holder.append((thread, worker))
+
+    def _cleanup():
+        try:
+            holder.remove((thread, worker))
+        except ValueError:
+            pass
+
+    thread.started.connect(worker.run)
+    worker.finished.connect(on_done)
+    worker.finished.connect(thread.quit)
+    worker.finished.connect(worker.deleteLater)
+    thread.finished.connect(thread.deleteLater)
+    thread.finished.connect(_cleanup)
+    thread.start()
+    return thread

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"


### PR DESCRIPTION
Phase 1 of the update system (docs/UPDATE_SYSTEM.md): notify-only. The app now tells operators when a newer release exists; it does not download or apply anything yet.

- utils/updater.py: background-thread check against the GitHub Releases API, SemVer comparison, silent-fails when offline
- ui/update_notifier.py: startup check; shows a dismissable banner on the main window when an update is available (the legacy ui_updated.json dialog is preserved alongside it)
- ui/UpdatesTab.py: a Settings > Updates panel showing the installed version with a manual "Check for updates" button
- gui.py: window title now shows the version; hosts the update banner
- main.py: passes the main window to the update check, and tags Slack error reports with the running version
- version.py: 1.0.0 -> 1.1.0 (MINOR: backward-compatible feature)