### PR TITLE
feat: blue-green release layout + data migration (Phase 2b)

### DIFF
--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/docs/UPDATE_SYSTEM.md
+++ b/docs/UPDATE_SYSTEM.md
@@ -559,3 +559,32 @@ is now part of the plan.
   Documented in each module header.
 - **D4 — `requirements_hash` state** must live in `shared/` to decide whether to re-pip.
   A single small state file is the one source of truth.
+
+### 14.6 Phase 2b — implementation risk log
+
+Found while designing the installer refactor; each is mitigated in the 2b code.
+
+- **B1 — root vs user home.** `install.sh` may run under `sudo`; assuming `$HOME` would build
+  the tree in `/root`. *Mitigation:* a shared `scripts/install/layout.sh` resolves the target
+  user/home via `SUDO_USER` (the pattern `50-services.sh` already uses); the tree is
+  `chown`ed to the target user.
+- **B2 — venv-path drift.** The venv path is referenced by `30-python`, `40-hardware`,
+  `60-verify`, and `launch.sh`. *Mitigation:* `layout.sh` defines `RRR_VENV` once; every
+  module consumes it — no path is hard-coded in more than one place.
+- **B3 — `--only` / `--skip` runs.** Modules now depend on layout variables. *Mitigation:*
+  `layout.sh` is sourced by `lib.sh`, so the variables exist for every module regardless of
+  which subset runs.
+- **B4 — a re-run corrupts the running release.** *Mitigation:* the bundle is extracted to
+  `.incoming-<v>` then atomically `mv`'d into place; the `current` symlink is swapped with
+  `mv -T` (atomic rename), never `rm`+`ln`.
+- **B5 — migration corruption / live DB.** *Mitigation:* the DB is copied with SQLite's
+  online-backup API (`Connection.backup()` via the stdlib — no `sqlite3` CLI dependency),
+  consistent even if the DB is open. Copy-not-move; a timestamped copy also goes to
+  `shared/backups/`.
+- **B6 — re-migration / split data.** *Mitigation:* migration is skipped entirely when
+  `shared/data/rrr_database.db` already exists.
+- **B7 — `20-repo` refuses a dirty tree.** A device whose clone has local edits will silently
+  not update through the installer. *Mitigation:* documented; a device clone is hard-reset to
+  the target branch before an installer run. OTA updates (2c) bypass this path entirely.
+- **B8 — orphaned pre-2b venv.** The old `~/rodRefReg/.venv` is left behind, unused.
+  *Mitigation:* harmless; documented as build-only cruft (relates to D2).

--- a/scripts/install/25-layout.sh
+++ b/scripts/install/25-layout.sh
@@ -1,0 +1,93 @@
+# shellcheck shell=bash
+# Layout: build the blue-green release tree under ~/rrr and migrate data.
+#
+# Runs after 20-repo (needs the synced checkout) and before 30-python (which
+# creates the venv inside shared/). See docs/UPDATE_SYSTEM.md §13.2 and §13.4.
+#
+# Idempotent: a re-run refreshes the release for the current version and
+# leaves already-migrated data untouched.
+
+VERSION=$(python3 -c "exec(open('$REPO_ROOT/Project/version.py').read()); print(__version__)") \
+  || die "cannot read version from Project/version.py"
+[[ -n "$VERSION" ]] || die "empty version in Project/version.py"
+RELEASE_DIR="$RRR_RELEASES/$VERSION"
+
+info "blue-green layout: home=$RRR_HOME version=$VERSION"
+
+# ---- directory skeleton -------------------------------------------------
+run install -d -o "$RRR_TARGET_USER" -g "$RRR_TARGET_USER" \
+  "$RRR_HOME" "$RRR_RELEASES" "$RRR_SHARED" "$RRR_DATA_DIR" \
+  "$RRR_LOGS_DIR" "$RRR_BACKUPS_DIR" "$RRR_STATE"
+
+# ---- build the release bundle and stage it ------------------------------
+# build-bundle.sh archives git HEAD, which 20-repo has already synced.
+step "building release bundle $VERSION" -- \
+  run bash "$REPO_ROOT/scripts/release/build-bundle.sh"
+
+BUNDLE="$REPO_ROOT/dist/rrr-$VERSION.rrrupdate"
+[[ -f "$BUNDLE" || "${DRY_RUN:-0}" == "1" ]] || die "release bundle not found: $BUNDLE"
+
+# Extract into a staging dir, then swap into place — never extract over a
+# live release directory (B4).
+INCOMING="$RRR_RELEASES/.incoming-$VERSION"
+run rm -rf "$INCOMING"
+run install -d -o "$RRR_TARGET_USER" -g "$RRR_TARGET_USER" "$INCOMING"
+step "extracting release $VERSION" -- run tar -xzf "$BUNDLE" -C "$INCOMING"
+run rm -rf "$RELEASE_DIR"
+run mv "$INCOMING" "$RELEASE_DIR"
+
+# ---- point `current` at this release (atomic rename) -------------------
+run ln -sfn "$RELEASE_DIR" "$RRR_HOME/.current.tmp"
+run mv -T "$RRR_HOME/.current.tmp" "$RRR_CURRENT"
+info "current -> $RELEASE_DIR"
+
+# ---- migrate persistent data into shared/ ------------------------------
+# Copy-not-move, idempotent. See docs/UPDATE_SYSTEM.md §13.4 / risks R1-R5.
+_rrr_migrate_data() {
+  local db_dst="$RRR_DATA_DIR/rrr_database.db"
+  if [[ -e "$db_dst" ]]; then
+    info "data already migrated ($db_dst) — skipping"
+    return 0
+  fi
+
+  local legacy_db="$REPO_ROOT/Project/rrr_database.db"
+  local legacy_settings="$REPO_ROOT/Project/settings/settings.json"
+  [[ -f "$legacy_settings" ]] || legacy_settings="$REPO_ROOT/Project/settings.json"
+
+  local backup
+  backup="$RRR_BACKUPS_DIR/$(date +%Y%m%d-%H%M%S)"
+
+  if [[ -f "$legacy_db" ]]; then
+    install -d "$backup"
+    # SQLite online-backup API: a consistent snapshot even if the DB is open.
+    python3 - "$legacy_db" "$db_dst" "$backup/rrr_database.db" <<'PY'
+import sqlite3, sys
+src = sqlite3.connect(sys.argv[1])
+for dest_path in sys.argv[2:]:
+    dst = sqlite3.connect(dest_path)
+    with dst:
+        src.backup(dst)
+    dst.close()
+src.close()
+PY
+    info "migrated database -> $db_dst (backup in $backup)"
+  else
+    info "no legacy database — fresh install, nothing to migrate"
+  fi
+
+  if [[ -f "$legacy_settings" ]]; then
+    install -d "$backup"
+    install -m 0644 "$legacy_settings" "$RRR_DATA_DIR/settings.json"
+    install -m 0644 "$legacy_settings" "$backup/settings.json"
+    info "migrated settings -> $RRR_DATA_DIR/settings.json"
+  fi
+}
+
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+  info "[dry-run] would migrate database + settings into $RRR_DATA_DIR"
+else
+  _rrr_migrate_data
+fi
+
+# ---- ensure the whole tree is owned by the target user (B1 / R4) -------
+run chown -R "$RRR_TARGET_USER:$RRR_TARGET_USER" "$RRR_HOME"

--- a/scripts/install/30-python.sh
+++ b/scripts/install/30-python.sh
@@ -1,7 +1,8 @@
 # shellcheck shell=bash
 # Python: venv with --system-site-packages, pip install -r requirements.txt.
 
-VENV_DIR="$REPO_ROOT/.venv"
+# venv lives in the shared/ tree so it survives release swaps (layout.sh).
+VENV_DIR="$RRR_VENV"
 REQ_FILE="$REPO_ROOT/requirements.txt"
 
 [[ -f "$REQ_FILE" ]] || die "requirements.txt missing at $REQ_FILE"

--- a/scripts/install/40-hardware.sh
+++ b/scripts/install/40-hardware.sh
@@ -62,7 +62,7 @@ fi
 # Install the SM16relind Python wrapper into the project venv.
 # Upstream ships it under python/ with a setup.py (modern build).
 SM_PY_DIR="$VENDOR_DIR/python"
-VENV_PIP="$REPO_ROOT/.venv/bin/pip"
+VENV_PIP="$RRR_VENV/bin/pip"
 if [[ -d "$SM_PY_DIR" && -x "$VENV_PIP" ]]; then
   if [[ -f "$SM_PY_DIR/pyproject.toml" || -f "$SM_PY_DIR/setup.py" ]]; then
     step "installing SM16relind python wrapper into venv" -- \

--- a/scripts/install/50-services.sh
+++ b/scripts/install/50-services.sh
@@ -2,9 +2,9 @@
 # Services: install launcher to ~/.local/bin/rrr, desktop entry, and an
 # optional systemd --user unit. No system-level service (GUI app).
 
-TARGET_USER=${SUDO_USER:-$USER}
-TARGET_HOME=$(getent passwd "$TARGET_USER" | cut -d: -f6)
-[[ -n "$TARGET_HOME" && -d "$TARGET_HOME" ]] || die "cannot resolve home for $TARGET_USER"
+# Target user/home come from layout.sh (resolves SUDO_USER correctly).
+TARGET_USER=$RRR_TARGET_USER
+TARGET_HOME=$RRR_TARGET_HOME
 
 BIN_DIR="$TARGET_HOME/.local/bin"
 APPS_DIR="$TARGET_HOME/.local/share/applications"
@@ -18,12 +18,14 @@ DESKTOP_DIR=$(
 run install -d -m 0755 -o "$TARGET_USER" -g "$TARGET_USER" \
   "$BIN_DIR" "$APPS_DIR" "$UNIT_DIR" "$DESKTOP_DIR"
 
-# ---- rrr launcher ------------------------------------------------------
-LAUNCHER_SRC="$REPO_ROOT/scripts/runtime/launch.sh"
+# ---- rrr launcher shim -------------------------------------------------
+# ~/.local/bin/rrr is a thin, stable shim — it delegates to the launcher
+# inside the current release, so launch logic itself is updatable.
+LAUNCHER_SRC="$REPO_ROOT/scripts/runtime/rrr-shim.sh"
 LAUNCHER_DST="$BIN_DIR/rrr"
 [[ -f "$LAUNCHER_SRC" ]] || die "missing $LAUNCHER_SRC"
 run install -m 0755 -o "$TARGET_USER" -g "$TARGET_USER" "$LAUNCHER_SRC" "$LAUNCHER_DST"
-info "installed launcher: $LAUNCHER_DST"
+info "installed launcher shim: $LAUNCHER_DST"
 
 # ---- Desktop entry -----------------------------------------------------
 # Menu entry under Applications.

--- a/scripts/install/60-verify.sh
+++ b/scripts/install/60-verify.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 # Verify: smoke-test imports and hardware presence. Non-fatal warnings only.
 
-VENV_PY="$REPO_ROOT/.venv/bin/python3"
+VENV_PY="$RRR_VENV/bin/python3"
 [[ -x "$VENV_PY" ]] || { warn "venv python not found; skipping verify"; return 0; }
 
 _check_import() {

--- a/scripts/install/layout.sh
+++ b/scripts/install/layout.sh
@@ -1,0 +1,30 @@
+# shellcheck shell=bash
+# Shared layout definitions for the blue-green install tree.
+#
+# Sourced by lib.sh, so every install module sees these variables — there is
+# no other source of truth for the tree's paths. Never executed directly.
+# See docs/UPDATE_SYSTEM.md §13.
+
+if [[ -z "${_RRR_LAYOUT_LOADED:-}" ]]; then
+_RRR_LAYOUT_LOADED=1
+
+# Resolve the user the install is *for* — not root, when run via sudo (B1).
+RRR_TARGET_USER=${SUDO_USER:-$USER}
+RRR_TARGET_HOME=$(getent passwd "$RRR_TARGET_USER" 2>/dev/null | cut -d: -f6)
+[[ -n "${RRR_TARGET_HOME:-}" && -d "$RRR_TARGET_HOME" ]] || RRR_TARGET_HOME=$HOME
+
+# Blue-green tree under the target user's home (docs/UPDATE_SYSTEM.md §13.0).
+RRR_HOME="$RRR_TARGET_HOME/rrr"
+RRR_RELEASES="$RRR_HOME/releases"
+RRR_CURRENT="$RRR_HOME/current"
+RRR_SHARED="$RRR_HOME/shared"
+RRR_VENV="$RRR_SHARED/venv"
+RRR_DATA_DIR="$RRR_SHARED/data"
+RRR_LOGS_DIR="$RRR_SHARED/logs"
+RRR_BACKUPS_DIR="$RRR_SHARED/backups"
+RRR_STATE="$RRR_HOME/state"
+
+export RRR_TARGET_USER RRR_TARGET_HOME RRR_HOME RRR_RELEASES RRR_CURRENT \
+       RRR_SHARED RRR_VENV RRR_DATA_DIR RRR_LOGS_DIR RRR_BACKUPS_DIR RRR_STATE
+
+fi # _RRR_LAYOUT_LOADED

--- a/scripts/install/lib.sh
+++ b/scripts/install/lib.sh
@@ -13,6 +13,10 @@ _RRR_LIB_LOADED=1
 # shellcheck source=ui.sh
 source "${BASH_SOURCE[0]%/*}/ui.sh"
 
+# shellcheck source=layout.sh
+# Blue-green layout paths (RRR_HOME, RRR_VENV, …) — every module consumes these.
+source "${BASH_SOURCE[0]%/*}/layout.sh"
+
 # ---- Logging shims -------------------------------------------------------
 # Back-compat helpers. Existing modules call info/warn/err/die/section; we
 # keep those names but route through the UI renderer.

--- a/scripts/runtime/launch.sh
+++ b/scripts/runtime/launch.sh
@@ -1,22 +1,24 @@
 #!/usr/bin/env bash
-# Launch the RRR application. Installed to ~/.local/bin/rrr.
+# RRR launcher — runs the application from the current release.
+#
+# Lives inside each release at scripts/runtime/launch.sh and is invoked by the
+# stable shim at ~/.local/bin/rrr. It resolves the blue-green layout, exports
+# RRR_DATA so the app stores data outside the swappable code, and execs the app.
+# See docs/UPDATE_SYSTEM.md §13.2.
 set -Eeuo pipefail
 
-# Resolve repo root: this file lives at <repo>/scripts/runtime/launch.sh
-# When installed to ~/.local/bin/rrr, RRR_REPO env var or fallback path is used.
-if [[ -n "${RRR_REPO:-}" && -d "$RRR_REPO" ]]; then
-  REPO="$RRR_REPO"
-elif [[ -d "$HOME/rodRefReg" ]]; then
-  REPO="$HOME/rodRefReg"
-elif [[ -d "$HOME/Documents/GitHub/rodRefReg" ]]; then
-  REPO="$HOME/Documents/GitHub/rodRefReg"
-else
-  echo "rrr: cannot locate repo; set RRR_REPO=/path/to/rodRefReg" >&2
-  exit 1
-fi
+RRR_HOME="${RRR_HOME:-$HOME/rrr}"
+CURRENT="$RRR_HOME/current"
+VENV="$RRR_HOME/shared/venv"
 
-VENV="$REPO/.venv"
-[[ -x "$VENV/bin/python3" ]] || { echo "rrr: venv missing at $VENV; run install.sh" >&2; exit 1; }
+[[ -d "$CURRENT/Project" ]] || {
+  echo "rrr: no current release at $CURRENT — run install.sh" >&2; exit 1; }
+[[ -x "$VENV/bin/python3" ]] || {
+  echo "rrr: venv missing at $VENV — run install.sh" >&2; exit 1; }
 
-cd "$REPO/Project"
+export RRR_HOME
+export RRR_DATA="$RRR_HOME/shared/data"
+mkdir -p "$RRR_DATA"
+
+cd "$CURRENT/Project"
 exec "$VENV/bin/python3" main.py "$@"

--- a/scripts/runtime/rrr-shim.sh
+++ b/scripts/runtime/rrr-shim.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# RRR launcher shim — installed to ~/.local/bin/rrr by the installer.
+#
+# A deliberately minimal, stable entry point: it delegates to the launcher
+# inside the current release, so the real launch logic can be updated by a
+# release without ever touching ~/.local/bin/rrr.
+# See docs/UPDATE_SYSTEM.md §13.2.
+exec "${RRR_HOME:-$HOME/rrr}/current/scripts/runtime/launch.sh" "$@"


### PR DESCRIPTION
Phase 2b of the update system (docs/UPDATE_SYSTEM.md §13.2). The device now runs from a versioned, swappable release tree under ~/rrr instead of in place from the git clone -- the groundwork for atomic updates and rollback.

Layout (~/rrr): releases/<version>/ holds extracted release code; a `current` symlink points at the live one; shared/ holds the venv, data, logs and backups and survives every release swap.

- scripts/install/layout.sh: single source of truth for the tree's paths; sourced by lib.sh so every module sees RRR_HOME, RRR_VENV, etc.
- scripts/install/25-layout.sh: builds the release bundle, extracts it to releases/<version>/, points `current` at it (atomic rename), and migrates the database + settings into shared/data (copy-not-move, timestamped backup, SQLite online-backup API)
- 30-python / 40-hardware / 60-verify: venv now lives at shared/venv
- 50-services: installs a thin, stable shim as ~/.local/bin/rrr that delegates to the launcher inside the current release
- scripts/runtime/launch.sh: rewritten to run from ~/rrr/current and export RRR_DATA; scripts/runtime/rrr-shim.sh: the shim
- docs/UPDATE_SYSTEM.md: Phase 2b implementation risk log (§14.6)
- version.py: 1.2.0 -> 1.3.0