### PR TITLE
feat: in-app apply engine + rollback (Phase 2c)

### DIFF
--- a/Project/main.py
+++ b/Project/main.py
@@ -20,6 +20,7 @@ from models.relay_unit_manager import RelayUnitManager
 from ui.SettingsTab import SettingsTab
 from ui.style.theme import StyleManager
 from version import __version__
+from utils import updater
 
 # =============================================================================
 # Global exception hook and stream redirection (unchanged)
@@ -107,6 +108,33 @@ class ControlSignals(QObject):
     stop_requested = pyqtSignal()
 
 control_signals = ControlSignals()
+
+
+def _schedule_is_running():
+    """True while a delivery worker thread is active — gates in-app updates."""
+    try:
+        return thread is not None and hasattr(thread, "isRunning") and thread.isRunning()
+    except Exception:
+        return False
+
+
+def _selftest():
+    """Health-check a candidate release for the update apply engine.
+
+    Imports the core modules and opens the database, then exits 0 (healthy) or
+    1 (broken). Invoked as ``main.py --selftest`` by updater.apply_update before
+    a release is activated. See docs/UPDATE_SYSTEM.md §14.7.
+    """
+    try:
+        from models.database_handler import DatabaseHandler
+        from controllers.system_controller import SystemController  # noqa: F401
+        from ui.gui import RodentRefreshmentGUI  # noqa: F401
+        DatabaseHandler().connect().close()
+        print("rrr selftest: OK")
+        sys.exit(0)
+    except Exception as exc:
+        print(f"rrr selftest: FAILED: {exc}")
+        sys.exit(1)
 
 # =============================================================================
 # setup() – create our global objects and UI
@@ -615,6 +643,9 @@ def main():
 
     # Create application
     app = SafeQApplication(sys.argv)
+
+    # Gate in-app updates: never apply one while a delivery schedule runs.
+    updater.set_busy_check(_schedule_is_running)
     
     # Apply initial theme
     try:
@@ -808,4 +839,7 @@ def _main_without_splash(app, instance_key):
     server.newConnection.connect(_handle_new_connection)
 
 if __name__ == "__main__":
-    main()
+    if "--selftest" in sys.argv:
+        _selftest()
+    else:
+        main()

--- a/Project/ui/UpdatesTab.py
+++ b/Project/ui/UpdatesTab.py
@@ -1,28 +1,30 @@
 """Settings -> Updates sub-tab.
 
-Shows the installed version and lets the operator check for a newer release on
-demand. Phase 1 of the update system is notify-only: this tab reports whether
-an update exists and links to the release page; it does not install anything.
-See docs/UPDATE_SYSTEM.md.
+Shows the installed version, checks for newer releases, and — on an installed
+(blue-green) device — installs them one click and rolls back. On a developer
+clone the install/rollback controls stay hidden. See docs/UPDATE_SYSTEM.md §13.
 """
 
 from PyQt5.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QGroupBox, QLabel, QPushButton, QTextEdit
+    QWidget, QVBoxLayout, QHBoxLayout, QGroupBox, QLabel, QPushButton,
+    QTextEdit, QMessageBox
 )
 from PyQt5.QtCore import QUrl, pyqtSlot
 from PyQt5.QtGui import QDesktopServices
 
 from version import __version__
-from utils.updater import run_check
+from utils import paths, updater
 
 
 class UpdatesTab(QWidget):
-    """A read-only update panel: installed version + 'Check for updates'."""
+    """Update panel: installed version, check, one-click install, rollback."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self._latest = None
+        self._applying = False
         self._build_ui()
+        self._refresh_revert_button()
 
     def _build_ui(self):
         layout = QVBoxLayout(self)
@@ -32,19 +34,26 @@ class UpdatesTab(QWidget):
 
         self.current_label = QLabel(f"Installed version:  {__version__}")
         self.status_label = QLabel(
-            "Press “Check for updates” to see whether a newer "
-            "version is available."
+            "Press “Check for updates” to see whether a newer version "
+            "is available."
         )
         self.status_label.setWordWrap(True)
 
         button_row = QHBoxLayout()
         self.check_button = QPushButton("Check for updates")
         self.check_button.clicked.connect(self.check)
+        self.update_button = QPushButton("Update now")
+        self.update_button.setVisible(False)
+        self.update_button.clicked.connect(self._on_update_now)
         self.view_button = QPushButton("View release")
         self.view_button.setVisible(False)
         self.view_button.clicked.connect(self._open_release)
-        button_row.addWidget(self.check_button)
-        button_row.addWidget(self.view_button)
+        self.revert_button = QPushButton("Revert to previous version")
+        self.revert_button.setVisible(False)
+        self.revert_button.clicked.connect(self._on_revert)
+        for widget in (self.check_button, self.update_button,
+                       self.view_button, self.revert_button):
+            button_row.addWidget(widget)
         button_row.addStretch()
 
         self.notes = QTextEdit()
@@ -59,12 +68,17 @@ class UpdatesTab(QWidget):
         layout.addWidget(box)
         layout.addStretch()
 
+    def _refresh_revert_button(self):
+        """Show 'Revert' only when a rollback target exists."""
+        self.revert_button.setVisible(updater.has_previous_release())
+
+    # --- check -------------------------------------------------------------
     def check(self):
         """Start a background check for a newer release."""
         self.check_button.setEnabled(False)
         self.status_label.setText("Checking…")
         try:
-            run_check(self, self._on_result)
+            updater.run_check(self, self._on_result)
         except Exception:
             self._on_result(None)
 
@@ -75,29 +89,103 @@ class UpdatesTab(QWidget):
 
         if info is None:
             self.status_label.setText(
-                "Couldn’t check for updates — no internet "
-                "connection, or GitHub could not be reached."
+                "Couldn’t check for updates — no internet connection, "
+                "or GitHub could not be reached."
             )
+            self.update_button.setVisible(False)
             self.view_button.setVisible(False)
             self.notes.setVisible(False)
             return
 
         self._latest = info
         if info.available:
-            self.status_label.setText(
-                f"Version {info.version} is available "
-                f"(you have {__version__})."
-            )
             self.view_button.setVisible(True)
+            can_apply = bool(paths.home_dir() and info.bundle_url)
+            self.update_button.setVisible(can_apply)
+            if can_apply:
+                self.status_label.setText(
+                    f"Version {info.version} is available "
+                    f"(you have {__version__})."
+                )
+            else:
+                self.status_label.setText(
+                    f"Version {info.version} is available (you have "
+                    f"{__version__}). Re-run the installer to update."
+                )
             if info.notes:
                 self.notes.setPlainText(info.notes)
                 self.notes.setVisible(True)
         else:
-            self.status_label.setText(
-                f"You’re up to date (version {__version__})."
-            )
+            self.status_label.setText(f"You’re up to date (version {__version__}).")
+            self.update_button.setVisible(False)
             self.view_button.setVisible(False)
             self.notes.setVisible(False)
+
+    # --- apply -------------------------------------------------------------
+    def _on_update_now(self):
+        if self._applying or not self._latest:
+            return
+        if QMessageBox.question(
+            self, "Install update",
+            f"Install version {self._latest.version} now?\n\n"
+            "The update is downloaded and verified, then takes effect when "
+            "RRR restarts. A running delivery schedule will block it.",
+        ) != QMessageBox.Yes:
+            return
+
+        self._applying = True
+        self.update_button.setEnabled(False)
+        self.check_button.setEnabled(False)
+        self.status_label.setText("Starting update…")
+        try:
+            updater.run_apply(self, self._latest,
+                              self._on_apply_progress, self._on_apply_done)
+        except Exception as exc:
+            self._on_apply_done(False, f"Update failed: {exc}")
+
+    @pyqtSlot(str)
+    def _on_apply_progress(self, message):
+        self.status_label.setText(message)
+
+    @pyqtSlot(bool, str)
+    def _on_apply_done(self, ok, message):
+        self._applying = False
+        self.check_button.setEnabled(True)
+        self.update_button.setEnabled(True)
+        self.status_label.setText(message)
+        self._refresh_revert_button()
+        if ok:
+            self.update_button.setVisible(False)
+            self._offer_restart(message)
+        else:
+            QMessageBox.warning(self, "Update not installed", message)
+
+    # --- revert ------------------------------------------------------------
+    def _on_revert(self):
+        if QMessageBox.question(
+            self, "Revert to previous version",
+            "Roll back to the previously installed version?\n\n"
+            "It takes effect when RRR restarts.",
+        ) != QMessageBox.Yes:
+            return
+        ok, message = updater.revert()
+        if ok:
+            self.status_label.setText(message)
+            self._offer_restart(message)
+        else:
+            QMessageBox.warning(self, "Could not revert", message)
+
+    # --- restart -----------------------------------------------------------
+    def _offer_restart(self, message):
+        box = QMessageBox(self)
+        box.setWindowTitle("Restart required")
+        box.setText(message)
+        box.setInformativeText("Restart RRR now?")
+        box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+        if box.exec_() == QMessageBox.Yes:
+            restarted, detail = updater.restart_app()
+            if not restarted:
+                QMessageBox.information(self, "Restart", detail)
 
     def _open_release(self):
         if self._latest is not None:

--- a/Project/ui/gui.py
+++ b/Project/ui/gui.py
@@ -4,7 +4,7 @@ from PyQt5.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QScrollArea,
     QPushButton, QPlainTextEdit, QLabel, QMessageBox, QSizePolicy, QTabWidget, QFrame
 )
-from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot, QUrl
+from PyQt5.QtCore import Qt, pyqtSignal, pyqtSlot, QUrl, QTimer
 from PyQt5.QtGui import QDesktopServices
 import traceback
 from .run_stop_section import RunStopSection
@@ -214,6 +214,10 @@ class RodentRefreshmentGUI(QWidget):
         # Initialize
         self.load_animals_tab()
         self.showMaximized()
+
+        # Boot sentinel: once the GUI is up and stable, clear the launcher's
+        # boot-failure counter (see docs/UPDATE_SYSTEM.md §14.7).
+        QTimer.singleShot(8000, self._mark_boot_healthy)
     
     def show_update_banner(self, version, url):
         """Show a dismissable banner announcing an available software update.
@@ -274,6 +278,14 @@ class RodentRefreshmentGUI(QWidget):
         """
         if info is not None and getattr(info, "available", False):
             self.show_update_banner(info.version, info.url)
+
+    def _mark_boot_healthy(self):
+        """Tell the update system this release started cleanly (boot sentinel)."""
+        try:
+            from utils.updater import mark_boot_healthy
+            mark_boot_healthy()
+        except Exception:
+            pass
 
     def _apply_right_stretch(self):
         """Adjust right column stretches based on active tab and settings sub-tab."""

--- a/Project/utils/paths.py
+++ b/Project/utils/paths.py
@@ -71,3 +71,54 @@ def debug_log_path():
         return os.path.join(logs, "rrr_app_debug.log")
     # Legacy: home directory.
     return os.path.expanduser("~/rrr_app_debug.log")
+
+
+# ---------------------------------------------------------------------------
+# Blue-green layout (~/rrr) — used by the update apply engine (Phase 2c).
+# These resolve only when the launcher has exported RRR_HOME; on a developer
+# clone they return None and in-app updates are simply unavailable.
+# ---------------------------------------------------------------------------
+
+def home_dir():
+    """The blue-green home (~/rrr) when running under it, else None."""
+    return os.environ.get("RRR_HOME") or None
+
+
+def releases_dir():
+    """Directory holding extracted releases, or None off-device."""
+    home = home_dir()
+    return os.path.join(home, "releases") if home else None
+
+
+def current_link():
+    """Path of the `current` symlink, or None off-device."""
+    home = home_dir()
+    return os.path.join(home, "current") if home else None
+
+
+def previous_link():
+    """Path of the `previous` symlink (rollback target), or None off-device."""
+    home = home_dir()
+    return os.path.join(home, "previous") if home else None
+
+
+def venv_python():
+    """Path to the shared venv's python3, or None off-device."""
+    home = home_dir()
+    return os.path.join(home, "shared", "venv", "bin", "python3") if home else None
+
+
+def state_dir():
+    """Directory for launcher/update state (created), or None off-device."""
+    home = home_dir()
+    if not home:
+        return None
+    path = os.path.join(home, "state")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def boot_state_path():
+    """Path of the boot sentinel file, or None off-device."""
+    state = state_dir()
+    return os.path.join(state, "boot.json") if state else None

--- a/Project/utils/updater.py
+++ b/Project/utils/updater.py
@@ -1,20 +1,28 @@
-"""Update checking for RRR.
+"""Update checking and applying for RRR.
 
-Phase 1 of the update system (notify-only): this module asks GitHub whether a
-newer release exists and reports the result. It does not download or apply
-anything — see docs/UPDATE_SYSTEM.md for the full design and later phases.
+This module (a) asks GitHub whether a newer release exists and (b) downloads,
+verifies, and installs it into the blue-green layout. See docs/UPDATE_SYSTEM.md
+§13 and §14.
 
-The network call always runs on a background thread (see ``run_check``) so the
-GUI never blocks, and every failure path is swallowed: offline devices simply
-get "no result", never an error.
+Network and filesystem work always runs on a background thread (see
+``run_check`` / ``run_apply``) so the GUI never blocks; failure paths are
+swallowed or returned as messages, never raised into the UI.
 """
 
+import hashlib
+import json
+import os
 import re
+import shutil
+import subprocess
+import tarfile
+import tempfile
 
 import requests
 from PyQt5.QtCore import QObject, QThread, pyqtSignal
 
 from version import __version__ as CURRENT_VERSION
+from utils import paths
 
 # The repository whose Releases are the update channel.
 GITHUB_REPO = "Corticomics/rodRefReg"
@@ -47,11 +55,14 @@ def is_newer(candidate, current=CURRENT_VERSION):
 class UpdateInfo:
     """The outcome of a successful update check."""
 
-    def __init__(self, version, url, notes, available):
+    def __init__(self, version, url, notes, available,
+                 bundle_url=None, sha256_url=None):
         self.version = version      # e.g. "1.1.0" (no leading "v")
         self.url = url              # GitHub release page URL
         self.notes = notes          # release notes / changelog text
         self.available = available  # True if `version` is newer than CURRENT_VERSION
+        self.bundle_url = bundle_url  # download URL of the .rrrupdate bundle
+        self.sha256_url = sha256_url  # download URL of the .rrrupdate.sha256 file
 
 
 def fetch_latest():
@@ -77,11 +88,22 @@ def fetch_latest():
     if _version_tuple(version) is None:
         return None
 
+    # Resolve the bundle + checksum download URLs from the release assets.
+    bundle_url = sha256_url = None
+    for asset in (data.get("assets") or []):
+        name = asset.get("name", "")
+        if name.endswith(".rrrupdate.sha256"):
+            sha256_url = asset.get("browser_download_url")
+        elif name.endswith(".rrrupdate"):
+            bundle_url = asset.get("browser_download_url")
+
     return UpdateInfo(
         version=version,
         url=data.get("html_url") or _RELEASES_PAGE,
         notes=(data.get("body") or "").strip(),
         available=is_newer(version),
+        bundle_url=bundle_url,
+        sha256_url=sha256_url,
     )
 
 
@@ -126,6 +148,329 @@ def run_check(parent, on_done):
             pass
 
     thread.started.connect(worker.run)
+    worker.finished.connect(on_done)
+    worker.finished.connect(thread.quit)
+    worker.finished.connect(worker.deleteLater)
+    thread.finished.connect(thread.deleteLater)
+    thread.finished.connect(_cleanup)
+    thread.start()
+    return thread
+
+
+# ===========================================================================
+# Apply engine (Phase 2c) — download, verify, install, roll back.
+# See docs/UPDATE_SYSTEM.md §13.3 and §14.7.
+# ===========================================================================
+
+_MIN_FREE_BYTES = 200 * 1024 * 1024   # refuse to apply with less free space
+_RELEASES_TO_KEEP = 3
+
+# A delivery schedule must never be interrupted by an update. main.py registers
+# a real check here at startup; until then, assume not busy.
+_busy_check = lambda: False  # noqa: E731
+
+
+def set_busy_check(fn):
+    """Register a callable returning True while a delivery schedule is running.
+
+    ``apply_update`` refuses to proceed whenever it returns True.
+    """
+    global _busy_check
+    _busy_check = fn
+
+
+def _sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 16), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _download(url, dest):
+    with requests.get(url, stream=True, timeout=60) as resp:
+        resp.raise_for_status()
+        with open(dest, "wb") as handle:
+            for chunk in resp.iter_content(1 << 16):
+                handle.write(chunk)
+
+
+def _fetch_sha256(url):
+    """Return the expected hex digest from a .sha256 asset, or None."""
+    if not url:
+        return None
+    try:
+        resp = requests.get(url, timeout=_REQUEST_TIMEOUT_S)
+        resp.raise_for_status()
+        return resp.text.strip().split()[0]
+    except Exception:
+        return None
+
+
+def _read_manifest(release_dir):
+    try:
+        with open(os.path.join(release_dir, "manifest.json")) as handle:
+            return json.load(handle)
+    except Exception:
+        return {}
+
+
+def _atomic_symlink(target, link):
+    """Point `link` at `target` via an atomic rename (never a gap)."""
+    tmp = link + ".tmp"
+    if os.path.lexists(tmp):
+        os.remove(tmp)
+    os.symlink(target, tmp)
+    os.replace(tmp, link)
+
+
+def _sync_venv_if_needed(new_dir, venv_python, progress):
+    """pip-install the new release's requirements iff they changed."""
+    current = paths.current_link()
+    old_hash = None
+    if current and os.path.exists(current):
+        old_hash = _read_manifest(os.path.realpath(current)).get("requirements_hash")
+    new_hash = _read_manifest(new_dir).get("requirements_hash")
+    req = os.path.join(new_dir, "requirements.txt")
+    if new_hash and new_hash == old_hash:
+        return  # dependencies unchanged — reuse the venv untouched
+    if not (venv_python and os.path.exists(venv_python) and os.path.exists(req)):
+        return
+    progress("Updating dependencies…")
+    subprocess.run(
+        [venv_python, "-m", "pip", "install", "--disable-pip-version-check",
+         "-q", "-r", req],
+        check=True, timeout=600,
+    )
+
+
+def _selftest_release(release_dir, venv_python):
+    """Run `<release>/Project/main.py --selftest`. Returns (ok, detail)."""
+    if not (venv_python and os.path.exists(venv_python)):
+        return True, "venv unavailable; health check skipped"
+    main_py = os.path.join(release_dir, "Project", "main.py")
+    if not os.path.exists(main_py):
+        return False, "release is missing Project/main.py"
+    try:
+        proc = subprocess.run(
+            [venv_python, main_py, "--selftest"],
+            cwd=os.path.join(release_dir, "Project"),
+            env=dict(os.environ), capture_output=True, text=True, timeout=120,
+        )
+    except Exception as exc:
+        return False, str(exc)
+    if proc.returncode == 0:
+        return True, "ok"
+    return False, (proc.stdout + proc.stderr).strip()[-300:] or "non-zero exit"
+
+
+def _swap_current(new_dir):
+    """Point `current` at new_dir, recording the outgoing release as `previous`."""
+    current = paths.current_link()
+    previous = paths.previous_link()
+    if current and os.path.lexists(current):
+        old_target = os.path.realpath(current)
+        if os.path.isdir(old_target) and old_target != os.path.realpath(new_dir):
+            _atomic_symlink(old_target, previous)
+    _atomic_symlink(new_dir, current)
+
+
+def _prune_releases(keep=_RELEASES_TO_KEEP):
+    """Delete old release dirs, never touching `current` or `previous`."""
+    releases = paths.releases_dir()
+    if not releases or not os.path.isdir(releases):
+        return
+    protected = set()
+    for link in (paths.current_link(), paths.previous_link()):
+        if link and os.path.lexists(link):
+            protected.add(os.path.realpath(link))
+    dirs = [
+        os.path.join(releases, name)
+        for name in os.listdir(releases)
+        if not name.startswith(".") and os.path.isdir(os.path.join(releases, name))
+    ]
+    spare = [d for d in dirs if d not in protected]
+    spare.sort(key=os.path.getmtime, reverse=True)
+    for old in spare[keep:]:
+        shutil.rmtree(old, ignore_errors=True)
+
+
+def apply_update(info, progress=lambda message: None):
+    """Download, verify, health-check and install the release in ``info``.
+
+    Runs the full apply sequence (docs/UPDATE_SYSTEM.md §14.7). Returns
+    ``(ok, message)``. Any failure before the symlink swap leaves the running
+    release completely untouched.
+    """
+    if not paths.home_dir():
+        return False, "Updates are only available on an installed device."
+    if not info or not getattr(info, "bundle_url", None):
+        return False, "No update bundle is available for this release."
+    if _busy_check():
+        return False, ("A delivery schedule is running. Stop it before "
+                        "installing an update.")
+
+    releases = paths.releases_dir()
+    new_dir = os.path.join(releases, info.version)
+    venv_python = paths.venv_python()
+
+    try:
+        if shutil.disk_usage(releases).free < _MIN_FREE_BYTES:
+            return False, "Not enough free disk space to install the update."
+
+        with tempfile.TemporaryDirectory(prefix="rrr-dl-") as tmp:
+            bundle = os.path.join(tmp, "bundle.rrrupdate")
+
+            progress("Downloading update…")
+            _download(info.bundle_url, bundle)
+
+            progress("Verifying download…")
+            expected = _fetch_sha256(info.sha256_url)
+            if expected and _sha256_file(bundle) != expected:
+                return False, "Download verification failed (checksum mismatch)."
+
+            progress("Extracting…")
+            staging = os.path.join(releases, ".incoming-%s" % info.version)
+            shutil.rmtree(staging, ignore_errors=True)
+            os.makedirs(staging)
+            with tarfile.open(bundle, "r:gz") as tar:
+                tar.extractall(staging)
+
+        # Move the staged release into place (the download tmp is now gone).
+        shutil.rmtree(new_dir, ignore_errors=True)
+        os.replace(staging, new_dir)
+
+        _sync_venv_if_needed(new_dir, venv_python, progress)
+
+        progress("Health-checking the new version…")
+        ok, detail = _selftest_release(new_dir, venv_python)
+        if not ok:
+            shutil.rmtree(new_dir, ignore_errors=True)
+            return False, "The update failed its health check: %s" % detail
+
+        progress("Activating…")
+        _swap_current(new_dir)
+        _reset_boot_state(info.version)
+        _prune_releases()
+
+        return True, ("Version %s installed. Restart RRR to use it."
+                       % info.version)
+    except Exception as exc:
+        return False, "Update failed: %s" % exc
+
+
+def revert():
+    """Roll back to the previous release. Returns ``(ok, message)``."""
+    if not paths.home_dir():
+        return False, "Rollback is only available on an installed device."
+    previous = paths.previous_link()
+    if not (previous and os.path.lexists(previous)):
+        return False, "There is no previous version to roll back to."
+    target = os.path.realpath(previous)
+    if not os.path.isdir(os.path.join(target, "Project")):
+        return False, "The previous version is no longer available."
+    current = paths.current_link()
+    if os.path.realpath(current) == target:
+        return False, "Already running the previous version."
+    if _busy_check():
+        return False, "A delivery schedule is running. Stop it before rolling back."
+
+    leaving = os.path.realpath(current)
+    _atomic_symlink(leaving, previous)   # so a re-apply path still exists
+    _atomic_symlink(target, current)
+    version = os.path.basename(target)
+    _reset_boot_state(version)
+    return True, "Rolled back to version %s. Restart RRR to use it." % version
+
+
+def _reset_boot_state(release):
+    """Clear the boot-failure counter for `release` (see the boot sentinel)."""
+    path = paths.boot_state_path()
+    if not path:
+        return
+    try:
+        with open(path, "w") as handle:
+            json.dump({"release": release, "fail_count": 0}, handle)
+    except Exception:
+        pass
+
+
+def mark_boot_healthy():
+    """Clear the boot-failure counter — the running release started cleanly.
+
+    Called a few seconds after the GUI is up; without it the launcher's boot
+    sentinel would eventually auto-roll-back a release that actually works.
+    """
+    _reset_boot_state(CURRENT_VERSION)
+
+
+def has_previous_release():
+    """True when a rollback target exists."""
+    previous = paths.previous_link()
+    return bool(previous and os.path.lexists(previous))
+
+
+def restart_app():
+    """Restart the application. Returns ``(restarted, message)``.
+
+    Restarts the systemd user service when one is active; otherwise the
+    operator must relaunch manually (there is no service to bounce).
+    """
+    try:
+        active = subprocess.run(
+            ["systemctl", "--user", "is-active", "--quiet", "rrr"], timeout=10
+        ).returncode == 0
+    except Exception:
+        active = False
+    if not active:
+        return False, "Please close and reopen RRR to finish the update."
+    try:
+        subprocess.Popen(["systemctl", "--user", "restart", "rrr"])
+        return True, "Restarting…"
+    except Exception as exc:
+        return False, "Could not restart automatically: %s" % exc
+
+
+class ApplyWorker(QObject):
+    """Runs :func:`apply_update` off the GUI thread."""
+
+    progress = pyqtSignal(str)
+    finished = pyqtSignal(bool, str)   # (ok, message)
+
+    def __init__(self, info):
+        super().__init__()
+        self._info = info
+
+    def run(self):
+        ok, message = apply_update(self._info, self.progress.emit)
+        self.finished.emit(ok, message)
+
+
+def run_apply(parent, info, on_progress, on_done):
+    """Run :func:`apply_update` on a background thread.
+
+    ``on_progress(str)`` and ``on_done(bool, str)`` must be bound methods of a
+    GUI-thread QObject (see :func:`run_check` for why). ``parent`` holds the
+    thread/worker references until the job completes.
+    """
+    thread = QThread()
+    worker = ApplyWorker(info)
+    worker.moveToThread(thread)
+
+    holder = getattr(parent, "_rrr_apply_jobs", None)
+    if holder is None:
+        holder = []
+        parent._rrr_apply_jobs = holder
+    holder.append((thread, worker))
+
+    def _cleanup():
+        try:
+            holder.remove((thread, worker))
+        except ValueError:
+            pass
+
+    thread.started.connect(worker.run)
+    worker.progress.connect(on_progress)
     worker.finished.connect(on_done)
     worker.finished.connect(thread.quit)
     worker.finished.connect(worker.deleteLater)

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/docs/UPDATE_SYSTEM.md
+++ b/docs/UPDATE_SYSTEM.md
@@ -588,3 +588,53 @@ Found while designing the installer refactor; each is mitigated in the 2b code.
   the target branch before an installer run. OTA updates (2c) bypass this path entirely.
 - **B8 — orphaned pre-2b venv.** The old `~/rodRefReg/.venv` is left behind, unused.
   *Mitigation:* harmless; documented as build-only cruft (relates to D2).
+
+### 14.7 Phase 2c — apply engine design & risk log
+
+**Apply sequence** (`updater.apply_update`, run on a background thread):
+gate → download → verify SHA256 → extract to `releases/<new>/` (staged, then atomic
+`mv`) → re-pip into `shared/venv` *iff* `manifest.requirements_hash` changed →
+`--selftest` the new release in a subprocess → record `state/previous` → atomic
+`current` swap → restart. Any failure before the swap aborts with the old release live.
+
+**Boot sentinel** (the subtle part). `state/boot.json` =
+`{"release": "<version>", "fail_count": N}`.
+- `launch.sh`, before exec'ing the app: if `boot.json.release` ≠ the version `current`
+  points at, reset `fail_count` to 0 (a new release — or a revert — gets a clean slate).
+  If `fail_count` ≥ 2 and a `previous` release exists → **revert** `current` → `previous`,
+  reset, and re-exec. Otherwise write `fail_count + 1` and launch.
+- The app, ~8 s after the GUI is up and the event loop is healthy, writes `fail_count: 0`.
+- Net effect: a release that never reaches "healthy" twice running is auto-rolled-back on
+  the third launch. A healthy release keeps `fail_count` at 0–1.
+
+**Risks**
+
+- **C1 — interrupted apply.** Extract to a staged dir; the `current` swap is the last
+  step → a kill at any earlier point leaves the running release untouched. Stale staged
+  dirs are cleared on the next apply.
+- **C2 — corrupt/partial download.** SHA256 verified before extraction; mismatch aborts.
+- **C3 — re-pip into a live venv.** The running app keeps its already-imported modules;
+  new deps take effect on the next launch. Re-pip runs only when `requirements_hash`
+  changed (rare). Documented limitation.
+- **C4 — sentinel false rollback** (a clean quit before the 8 s healthy mark).
+  *Mitigation:* the healthy mark fires quickly; two quick quits in a row are needed to
+  trigger a revert — rare. Documented.
+- **C5 — `launch.sh` now carries sentinel logic** (tension with "minimal launcher").
+  *Mitigation:* the *shim* stays the immutable anchor; sentinel reads are all guarded so
+  a malformed `boot.json` can never block launch.
+- **C6 — apply during an experiment.** Hard gate: a module-level busy-check (registered
+  by `main.py`) refuses to apply while a delivery worker runs.
+- **C7 — shallow `--selftest`** (imports + DB open only). Accepted; the sentinel is the
+  deeper net.
+- **C8 — restart path.** `systemctl --user is-active rrr` decides: restart the unit, or
+  tell the operator to relaunch.
+- **C9 — disk.** Free space checked before download/extract; releases pruned to 3.
+- **C11 — double-apply.** The "Update Now" button is disabled while an apply runs.
+- **C14 — no previous release.** "Revert" is disabled when `previous` is absent.
+
+**Technical debt**
+
+- **D5 — `launch.sh` grows** to carry the sentinel; kept compact and fully guarded.
+- **D7 — extract+swap exists twice** — in `25-layout.sh` (bash, install path) and
+  `updater.py` (Python, OTA path). The shared contract is the release-dir layout, not the
+  code. Accepted; both kept small.

--- a/scripts/runtime/launch.sh
+++ b/scripts/runtime/launch.sh
@@ -2,17 +2,50 @@
 # RRR launcher — runs the application from the current release.
 #
 # Lives inside each release at scripts/runtime/launch.sh and is invoked by the
-# stable shim at ~/.local/bin/rrr. It resolves the blue-green layout, exports
-# RRR_DATA so the app stores data outside the swappable code, and execs the app.
-# See docs/UPDATE_SYSTEM.md §13.2.
+# stable shim at ~/.local/bin/rrr. It resolves the blue-green layout, runs the
+# boot sentinel (auto-rollback of a release that fails to start), exports
+# RRR_DATA, and execs the app. See docs/UPDATE_SYSTEM.md §13.2 / §14.7.
 set -Eeuo pipefail
 
 RRR_HOME="${RRR_HOME:-$HOME/rrr}"
 CURRENT="$RRR_HOME/current"
+PREVIOUS="$RRR_HOME/previous"
+STATE="$RRR_HOME/state"
+BOOT="$STATE/boot.json"
 VENV="$RRR_HOME/shared/venv"
 
 [[ -d "$CURRENT/Project" ]] || {
   echo "rrr: no current release at $CURRENT — run install.sh" >&2; exit 1; }
+
+# ---- boot sentinel --------------------------------------------------------
+# launch.sh increments a per-release failure counter; the app resets it to 0
+# once it has started cleanly. If a release is launched twice without ever
+# reaching that healthy mark, roll back to the previous release.
+cur_ver=$(basename "$(readlink -f "$CURRENT")")
+fail=0 ; rel=""
+if [[ -f "$BOOT" ]]; then
+  rel=$(python3 -c "import json;print(json.load(open('$BOOT')).get('release',''))" 2>/dev/null || true)
+  fail=$(python3 -c "import json;print(int(json.load(open('$BOOT')).get('fail_count',0)))" 2>/dev/null || echo 0)
+fi
+[[ "$fail" =~ ^[0-9]+$ ]] || fail=0
+[[ "$rel" == "$cur_ver" ]] || fail=0          # current changed -> clean slate
+
+if (( fail >= 2 )) && [[ -L "$PREVIOUS" ]]; then
+  prev_target=$(readlink -f "$PREVIOUS")
+  if [[ -d "$prev_target/Project" && "$prev_target" != "$(readlink -f "$CURRENT")" ]]; then
+    echo "rrr: release $cur_ver failed to start twice — rolling back" >&2
+    ln -sfn "$prev_target" "$RRR_HOME/.current.tmp"
+    mv -T "$RRR_HOME/.current.tmp" "$CURRENT"
+    mkdir -p "$STATE"
+    printf '{"release": "%s", "fail_count": 0}\n' "$(basename "$prev_target")" >"$BOOT"
+    exec "$CURRENT/scripts/runtime/launch.sh" "$@"
+  fi
+fi
+
+mkdir -p "$STATE"
+printf '{"release": "%s", "fail_count": %d}\n' "$cur_ver" "$((fail + 1))" >"$BOOT"
+
+# ---- launch ---------------------------------------------------------------
 [[ -x "$VENV/bin/python3" ]] || {
   echo "rrr: venv missing at $VENV — run install.sh" >&2; exit 1; }
 


### PR DESCRIPTION
Phase 2c of the update system (docs/UPDATE_SYSTEM.md §13.3 / §14.7). The app can now install updates itself: download, verify, health-check, and atomically activate a new release -- with rollback.

- utils/updater.py: apply_update() (download -> SHA256 verify -> extract ->
  re-pip if requirements changed -> --selftest -> atomic `current` swap ->
  prune), revert(), restart_app(), and an ApplyWorker/run_apply background
  runner; a busy-check gate blocks updates while a delivery schedule runs
- utils/paths.py: blue-green path helpers (releases, current, previous, state)
- main.py: `--selftest` health-check entry point; registers the busy-check
- scripts/runtime/launch.sh: boot sentinel -- auto-rolls-back a release that fails to start twice running
- ui/gui.py: marks the release healthy ~8s after the GUI is up
- ui/UpdatesTab.py: "Update now" and "Revert to previous version" controls
- version.py: 1.3.0 -> 1.4.0