### PR TITLE
chore: v1.4.1 — refresh design-doc status

### DIFF
--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"

--- a/docs/UPDATE_SYSTEM.md
+++ b/docs/UPDATE_SYSTEM.md
@@ -1,6 +1,6 @@
 # RRR Update System — Design
 
-**Status:** Proposed · **Date:** 2026-05-17 · **Owner:** TBD
+**Status:** Phase 2 shipped (v1.4.0) — Phase 3 (offline + signing) deferred · **Date:** 2026-05-19 · **Owner:** zepaulojr1
 
 Design for shipping updates to deployed Rodent Refreshment Regulator (RRR) devices —
 automatically, safely, and without requiring operators to touch a terminal.


### PR DESCRIPTION
PATCH bump (1.4.0 -> 1.4.1). Updates the design doc's Status field to reflect that Phase 2 has shipped; also doubles as the first real end-to-end OTA exercise of the in-app update engine.