### PR TITLE
fix(installer): stay pinned when 20-repo runs on a detached HEAD (v1.…

### DIFF
--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"

--- a/scripts/install/20-repo.sh
+++ b/scripts/install/20-repo.sh
@@ -24,6 +24,16 @@ CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 TARGET_BRANCH=${BRANCH:-$CURRENT_BRANCH}
 info "current branch: $CURRENT_BRANCH; target: $TARGET_BRANCH"
 
+# Detached HEAD (e.g. user pinned via RRR_BRANCH=<tag> in bootstrap) without
+# an explicit --branch override: just fetch and stay pinned. `git pull origin
+# HEAD` resolves to the remote's default branch and would silently move the
+# clone off the pinned tag.
+if [[ "$CURRENT_BRANCH" == "HEAD" && -z "${BRANCH:-}" ]]; then
+  step "fetching from origin (pinned commit; not pulling)" -- \
+    with_retry 3 3 -- run git fetch --prune --tags origin
+  return 0
+fi
+
 step "fetching from origin" -- with_retry 3 3 -- run git fetch --prune origin
 
 if [[ "$TARGET_BRANCH" != "$CURRENT_BRANCH" ]]; then


### PR DESCRIPTION

When a user pins a specific tag via `RRR_BRANCH=v1.4.0 curl ... | bash`, the bootstrap clones at the tag (detached HEAD). 20-repo then computed TARGET_BRANCH=CURRENT_BRANCH="HEAD" and ran `git pull --ff-only origin HEAD`, which resolves to the remote's default branch and silently moved the clone off the pinned tag.

Detect detached HEAD with no `--branch` override and skip the pull: just fetch (with --tags) and stay pinned. Surfaced during the v1.4.0 -> v1.4.1 end-to-end OTA test, which had to work around it with `--skip 20-repo`.