### PR TITLE
refactor(secrets): move Slack credentials to mode-0600 secrets.json (…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 pump_log.json
 Project/rrr_database.db
 Project/settings/settings.json
+
+# Credentials — never committed (see docs/UPDATE_SYSTEM.md §13.8)
+secrets.json
 *.db
 *.sqlite
 *.sqlite3

--- a/Project/controllers/system_controller.py
+++ b/Project/controllers/system_controller.py
@@ -15,29 +15,34 @@ class SystemController(QObject):
         self.settings = self.load_settings()
 
     def load_settings(self):
-        """Load settings from the SQLite ``system_settings`` table.
+        """Load settings from the DB and the dedicated secrets file.
 
-        On first run after the v1.5.0 upgrade, any values in the legacy
-        ``settings.json`` are copied into the DB and the file is never touched
-        again. Defaults fill in any keys still missing. See
-        docs/UPDATE_SYSTEM.md §13.8.
+        On the first run after the v1.5.0 upgrade, values in the legacy
+        ``settings.json`` are copied into the DB. On the first run after
+        the v1.5.1 upgrade, Slack credentials are extracted into a
+        mode-0600 ``secrets.json`` (and removed from the DB). Defaults fill
+        any keys still missing. See docs/UPDATE_SYSTEM.md §13.8.
         """
         try:
             self._migrate_legacy_json_if_needed()
+            self._ensure_secrets_migrated()
             settings = self._create_default_settings()
             settings.update(self._load_database_settings())
+            settings.update(self._load_secrets())
             return settings
         except Exception as e:
             self.system_status.emit(f"Error loading settings: {str(e)}")
             return self._create_default_settings()
 
     def save_settings(self, settings_dict):
-        """Persist managed settings to the DB; merge into ``self.settings``.
+        """Persist managed settings: secrets to ``secrets.json``, the rest to
+        the DB; merge everything into ``self.settings``.
 
         Unmanaged keys (runtime objects, ephemeral state) are kept in memory
         but not persisted — see :meth:`_get_persisted_keys`.
         """
         try:
+            self._save_secrets_if_present(settings_dict)
             self._save_database_settings(settings_dict)
             self.settings.update(settings_dict)
             self.settings_updated.emit(self.settings)
@@ -84,7 +89,9 @@ class SystemController(QObject):
         between ``_get_json_settings_keys`` and ``_get_db_settings_keys``.
         """
         return {
-            'num_hats', 'slack_token', 'channel_id', 'hardware_mode',
+            # Note: slack_token + channel_id are NOT here — they live in the
+            # dedicated mode-0600 secrets.json since Phase 2.5b.
+            'num_hats', 'hardware_mode',
             'global_master_relay_id', 'i2c_bus', 'flow_sensor_type', 'uart_port',
             'flow_sampling_hz', 'predictive_close_ms', 'residual_check_ms',
             'residual_flow_threshold_ml_min', 'max_consecutive_sensor_errors',
@@ -480,6 +487,97 @@ class SystemController(QObject):
             )
         except Exception:
             pass
+
+    # ------------------------------------------------------------------
+    # Secrets (Phase 2.5b) — credentials live in a dedicated mode-0600
+    # file, never in the DB and never in git. See docs/UPDATE_SYSTEM.md §13.8.
+    # ------------------------------------------------------------------
+
+    _SECRET_KEYS = ('slack_token', 'channel_id')
+
+    def _load_secrets(self):
+        """Return whatever is in the secrets file (empty dict when absent)."""
+        from utils import secrets
+        try:
+            return secrets.get_credentials()
+        except Exception as exc:
+            self.system_status.emit(f"Could not read secrets file: {exc}")
+            return {}
+
+    def _save_secrets_if_present(self, settings_dict):
+        """Persist Slack credentials to ``secrets.json`` when the caller
+        touched any secret key.
+
+        Merges into existing values so a partial save (e.g. token only) does
+        not clobber an unrelated field.
+        """
+        if not any(key in settings_dict for key in self._SECRET_KEYS):
+            return
+        from utils import secrets
+        merged = self._load_secrets()
+        for key in self._SECRET_KEYS:
+            if key in settings_dict:
+                merged[key] = settings_dict[key]
+        secrets.save_credentials(
+            slack_token=merged.get('slack_token', ''),
+            channel_id=merged.get('channel_id', ''),
+        )
+
+    def _ensure_secrets_migrated(self):
+        """One-time: move legacy Slack credentials into ``secrets.json``.
+
+        Sources, in priority order:
+            (1) the dedicated file — if it already exists, sweep any
+                stale DB rows and return;
+            (2) the v1.5.0 ``system_settings`` rows (Phase 2.5a wrote
+                slack creds there briefly);
+            (3) the pre-v1.5.0 legacy ``settings.json``.
+        After a copy, the DB rows are deleted. The legacy JSON is left
+        intact (copy-not-move).
+        """
+        from utils import secrets
+
+        db_rows = {}
+        try:
+            db_rows = self.database_handler.get_system_settings()
+        except Exception:
+            pass
+        if not isinstance(db_rows, dict):
+            db_rows = {}
+
+        if secrets.exists():
+            # Defensive: even if the secrets file is already present, sweep
+            # leftover DB rows from a partial earlier run.
+            for key in self._SECRET_KEYS:
+                if key in db_rows:
+                    try:
+                        self.database_handler.delete_system_setting(key)
+                    except Exception:
+                        pass
+            return
+
+        token = db_rows.get('slack_token') or ''
+        channel = db_rows.get('channel_id') or ''
+
+        if not token and not channel:
+            legacy_path = paths.settings_path()
+            if os.path.exists(legacy_path):
+                try:
+                    with open(legacy_path, 'r') as handle:
+                        legacy = json.load(handle)
+                    token = legacy.get('slack_token') or ''
+                    channel = legacy.get('channel_id') or ''
+                except Exception:
+                    pass
+
+        secrets.save_credentials(slack_token=token, channel_id=channel)
+
+        for key in self._SECRET_KEYS:
+            if key in db_rows:
+                try:
+                    self.database_handler.delete_system_setting(key)
+                except Exception:
+                    pass
 
     def get_pump_controller(self):
         """Get or create a pump controller instance"""

--- a/Project/models/database_handler.py
+++ b/Project/models/database_handler.py
@@ -1530,7 +1530,7 @@ class DatabaseHandler:
             with self.connect() as conn:
                 cursor = conn.cursor()
                 cursor.execute('''
-                    INSERT OR REPLACE INTO system_settings 
+                    INSERT OR REPLACE INTO system_settings
                     (setting_key, setting_value, setting_type, updated_at)
                     VALUES (?, ?, ?, datetime('now'))
                 ''', (key, str(value), setting_type))
@@ -1538,6 +1538,19 @@ class DatabaseHandler:
                 return True
         except sqlite3.Error as e:
             print(f"Error updating system setting: {e}")
+            return False
+
+    def delete_system_setting(self, key):
+        """Delete a single row from system_settings. Returns True on success."""
+        try:
+            with self.connect() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    'DELETE FROM system_settings WHERE setting_key = ?', (key,))
+                conn.commit()
+                return True
+        except sqlite3.Error as e:
+            print(f"Error deleting system setting {key}: {e}")
             return False
     
     # ==================== VALVE CALIBRATION METHODS ====================

--- a/Project/tests/unit/test_secrets.py
+++ b/Project/tests/unit/test_secrets.py
@@ -1,0 +1,171 @@
+"""Tests for the Phase 2.5b secrets store (v1.5.1).
+
+Covers:
+
+- ``secrets.json`` is written atomically with mode 0600,
+- get/save round-trip, including absent and malformed inputs,
+- ``SystemController.save_settings`` routes Slack credentials to the
+  secrets file and **never** writes them to ``system_settings``,
+- ``SystemController.load_settings`` exposes the secrets in
+  ``self.settings`` for backward-compatible reads,
+- one-time migration from a v1.5.0 device (creds in ``system_settings``)
+  copies them into ``secrets.json`` and removes the DB rows,
+- one-time migration from a pre-v1.5.0 device (creds in legacy
+  ``settings.json``) copies them into ``secrets.json``,
+- the migration is idempotent and sweeps any DB leftovers on re-runs.
+
+See docs/UPDATE_SYSTEM.md §13.8.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+
+
+# ---------------------------------------------------------------------------
+# secrets.py primitives
+# ---------------------------------------------------------------------------
+
+def test_save_then_get_round_trips(isolated_data_dir):
+    from utils import secrets
+    assert secrets.save_credentials("xoxb-token", "C0123")
+    assert secrets.get_credentials() == {"slack_token": "xoxb-token", "channel_id": "C0123"}
+
+
+def test_get_returns_empty_when_file_absent(isolated_data_dir):
+    from utils import secrets
+    assert not secrets.exists()
+    assert secrets.get_credentials() == {}
+
+
+def test_get_returns_empty_when_file_is_malformed(isolated_data_dir):
+    from utils import secrets, paths
+    with open(paths.secrets_path(), "w") as handle:
+        handle.write("not json{{{")
+    assert secrets.get_credentials() == {}
+
+
+def test_save_writes_file_with_mode_0600(isolated_data_dir):
+    from utils import secrets, paths
+    secrets.save_credentials("x", "y")
+    mode = stat.S_IMODE(os.stat(paths.secrets_path()).st_mode)
+    assert mode == 0o600, f"expected mode 0600, got {oct(mode)}"
+
+
+def test_save_leaves_no_temp_files_behind(isolated_data_dir):
+    from utils import secrets
+    secrets.save_credentials("a", "b")
+    leftovers = [name for name in os.listdir(isolated_data_dir) if name.startswith(".secrets-")]
+    assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# SystemController routing
+# ---------------------------------------------------------------------------
+
+def test_save_settings_routes_slack_creds_to_secrets_not_db(system_controller, database_handler):
+    from utils import secrets
+    system_controller.save_settings({"slack_token": "xoxb-1", "channel_id": "C9"})
+
+    assert secrets.get_credentials() == {"slack_token": "xoxb-1", "channel_id": "C9"}
+    db = database_handler.get_system_settings()
+    assert "slack_token" not in db
+    assert "channel_id" not in db
+    assert system_controller.settings["slack_token"] == "xoxb-1"
+    assert system_controller.settings["channel_id"] == "C9"
+
+
+def test_partial_save_preserves_the_other_credential(system_controller):
+    from utils import secrets
+    system_controller.save_settings({"slack_token": "first", "channel_id": "Cfirst"})
+    system_controller.save_settings({"slack_token": "updated"})           # token only
+    creds = secrets.get_credentials()
+    assert creds["slack_token"] == "updated"
+    assert creds["channel_id"] == "Cfirst"                                 # not clobbered
+
+
+def test_load_settings_merges_secrets_into_in_memory_dict(database_handler, isolated_data_dir):
+    from utils import secrets
+    from controllers.system_controller import SystemController
+    secrets.save_credentials("preset", "Cpre")
+
+    sc = SystemController(database_handler)
+    assert sc.settings["slack_token"] == "preset"
+    assert sc.settings["channel_id"] == "Cpre"
+
+
+# ---------------------------------------------------------------------------
+# Migration paths
+# ---------------------------------------------------------------------------
+
+def test_migration_moves_slack_from_db_to_secrets(database_handler, isolated_data_dir):
+    """v1.5.0 -> v1.5.1: 2.5a put creds in system_settings; 2.5b extracts them."""
+    from utils import secrets
+    database_handler.update_system_setting("slack_token", "from-db", "str")
+    database_handler.update_system_setting("channel_id", "Cdb", "str")
+    assert not secrets.exists()
+
+    from controllers.system_controller import SystemController
+    SystemController(database_handler)
+
+    creds = secrets.get_credentials()
+    assert creds["slack_token"] == "from-db"
+    assert creds["channel_id"] == "Cdb"
+    db = database_handler.get_system_settings()
+    assert "slack_token" not in db, "DB row must be removed after migration"
+    assert "channel_id" not in db, "DB row must be removed after migration"
+
+
+def test_migration_copies_legacy_slack_into_secrets(database_handler, write_legacy_settings):
+    """Pre-v1.5.0 -> v1.5.1 direct: creds in legacy settings.json move out."""
+    from utils import secrets
+    write_legacy_settings({"slack_token": "legacy", "channel_id": "Cleg"})
+    assert not secrets.exists()
+
+    from controllers.system_controller import SystemController
+    SystemController(database_handler)
+
+    creds = secrets.get_credentials()
+    assert creds["slack_token"] == "legacy"
+    assert creds["channel_id"] == "Cleg"
+
+
+def test_migration_does_not_overwrite_existing_secrets_file(database_handler, isolated_data_dir):
+    """An existing secrets.json wins; a stale DB row is cleaned up anyway."""
+    from utils import secrets
+    secrets.save_credentials("already-set", "Cset")
+    database_handler.update_system_setting("slack_token", "should-be-ignored", "str")
+
+    from controllers.system_controller import SystemController
+    SystemController(database_handler)
+
+    assert secrets.get_credentials()["slack_token"] == "already-set"
+    # the migration also sweeps stale DB leftovers
+    assert "slack_token" not in database_handler.get_system_settings()
+
+
+def test_migration_on_fresh_device_creates_empty_secrets_file(database_handler, isolated_data_dir):
+    """No legacy data anywhere → secrets.json is created empty (marker for the next boot)."""
+    from utils import secrets
+    from controllers.system_controller import SystemController
+
+    SystemController(database_handler)
+
+    assert secrets.exists()
+    assert secrets.get_credentials() == {"slack_token": "", "channel_id": ""}
+
+
+def test_phase_2_5a_legacy_migration_does_not_copy_slack_keys(database_handler, write_legacy_settings):
+    """Regression for the 2.5b half of the contract: the legacy-JSON-to-DB
+    migration introduced in 2.5a must no longer copy slack_token / channel_id
+    into the DB (those keys are owned by the secrets file in 2.5b)."""
+    write_legacy_settings({"slack_token": "leg", "channel_id": "Cleg", "num_hats": 4})
+
+    from controllers.system_controller import SystemController
+    SystemController(database_handler)
+
+    db = database_handler.get_system_settings()
+    assert db.get("num_hats") == 4, "non-secret keys still migrate to DB"
+    assert "slack_token" not in db, "slack_token must not enter system_settings"
+    assert "channel_id" not in db, "channel_id must not enter system_settings"

--- a/Project/utils/paths.py
+++ b/Project/utils/paths.py
@@ -52,6 +52,15 @@ def settings_path():
     return os.path.join(_PROJECT_DIR, "settings", "settings.json")
 
 
+def secrets_path():
+    """Absolute path to the secrets file (mode 0600; gitignored).
+
+    Stored alongside the database/settings; the launcher's ``RRR_DATA`` env
+    var decides the location. Phase 2.5b of the update system.
+    """
+    return os.path.join(data_dir(), "secrets.json")
+
+
 def pump_log_path():
     """Absolute path to the offline pump-trigger log (pump_log.json)."""
     root = _data_root()

--- a/Project/utils/secrets.py
+++ b/Project/utils/secrets.py
@@ -1,0 +1,74 @@
+"""Credential storage for RRR.
+
+Slack tokens (and any future secrets) live in a dedicated mode-0600 file —
+kept separate from the SQLite database and never tracked in git — so they
+can be rotated, audited, or wiped without touching the rest of the app
+state, and so a leaked database backup never exposes the token.
+
+Phase 2.5b of the update system; see docs/UPDATE_SYSTEM.md §13.8.
+
+The functions here are pure file I/O; the credential lifecycle (load on
+startup, route writes from the UI, migrate from the DB or the legacy
+``settings.json``) is owned by
+:class:`controllers.system_controller.SystemController`.
+"""
+
+import json
+import os
+import tempfile
+
+from utils import paths
+
+
+def exists() -> bool:
+    """True when a secrets file is on disk, regardless of contents."""
+    return os.path.exists(paths.secrets_path())
+
+
+def get_credentials() -> dict:
+    """Return the stored credentials, or an empty dict if absent or unreadable.
+
+    Never raises. A malformed file is treated as "no credentials" so a
+    hand-edited typo cannot brick the app at startup.
+    """
+    path = paths.secrets_path()
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r") as handle:
+            data = json.load(handle)
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def save_credentials(slack_token: str = "", channel_id: str = "") -> bool:
+    """Write the credentials atomically with mode 0600. Returns success.
+
+    The file is created via :func:`tempfile.mkstemp` (which yields a 0600
+    file on POSIX), written, then atomically renamed into place — readers
+    never see a partial write.
+    """
+    payload = {
+        "slack_token": slack_token or "",
+        "channel_id": channel_id or "",
+    }
+    dest = paths.secrets_path()
+    try:
+        directory = os.path.dirname(dest) or "."
+        os.makedirs(directory, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=".secrets-", dir=directory)
+        try:
+            with os.fdopen(fd, "w") as handle:
+                json.dump(payload, handle, indent=2)
+            os.chmod(tmp, 0o600)          # belt-and-braces — mkstemp already 0600
+            os.replace(tmp, dest)          # atomic on POSIX
+            return True
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except Exception:
+        return False

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -524,10 +524,15 @@ All methods are synchronous (with one broken exception flagged in §7).
 
 ---
 
-## 6. Settings persistence (Phase 2.5a, v1.5.0+)
+## 6. Settings persistence (Phase 2.5, v1.5.0+)
 
-Every persisted setting lives in `system_settings`. `setting_type` records how
-to decode `setting_value`:
+Every persisted *preference* lives in `system_settings`. **Slack credentials
+do NOT** — since Phase 2.5b (v1.5.1) they live in a dedicated mode-0600
+`secrets.json` next to the database; see
+[`Project/utils/secrets.py`](../Project/utils/secrets.py) and
+[`SystemController._ensure_secrets_migrated()`](../Project/controllers/system_controller.py).
+
+`setting_type` records how to decode `setting_value`:
 
 | `setting_type` | Storage | Decode on read |
 |---|---|---|
@@ -553,9 +558,10 @@ row that prevents re-running. The legacy file is left intact (copy-not-move).
 See [`docs/UPDATE_SYSTEM.md` §13.8 / §14](UPDATE_SYSTEM.md) for the full plan.
 
 Test coverage:
-[`Project/tests/unit/test_settings_persistence.py`](../Project/tests/unit/test_settings_persistence.py)
-— 20 cases covering round-trip, migration, save semantics, and the previously
-silent `theme` drop.
+[`test_settings_persistence.py`](../Project/tests/unit/test_settings_persistence.py)
+— 20 cases for round-trip, migration, save semantics, and the previously silent `theme` drop.
+[`test_secrets.py`](../Project/tests/unit/test_secrets.py) — 12 cases for the secrets store
+plus the v1.5.0 → v1.5.1 and pre-v1.5.0 → v1.5.1 migration paths.
 
 ---
 

--- a/docs/UPDATE_SYSTEM.md
+++ b/docs/UPDATE_SYSTEM.md
@@ -456,23 +456,28 @@ installer on it and confirming: data lands in `~/rrr/shared/data`, the app runs 
 | 2b — blue-green + migration | v1.3.0 | medium | one installer re-run per device |
 | 2c — apply engine + rollback + UI | v1.4.0 | medium | first version with one-click in-app updates |
 
-### 13.8 Deferred — Phase 2.5: settings consolidation
+### 13.8 Phase 2.5 — settings consolidation
 
-`settings.json` today conflates three things that want different homes: secrets
+`settings.json` previously conflated three things that wanted different homes: secrets
 (`slack_token`), preferences (`interval`, `num_hats`, …), and domain records (`schedules`,
-`animals` — already duplicated in the SQLite tables). Phase 2a only does the *interim* fix:
+`animals` — already duplicated in the SQLite tables). Phase 2a only did the *interim* fix:
 unify the two write paths into one `settings.json` and stop tracking it in git.
 
-The proper end state — best practice for this project — is **zero general-settings files**:
+Phase 2.5 finished the job — best practice for this project — by giving every category its
+proper home:
 
-- preferences + domain data → the SQLite DB (the `system_settings` table already exists), so
-  the update system has a *single* artifact to back up, migrate, and roll back;
-- the Slack secret → a separate mode-600, gitignored `secrets.json` (or an OS keyring);
-- retire `settings.json` and the dead `migrate_settings.py`.
+- preferences → the SQLite DB (`system_settings` table); shipped in **Phase 2.5a (v1.5.0)**;
+- the Slack secret → a separate mode-0600, gitignored `secrets.json`; shipped in
+  **Phase 2.5b (v1.5.1)**;
+- `migrate_settings.py` deleted as dead code (it was never wired in).
 
-This is a refactor that needs an audit of how `schedules`/`animals` actually flow (JSON blob
-vs DB tables). It is scheduled as **Phase 2.5**, its own change after Phase 2 — deliberately
-not entangled with the layout work.
+Domain records (`schedules`, `animals`) were already in their SQLite tables; the redundant
+`setdefault` lines in the old `load_settings` were removed without touching real data flow.
+
+Both phases are non-destructive on upgrade: 2.5a copies legacy `settings.json` values into
+the DB on first launch (sentinel prevents re-running); 2.5b moves Slack credentials out of
+either the DB (v1.5.0 source) or the legacy JSON (pre-v1.5.0 source) into
+`secrets.json` and deletes the DB rows. The legacy file is left intact in both cases.
 
 ---
 


### PR DESCRIPTION

Phase 2.5b of the update system (docs/UPDATE_SYSTEM.md §13.8). Slack credentials now live in a dedicated mode-0600 secrets.json next to the database -- never in the DB, never in git -- so a leaked database backup or accidental commit cannot expose the token.

- utils/secrets.py: tempfile.mkstemp + os.replace atomic writer (mkstemp yields 0600 on POSIX); get_credentials swallows malformed input so a hand-edited typo cannot brick startup.
- utils/paths.py: new secrets_path() resolving to $RRR_DATA/secrets.json (or Project/secrets.json on dev clones).
- models/database_handler.py: new delete_system_setting() -- used only by the 2.5b migration to clean up DB rows after relocating creds to the file.
- controllers/system_controller.py:
  - slack_token + channel_id removed from _get_persisted_keys
  - load_settings: also runs _ensure_secrets_migrated and merges _load_secrets() over the DB result
  - save_settings: routes slack creds to secrets.json first, then writes the rest to the DB; a partial save preserves the other secret
  - _ensure_secrets_migrated: one-time copy from either v1.5.0 DB rows or the pre-v1.5.0 legacy settings.json (priority order); deletes the DB rows after; idempotent (also sweeps stale DB leftovers on re-runs); copy-not-move on the legacy file
- .gitignore: secrets.json
- tests/unit/test_secrets.py: 12 cases -- mode 0600, atomic write, no temp leftovers, malformed-input handling, SC routing (secrets written, DB never), partial save preserves the other field, both migration paths, idempotency, fresh-device path, regression that the 2.5a legacy-JSON migration no longer copies slack keys into the DB.
- docs/UPDATE_SYSTEM.md §13.8: Phase 2.5 (a + b) marked shipped.
- docs/DATABASE.md §6: notes Slack lives in secrets.json since 2.5b.
- version.py: 1.5.0 -> 1.5.1