### PR TITLE
test(offline): add offline-resilience characterization harness (Phase…

### DIFF
--- a/Project/tests/unit/conftest.py
+++ b/Project/tests/unit/conftest.py
@@ -66,3 +66,22 @@ def write_legacy_settings(isolated_data_dir: Path) -> Callable[[dict], Path]:
         return path
 
     return _write
+
+
+@pytest.fixture
+def offline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate a device with no network: DNS resolution fails for every host.
+
+    Patches ``socket.getaddrinfo`` so any library that opens a connection
+    (``requests``, ``urllib``, ``slack_sdk``) fails exactly as it would on a
+    Pi that has lost its network — without the test ever touching a real
+    socket. The patch is rolled back automatically after the test.
+
+    Part of the Phase 1 offline-resilience test harness.
+    """
+    import socket
+
+    def _no_dns(*_args, **_kwargs):
+        raise socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _no_dns)

--- a/Project/tests/unit/test_notifications_offline.py
+++ b/Project/tests/unit/test_notifications_offline.py
@@ -1,0 +1,135 @@
+"""Characterization tests: Slack notifications when the network is down.
+
+Phase 1 of the offline-resilience work. These tests do **not** change
+behaviour — they pin down what the code does *today* so Phase 2 can harden
+the internals (explicit Slack timeout, broader failure handling) without
+regressing the offline fallback that lab deployments rely on.
+
+Why this matters: ``NotificationHandler.send_slack_notification`` runs on the
+relay-worker hot path (``gpio/relay_worker.py``, ``schedule_controller.py``).
+A delivery to live animals must never be disrupted by a Slack/network
+failure.
+
+Two of these tests are **strict xfail canaries**: they assert the *desired*
+Phase 2 behaviour and currently fail. When Phase 2 lands, they flip to
+passing and the strict marker forces removal of the ``xfail`` — so the canary
+cannot rot.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+# Skip cleanly on a machine without the runtime deps (CI installs both).
+pytest.importorskip("requests")
+pytest.importorskip("slack_sdk")
+
+
+@pytest.fixture
+def handler(monkeypatch, tmp_path):
+    """A ``NotificationHandler`` whose offline pump log points at a tmp file.
+
+    Returns ``(handler, log_path)``. No real Slack token, no network.
+    """
+    import notifications.notifications as notif
+
+    log_path = tmp_path / "pump_log.json"
+    monkeypatch.setattr(notif, "LOG_FILE", str(log_path))
+    return notif.NotificationHandler("xoxb-not-a-real-token", "C0000000"), log_path
+
+
+def _slack_api_error(error_code: str):
+    """Build a ``SlackApiError`` the way the Slack SDK does for an API reply."""
+    from slack_sdk.errors import SlackApiError
+
+    return SlackApiError(f"slack returned {error_code}", {"error": error_code})
+
+
+# ---------------------------------------------------------------------------
+# Current behaviour — locked in
+# ---------------------------------------------------------------------------
+
+def test_slack_api_error_falls_back_to_local_log(handler, monkeypatch):
+    """An API-level failure (e.g. revoked token) logs the message locally."""
+    handler_obj, log_path = handler
+
+    def _raise(*_a, **_k):
+        raise _slack_api_error("token_revoked")
+
+    monkeypatch.setattr(handler_obj.client, "chat_postMessage", _raise)
+    handler_obj.send_slack_notification("relay unit 3 triggered")
+
+    assert log_path.exists(), "pump trigger must be logged when Slack fails"
+    entries = json.loads(log_path.read_text())
+    assert len(entries) == 1
+    assert entries[0]["relay_info"] == "relay unit 3 triggered"
+    assert "timestamp" in entries[0]
+
+
+def test_slack_api_error_does_not_propagate(handler, monkeypatch):
+    """A Slack API failure must never raise into the relay worker."""
+    handler_obj, _ = handler
+    monkeypatch.setattr(
+        handler_obj.client, "chat_postMessage",
+        lambda *_a, **_k: (_ for _ in ()).throw(_slack_api_error("not_authed")),
+    )
+    # Must return normally — no exception reaches the caller.
+    handler_obj.send_slack_notification("delivery complete")
+
+
+def test_repeated_failures_accumulate_in_the_log(handler, monkeypatch):
+    """Each failed notification appends; the local log is the durable record."""
+    handler_obj, log_path = handler
+    monkeypatch.setattr(
+        handler_obj.client, "chat_postMessage",
+        lambda *_a, **_k: (_ for _ in ()).throw(_slack_api_error("channel_not_found")),
+    )
+    for i in range(3):
+        handler_obj.send_slack_notification(f"trigger {i}")
+
+    entries = json.loads(log_path.read_text())
+    assert [e["relay_info"] for e in entries] == ["trigger 0", "trigger 1", "trigger 2"]
+
+
+# ---------------------------------------------------------------------------
+# Strict xfail canaries — assert the Phase 2 target behaviour
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Phase 2: send_slack_notification only catches SlackApiError. A "
+           "network-level failure (the real offline symptom) is not caught "
+           "and propagates into the relay worker. Phase 2 broadens the "
+           "handler and removes this marker.",
+)
+def test_network_level_failure_also_falls_back(handler, monkeypatch):
+    """Offline Slack calls fail with connection errors, not SlackApiError.
+
+    The fallback log must catch those too — otherwise an offline device
+    raises straight into the delivery worker.
+    """
+    handler_obj, log_path = handler
+
+    def _raise(*_a, **_k):
+        raise ConnectionError("network is unreachable")
+
+    monkeypatch.setattr(handler_obj.client, "chat_postMessage", _raise)
+    handler_obj.send_slack_notification("trigger during outage")  # must not raise
+
+    assert log_path.exists()
+    assert json.loads(log_path.read_text())[0]["relay_info"] == "trigger during outage"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Phase 2: the Slack WebClient is constructed without an explicit "
+           "timeout, so a stalled connection can block the relay worker. "
+           "Phase 2 sets an explicit timeout and removes this marker.",
+)
+def test_webclient_is_constructed_with_an_explicit_timeout(handler):
+    """The Slack client must carry a bounded timeout to protect the hot path."""
+    handler_obj, _ = handler
+    timeout = getattr(handler_obj.client, "timeout", None)
+    assert isinstance(timeout, (int, float)) and timeout <= 15

--- a/Project/tests/unit/test_updater_offline.py
+++ b/Project/tests/unit/test_updater_offline.py
@@ -1,0 +1,201 @@
+"""Characterization tests: the update system when GitHub is unreachable.
+
+Phase 1 of the offline-resilience work. These tests pin down today's
+behaviour so Phase 2 can harden the update path without regressions, and
+plant a **strict xfail canary** on the one genuine defect found in the audit:
+``apply_update`` silently skips SHA256 verification when the ``.sha256`` asset
+cannot be fetched (``updater.py``: ``if expected and ...``). Phase 2 makes
+that check fail-closed; the canary then flips to passing and its strict
+marker forces removal.
+
+No production code changes here.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+
+import pytest
+
+# updater imports PyQt5 + requests; skip cleanly where they are absent.
+pytest.importorskip("PyQt5.QtCore")
+pytest.importorskip("requests")
+
+
+@pytest.fixture
+def updater(monkeypatch):
+    """The updater module, with any ambient blue-green env vars cleared."""
+    monkeypatch.delenv("RRR_HOME", raising=False)
+    from utils import updater as _updater
+
+    return _updater
+
+
+class _FakeResponse:
+    """Minimal stand-in for a ``requests`` response."""
+
+    def __init__(self, *, json_data=None, text="", raise_json=False):
+        self._json_data = json_data
+        self._raise_json = raise_json
+        self.text = text
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        if self._raise_json:
+            raise ValueError("not JSON")
+        return self._json_data
+
+
+def _make_bundle(dest_path, version):
+    """Write a minimal but structurally valid ``.rrrupdate`` tar.gz."""
+    with tarfile.open(dest_path, "w:gz") as tar:
+        for name, payload in (
+            ("Project/main.py", "# minimal release payload\n"),
+            ("manifest.json", json.dumps({"version": version})),
+        ):
+            raw = payload.encode()
+            info = tarfile.TarInfo(name)
+            info.size = len(raw)
+            tar.addfile(info, io.BytesIO(raw))
+
+
+# ---------------------------------------------------------------------------
+# Version comparison — pure logic
+# ---------------------------------------------------------------------------
+
+def test_is_newer_compares_versions(updater):
+    assert updater.is_newer("1.6.0", "1.5.3") is True
+    assert updater.is_newer("1.5.3", "1.5.3") is False
+    assert updater.is_newer("1.5.2", "1.5.3") is False
+    assert updater.is_newer("2.0.0", "1.9.9") is True
+
+
+def test_is_newer_ignores_prerelease_suffix(updater):
+    assert updater.is_newer("1.6.0-beta", "1.5.3") is True
+
+
+def test_is_newer_rejects_unparseable_input(updater):
+    assert updater.is_newer("", "1.5.3") is False
+    assert updater.is_newer("not-a-version", "1.5.3") is False
+    assert updater.is_newer("1.6.0", "garbage") is False
+
+
+# ---------------------------------------------------------------------------
+# fetch_latest — must degrade silently when offline
+# ---------------------------------------------------------------------------
+
+def test_fetch_latest_returns_none_on_connection_error(updater, monkeypatch):
+    """An offline device gets ``None`` — never an exception, never a banner."""
+    import requests
+
+    def _boom(*_a, **_k):
+        raise requests.exceptions.ConnectionError("offline")
+
+    monkeypatch.setattr(updater.requests, "get", _boom)
+    assert updater.fetch_latest() is None
+
+
+def test_fetch_latest_returns_none_on_dns_failure(updater, offline):
+    """With DNS resolution failing for every host, the check is a no-op."""
+    assert updater.fetch_latest() is None
+
+
+def test_fetch_latest_returns_none_on_timeout(updater, monkeypatch):
+    import requests
+
+    def _timeout(*_a, **_k):
+        raise requests.exceptions.Timeout("slow network")
+
+    monkeypatch.setattr(updater.requests, "get", _timeout)
+    assert updater.fetch_latest() is None
+
+
+def test_fetch_latest_returns_none_on_malformed_json(updater, monkeypatch):
+    """A reachable-but-garbage response must not crash the check."""
+    monkeypatch.setattr(
+        updater.requests, "get",
+        lambda *_a, **_k: _FakeResponse(raise_json=True),
+    )
+    assert updater.fetch_latest() is None
+
+
+# ---------------------------------------------------------------------------
+# apply_update — off-device and bad-bundle paths
+# ---------------------------------------------------------------------------
+
+def test_apply_update_off_device_is_blocked_with_a_clear_message(updater):
+    """On a dev clone (no RRR_HOME) apply is unavailable, not a crash."""
+    info = updater.UpdateInfo(
+        version="9.9.9", url="https://example/r", notes="", available=True,
+        bundle_url="https://example/b.rrrupdate",
+    )
+    ok, message = updater.apply_update(info)
+    assert ok is False
+    assert "installed device" in message
+
+
+def test_apply_update_rejects_a_corrupt_bundle_when_checksum_is_known(
+    updater, tmp_path, monkeypatch,
+):
+    """When the .sha256 IS fetched and mismatches, the bundle is rejected.
+
+    This is the verification path working correctly — locked in as a
+    regression guard for the Phase 2 changes.
+    """
+    home = tmp_path / "rrr"
+    (home / "releases").mkdir(parents=True)
+    monkeypatch.setenv("RRR_HOME", str(home))
+
+    monkeypatch.setattr(
+        updater, "_download", lambda _url, dest: _make_bundle(dest, "9.9.9"),
+    )
+    monkeypatch.setattr(updater, "_fetch_sha256", lambda _url: "0" * 64)
+
+    info = updater.UpdateInfo(
+        version="9.9.9", url="https://example/r", notes="", available=True,
+        bundle_url="https://example/b.rrrupdate",
+        sha256_url="https://example/b.rrrupdate.sha256",
+    )
+    ok, message = updater.apply_update(info)
+    assert ok is False
+    assert "verification failed" in message.lower()
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Phase 2: apply_update silently SKIPS SHA256 verification when the "
+           ".sha256 asset cannot be fetched ('if expected and ...'). An "
+           "unverifiable bundle is currently installed. Phase 2 makes the "
+           "check fail-closed and removes this marker.",
+)
+def test_apply_update_rejects_bundle_when_checksum_cannot_be_fetched(
+    updater, tmp_path, monkeypatch,
+):
+    """An unreachable / 404 / rate-limited .sha256 asset must block the apply.
+
+    Today ``_fetch_sha256`` returns ``None`` on failure and ``apply_update``
+    treats "no checksum" as "skip the check" — a fail-OPEN integrity hole.
+    """
+    home = tmp_path / "rrr"
+    (home / "releases").mkdir(parents=True)
+    monkeypatch.setenv("RRR_HOME", str(home))
+
+    monkeypatch.setattr(
+        updater, "_download", lambda _url, dest: _make_bundle(dest, "9.9.9"),
+    )
+    # Simulate the checksum asset being unreachable.
+    monkeypatch.setattr(updater, "_fetch_sha256", lambda _url: None)
+
+    info = updater.UpdateInfo(
+        version="9.9.9", url="https://example/r", notes="", available=True,
+        bundle_url="https://example/b.rrrupdate",
+        sha256_url="https://example/b.rrrupdate.sha256",
+    )
+    ok, message = updater.apply_update(info)
+    # DESIRED (Phase 2): no verified checksum -> refuse to install.
+    assert ok is False
+    assert "verif" in message.lower()

--- a/Project/ui/SettingsTab.py
+++ b/Project/ui/SettingsTab.py
@@ -582,28 +582,28 @@ class SettingsTab(QWidget):
         header.setStretchLastSection(False)
         header.setMinimumSectionSize(40)
         
-        # Column 0: Cage - fixed width (compact)
-        header.setSectionResizeMode(0, QHeaderView.Fixed)
-        self.calibration_table.setColumnWidth(0, 100)
-        
-        # Column 1: Status - stretch to fill available space
-        header.setSectionResizeMode(1, QHeaderView.Stretch)
-        
-        # Column 2: mL/Pulse - compact fixed width
+        # Column 0: Cage - stretch to absorb slack (names vary in length)
+        header.setSectionResizeMode(0, QHeaderView.Stretch)
+
+        # Column 1: Status - compact fixed width (badge only)
+        header.setSectionResizeMode(1, QHeaderView.Fixed)
+        self.calibration_table.setColumnWidth(1, 120)
+
+        # Column 2: mL/Pulse - fixed width (fits "0.001234")
         header.setSectionResizeMode(2, QHeaderView.Fixed)
-        self.calibration_table.setColumnWidth(2, 70)
-        
-        # Column 3: CV% - compact fixed width
+        self.calibration_table.setColumnWidth(2, 95)
+
+        # Column 3: CV% - fixed width
         header.setSectionResizeMode(3, QHeaderView.Fixed)
-        self.calibration_table.setColumnWidth(3, 55)
-        
-        # Column 4: Date - compact fixed width
+        self.calibration_table.setColumnWidth(3, 70)
+
+        # Column 4: Date - fixed width (fits "2026-05-12")
         header.setSectionResizeMode(4, QHeaderView.Fixed)
-        self.calibration_table.setColumnWidth(4, 80)
+        self.calibration_table.setColumnWidth(4, 100)
         
         # Column 5: Action - fixed width for button with padding
         header.setSectionResizeMode(5, QHeaderView.Fixed)
-        self.calibration_table.setColumnWidth(5, 90)
+        self.calibration_table.setColumnWidth(5, 110)
         
         # Populate table with 15 cages
         self._populate_calibration_table()
@@ -706,8 +706,10 @@ class SettingsTab(QWidget):
             
             if cal:
                 # Calibrated - show data
-                status_item = QTableWidgetItem("[OK] Calibrated")
+                status_item = QTableWidgetItem("[OK]")
                 status_item.setForeground(QColor(0, 150, 0))
+                status_item.setTextAlignment(Qt.AlignCenter)
+                status_item.setToolTip("Calibrated")
                 
                 volume_item = QTableWidgetItem(f"{cal['volume_per_pulse_ml']:.6f}")
                 volume_item.setTextAlignment(Qt.AlignCenter)
@@ -751,8 +753,10 @@ class SettingsTab(QWidget):
                 
             else:
                 # Not calibrated - show warning
-                status_item = QTableWidgetItem("[X] Not Calibrated")
+                status_item = QTableWidgetItem("Not Calibrated")
                 status_item.setForeground(QColor(200, 0, 0))
+                status_item.setTextAlignment(Qt.AlignCenter)
+                status_item.setToolTip("Not calibrated")
                 
                 volume_item = QTableWidgetItem("—")
                 volume_item.setTextAlignment(Qt.AlignCenter)

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"


### PR DESCRIPTION
 v1.5.3

Phase 1 of the offline-resilience plan. Locks in the current behaviour of the update checker and the Slack notifier under network failure, with no production code changes — a safety net for the Phase 2/3 hardening.

- conftest: `offline` fixture simulating DNS failure for every host (socket.getaddrinfo), reusable by any test needing a netless device.
- test_updater_offline.py: fetch_latest degrades to None when offline (connection error, DNS failure, timeout, malformed JSON); apply_update off-device and corrupt-bundle paths.
- test_notifications_offline.py: a Slack API failure falls back to the local pump log without propagating into the relay worker.

Three strict-xfail canaries assert the Phase 2 target behaviour and fail by design today, so the fix cannot land silently:
- apply_update must fail-closed when the .sha256 asset is unverifiable
- the Slack notifier must catch network-level (non-SlackApiError) failures
- the Slack WebClient must be constructed with an explicit timeout

Also includes a calibration-table layout fix in SettingsTab.py (separate in-progress work, folded in at the author's request): Status column is now fixed-width with a centered badge + tooltip ("[OK]" / "Not Calibrated"), Cage column stretches to absorb slack, and the mL/Pulse, CV%, Date and Action columns are widened so values no longer truncate — removing the horizontal scrollbar.

Bumps Project/version.py to 1.5.3.