### PR TITLE
refactor(offline): central net policy + fail-closed updater + Slack t…

### DIFF
--- a/Project/notifications/notifications.py
+++ b/Project/notifications/notifications.py
@@ -1,80 +1,100 @@
-import requests
-import json
+"""Slack notifications for RRR.
+
+A delivery to live animals must never be disrupted by a Slack or network
+failure. This module enforces that contract:
+
+* the ``WebClient`` is constructed with an explicit short timeout so a
+  stalled connection cannot block the relay-worker thread that calls in
+  here from the schedule hot path;
+* every failure mode (API rejection, connection refused, DNS failure,
+  timeout, unexpected exception) is caught, recorded, and the message is
+  appended to a local file (``pump_log.json``) so no trigger is ever
+  lost;
+* the most recent outcome is stored on ``self.last_status`` so the GUI's
+  Slack indicator (Phase 3) can surface "ok" / "Slack token revoked" /
+  "network unreachable" with actionable detail — instead of forcing the
+  operator to read ``stdout`` to know what happened.
+
+Phase 2 of the offline-resilience plan.
+"""
+
 import datetime
-import time
-import threading
+import json
+import os
+
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
-import os
 
 from utils import paths
 
+# Local fallback log: every relay trigger we couldn't tell Slack about is
+# appended here so the operator can reconcile after the fact.
 LOG_FILE = paths.pump_log_path()
 
+# Bounded wall-clock budget for a single Slack call. Short on purpose: the
+# relay worker calls in here from the hot path of schedule execution.
+_SLACK_TIMEOUT_S = 10
+
+
 class NotificationHandler:
+    """Send delivery/error messages to Slack with a durable local fallback."""
+
     def __init__(self, slack_token, channel_id):
-        self.client = WebClient(token=slack_token)
+        # Explicit timeout protects the relay worker — see module docstring.
+        self.client = WebClient(token=slack_token, timeout=_SLACK_TIMEOUT_S)
         self.channel_id = channel_id
+        # Last delivery outcome, consumed by the Phase 3 GUI indicator.
+        # Format: {"ok": bool, "detail": str, "timestamp": iso8601}.
+        self.last_status = None
 
     def send_slack_notification(self, message):
+        """Send ``message`` to Slack; on any failure, log it locally instead.
+
+        Must never raise into the caller — the relay worker depends on it.
+        """
         try:
-            response = self.client.chat_postMessage(
-                channel=self.channel_id,
-                text=message
-            )
-            print(f"{datetime.datetime.now()} - Slack message sent successfully! Response: {response}")
-        except SlackApiError as e:
-            print(f"{datetime.datetime.now()} - Failed to send Slack message: {e.response['error']}")
-            
+            self.client.chat_postMessage(channel=self.channel_id, text=message)
+        except SlackApiError as exc:
+            err = "unknown"
+            try:
+                err = exc.response["error"]
+            except Exception:
+                pass
+            print(f"{datetime.datetime.now()} - Slack API error: {err}")
+            self._record_status(False, f"Slack rejected the message: {err}")
             self.log_pump_trigger(message)
+        except Exception as exc:
+            # Connection refused, DNS failure, timeout, urllib errors, etc.
+            # Whatever the Slack SDK raised on a network failure, we treat
+            # it as "Slack unreachable" and fall back to the local log.
+            print(f"{datetime.datetime.now()} - Slack network failure: "
+                  f"{exc.__class__.__name__}: {exc}")
+            self._record_status(False,
+                                f"Network failure ({exc.__class__.__name__})")
+            self.log_pump_trigger(message)
+        else:
+            self._record_status(True, "ok")
 
     def log_pump_trigger(self, relay_info):
+        """Append a trigger to ``pump_log.json`` so it survives an outage."""
         log_entry = {
             "timestamp": datetime.datetime.now().isoformat(),
-            "relay_info": relay_info
+            "relay_info": relay_info,
         }
-
         if not os.path.exists(LOG_FILE):
-            with open(LOG_FILE, 'w') as f:
+            with open(LOG_FILE, "w") as f:
                 json.dump([], f)
-
-        with open(LOG_FILE, 'r') as f:
+        with open(LOG_FILE, "r") as f:
             logs = json.load(f)
-
         logs.append(log_entry)
-
-        with open(LOG_FILE, 'w') as f:
+        with open(LOG_FILE, "w") as f:
             json.dump(logs, f, indent=4)
-        
         print(f"Logged pump trigger: {log_entry}")
 
-    def is_internet_available(self):
-        try:
-            requests.get('http://google.com', timeout=5)
-            return True
-        except requests.ConnectionError:
-            return False
-
-    def retry_sending_logs(self):
-        while True:
-            if self.is_internet_available() and os.path.exists(LOG_FILE):
-                with open(LOG_FILE, 'r') as f:
-                    logs = json.load(f)
-
-                for log in logs:
-                    message = log["relay_info"]
-                    try:
-                        self.send_slack_notification(message)
-                        logs.remove(log)
-                    except SlackApiError:
-                        break  # Stop retrying if sending fails
-
-                with open(LOG_FILE, 'w') as f:
-                    json.dump(logs, f, indent=4)
-
-            time.sleep(60)  # Retry every minute
-
-    def start_retry_thread(self):
-        retry_thread = threading.Thread(target=self.retry_sending_logs)
-        retry_thread.daemon = True  # Ensure thread exits when the main program does
-        retry_thread.start()
+    def _record_status(self, ok, detail):
+        """Update ``last_status`` for the GUI's Slack indicator."""
+        self.last_status = {
+            "ok": bool(ok),
+            "detail": detail,
+            "timestamp": datetime.datetime.now().isoformat(),
+        }

--- a/Project/tests/unit/test_net.py
+++ b/Project/tests/unit/test_net.py
@@ -1,0 +1,209 @@
+"""Unit tests for ``utils.net`` — the central network policy module.
+
+Phase 2 of the offline-resilience work. Pins the contract that the updater
+and notifications modules now depend on:
+
+* :func:`utils.net.get_json` is fail-soft (returns ``None`` on any failure);
+* :func:`utils.net.require_digest` is fail-closed (raises ``NetworkError``);
+* :func:`utils.net.stream_download` enforces both a byte cap and a
+  wall-clock deadline, and cleans up the partial file on any failure.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+requests = pytest.importorskip("requests")
+
+from utils import net  # noqa: E402  (importorskip first)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    """Stand-in for a ``requests.Response`` from a non-streaming GET."""
+
+    def __init__(self, *, status_ok=True, json_data=None, text="", raise_json=False):
+        self._json_data = json_data
+        self._raise_json = raise_json
+        self._ok = status_ok
+        self.text = text
+
+    def raise_for_status(self):
+        if not self._ok:
+            raise requests.HTTPError("404")
+
+    def json(self):
+        if self._raise_json:
+            raise ValueError("not JSON")
+        return self._json_data
+
+
+class _FakeStream:
+    """Stand-in for a streaming ``requests`` response used as a CM."""
+
+    def __init__(self, chunks, *, status_ok=True):
+        self._chunks = chunks
+        self._ok = status_ok
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def raise_for_status(self):
+        if not self._ok:
+            raise requests.HTTPError("404")
+
+    def iter_content(self, _chunk_size):
+        yield from self._chunks
+
+
+def _conn_error(*_a, **_k):
+    raise requests.exceptions.ConnectionError("offline")
+
+
+# ---------------------------------------------------------------------------
+# get_json — fail-soft
+# ---------------------------------------------------------------------------
+
+def test_get_json_returns_dict_on_success(monkeypatch):
+    monkeypatch.setattr(net.requests, "get",
+                        lambda *_a, **_k: _FakeResponse(json_data={"a": 1}))
+    assert net.get_json("https://example/x") == {"a": 1}
+
+
+def test_get_json_returns_none_on_connection_error(monkeypatch):
+    monkeypatch.setattr(net.requests, "get", _conn_error)
+    assert net.get_json("https://example/x") is None
+
+
+def test_get_json_returns_none_on_http_error(monkeypatch):
+    monkeypatch.setattr(net.requests, "get",
+                        lambda *_a, **_k: _FakeResponse(status_ok=False))
+    assert net.get_json("https://example/x") is None
+
+
+def test_get_json_returns_none_on_malformed_json(monkeypatch):
+    monkeypatch.setattr(net.requests, "get",
+                        lambda *_a, **_k: _FakeResponse(raise_json=True))
+    assert net.get_json("https://example/x") is None
+
+
+def test_get_json_returns_none_on_dns_failure(offline):
+    assert net.get_json("https://nope.invalid/x") is None
+
+
+# ---------------------------------------------------------------------------
+# require_digest — fail-closed
+# ---------------------------------------------------------------------------
+
+def test_require_digest_returns_clean_lowercase_hex(monkeypatch):
+    digest = "a" * 64
+    monkeypatch.setattr(
+        net.requests, "get",
+        lambda *_a, **_k: _FakeResponse(text=f"{digest.upper()}  file.tar.gz\n"),
+    )
+    assert net.require_digest("https://example/x.sha256") == digest
+
+
+def test_require_digest_raises_when_url_is_empty():
+    with pytest.raises(net.NetworkError, match="checksum URL"):
+        net.require_digest("")
+
+
+def test_require_digest_raises_on_http_error(monkeypatch):
+    monkeypatch.setattr(net.requests, "get",
+                        lambda *_a, **_k: _FakeResponse(status_ok=False))
+    with pytest.raises(net.NetworkError, match="fetch checksum"):
+        net.require_digest("https://example/x.sha256")
+
+
+def test_require_digest_raises_on_connection_error(monkeypatch):
+    monkeypatch.setattr(net.requests, "get", _conn_error)
+    with pytest.raises(net.NetworkError):
+        net.require_digest("https://example/x.sha256")
+
+
+def test_require_digest_raises_on_dns_failure(offline):
+    with pytest.raises(net.NetworkError):
+        net.require_digest("https://nope.invalid/x.sha256")
+
+
+def test_require_digest_raises_on_empty_response(monkeypatch):
+    monkeypatch.setattr(net.requests, "get",
+                        lambda *_a, **_k: _FakeResponse(text=""))
+    with pytest.raises(net.NetworkError, match="empty"):
+        net.require_digest("https://example/x.sha256")
+
+
+def test_require_digest_raises_on_invalid_format(monkeypatch):
+    monkeypatch.setattr(net.requests, "get",
+                        lambda *_a, **_k: _FakeResponse(text="not-a-hex-digest"))
+    with pytest.raises(net.NetworkError, match="SHA256"):
+        net.require_digest("https://example/x.sha256")
+
+
+def test_require_digest_raises_on_wrong_length(monkeypatch):
+    """A 32-char (MD5-shaped) digest must be rejected."""
+    monkeypatch.setattr(net.requests, "get",
+                        lambda *_a, **_k: _FakeResponse(text="abc" * 10))
+    with pytest.raises(net.NetworkError, match="SHA256"):
+        net.require_digest("https://example/x.sha256")
+
+
+# ---------------------------------------------------------------------------
+# stream_download — wall-clock + byte cap + cleanup
+# ---------------------------------------------------------------------------
+
+def test_stream_download_writes_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(net.requests, "get",
+                        lambda *_a, **_k: _FakeStream([b"hello ", b"world"]))
+    dst = tmp_path / "out.bin"
+    net.stream_download("https://example/x", str(dst))
+    assert dst.read_bytes() == b"hello world"
+
+
+def test_stream_download_enforces_byte_cap(tmp_path, monkeypatch):
+    monkeypatch.setattr(net.requests, "get",
+                        lambda *_a, **_k: _FakeStream([b"x" * 1024] * 10))
+    dst = tmp_path / "out.bin"
+    with pytest.raises(net.NetworkError, match="bytes"):
+        net.stream_download("https://example/x", str(dst), max_bytes=2048)
+    assert not dst.exists(), "partial file must be cleaned up on failure"
+
+
+def test_stream_download_enforces_wall_clock(tmp_path, monkeypatch):
+    monkeypatch.setattr(net.requests, "get",
+                        lambda *_a, **_k: _FakeStream([b"a", b"b", b"c"]))
+    # 1st monotonic() call sets deadline=100+10=110. Subsequent calls
+    # return 105 (under deadline), 200 (over → raise).
+    times = iter([100.0, 105.0, 200.0, 200.0, 200.0])
+    monkeypatch.setattr(net.time, "monotonic", lambda: next(times))
+
+    dst = tmp_path / "out.bin"
+    with pytest.raises(net.NetworkError, match="wall-clock"):
+        net.stream_download("https://example/x", str(dst), total_timeout=10)
+    assert not dst.exists()
+
+
+def test_stream_download_cleans_up_on_http_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        net.requests, "get",
+        lambda *_a, **_k: _FakeStream([b"data"], status_ok=False),
+    )
+    dst = tmp_path / "out.bin"
+    with pytest.raises(net.NetworkError):
+        net.stream_download("https://example/x", str(dst))
+    assert not dst.exists()
+
+
+def test_stream_download_cleans_up_on_connection_error(tmp_path, monkeypatch):
+    monkeypatch.setattr(net.requests, "get", _conn_error)
+    dst = tmp_path / "out.bin"
+    with pytest.raises(net.NetworkError):
+        net.stream_download("https://example/x", str(dst))
+    assert not dst.exists()

--- a/Project/tests/unit/test_notifications_offline.py
+++ b/Project/tests/unit/test_notifications_offline.py
@@ -97,18 +97,12 @@ def test_repeated_failures_accumulate_in_the_log(handler, monkeypatch):
 # Strict xfail canaries — assert the Phase 2 target behaviour
 # ---------------------------------------------------------------------------
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Phase 2: send_slack_notification only catches SlackApiError. A "
-           "network-level failure (the real offline symptom) is not caught "
-           "and propagates into the relay worker. Phase 2 broadens the "
-           "handler and removes this marker.",
-)
 def test_network_level_failure_also_falls_back(handler, monkeypatch):
     """Offline Slack calls fail with connection errors, not SlackApiError.
 
-    The fallback log must catch those too — otherwise an offline device
-    raises straight into the delivery worker.
+    Phase 2 broadened the failure handler to catch ``Exception`` so any
+    network-level failure (the real offline symptom) is logged locally —
+    a connection error must never raise into the relay worker.
     """
     handler_obj, log_path = handler
 
@@ -122,14 +116,60 @@ def test_network_level_failure_also_falls_back(handler, monkeypatch):
     assert json.loads(log_path.read_text())[0]["relay_info"] == "trigger during outage"
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Phase 2: the Slack WebClient is constructed without an explicit "
-           "timeout, so a stalled connection can block the relay worker. "
-           "Phase 2 sets an explicit timeout and removes this marker.",
-)
 def test_webclient_is_constructed_with_an_explicit_timeout(handler):
-    """The Slack client must carry a bounded timeout to protect the hot path."""
+    """The Slack client must carry a bounded timeout to protect the hot path.
+
+    Phase 2 sets an explicit ``timeout=10`` on the ``WebClient``; a stalled
+    connection cannot block the relay-worker thread.
+    """
     handler_obj, _ = handler
     timeout = getattr(handler_obj.client, "timeout", None)
     assert isinstance(timeout, (int, float)) and timeout <= 15
+
+
+# ---------------------------------------------------------------------------
+# last_status — Phase 2 recorder consumed by the GUI Slack indicator
+# ---------------------------------------------------------------------------
+
+def test_last_status_is_none_before_any_send(handler):
+    handler_obj, _ = handler
+    assert handler_obj.last_status is None
+
+
+def test_last_status_records_success(handler, monkeypatch):
+    handler_obj, _ = handler
+    monkeypatch.setattr(handler_obj.client, "chat_postMessage",
+                        lambda *_a, **_k: {"ok": True})
+    handler_obj.send_slack_notification("delivery complete")
+
+    status = handler_obj.last_status
+    assert status is not None
+    assert status["ok"] is True
+    assert "timestamp" in status
+
+
+def test_last_status_records_api_failure_with_error_code(handler, monkeypatch):
+    handler_obj, _ = handler
+    monkeypatch.setattr(
+        handler_obj.client, "chat_postMessage",
+        lambda *_a, **_k: (_ for _ in ()).throw(_slack_api_error("token_revoked")),
+    )
+    handler_obj.send_slack_notification("msg")
+
+    status = handler_obj.last_status
+    assert status["ok"] is False
+    assert "token_revoked" in status["detail"]
+
+
+def test_last_status_records_network_failure(handler, monkeypatch):
+    handler_obj, _ = handler
+
+    def _raise(*_a, **_k):
+        raise ConnectionError("offline")
+
+    monkeypatch.setattr(handler_obj.client, "chat_postMessage", _raise)
+    handler_obj.send_slack_notification("msg")
+
+    status = handler_obj.last_status
+    assert status["ok"] is False
+    assert "ConnectionError" in status["detail"] or "Network" in status["detail"]

--- a/Project/tests/unit/test_updater_offline.py
+++ b/Project/tests/unit/test_updater_offline.py
@@ -89,13 +89,18 @@ def test_is_newer_rejects_unparseable_input(updater):
 # ---------------------------------------------------------------------------
 
 def test_fetch_latest_returns_none_on_connection_error(updater, monkeypatch):
-    """An offline device gets ``None`` — never an exception, never a banner."""
+    """An offline device gets ``None`` — never an exception, never a banner.
+
+    Phase 2 routed the HTTP call through ``utils.net``; the patch target is
+    therefore ``net.requests`` (same module object, more honest naming).
+    """
     import requests
+    from utils import net
 
     def _boom(*_a, **_k):
         raise requests.exceptions.ConnectionError("offline")
 
-    monkeypatch.setattr(updater.requests, "get", _boom)
+    monkeypatch.setattr(net.requests, "get", _boom)
     assert updater.fetch_latest() is None
 
 
@@ -106,18 +111,21 @@ def test_fetch_latest_returns_none_on_dns_failure(updater, offline):
 
 def test_fetch_latest_returns_none_on_timeout(updater, monkeypatch):
     import requests
+    from utils import net
 
     def _timeout(*_a, **_k):
         raise requests.exceptions.Timeout("slow network")
 
-    monkeypatch.setattr(updater.requests, "get", _timeout)
+    monkeypatch.setattr(net.requests, "get", _timeout)
     assert updater.fetch_latest() is None
 
 
 def test_fetch_latest_returns_none_on_malformed_json(updater, monkeypatch):
     """A reachable-but-garbage response must not crash the check."""
+    from utils import net
+
     monkeypatch.setattr(
-        updater.requests, "get",
+        net.requests, "get",
         lambda *_a, **_k: _FakeResponse(raise_json=True),
     )
     assert updater.fetch_latest() is None
@@ -165,21 +173,18 @@ def test_apply_update_rejects_a_corrupt_bundle_when_checksum_is_known(
     assert "verification failed" in message.lower()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Phase 2: apply_update silently SKIPS SHA256 verification when the "
-           ".sha256 asset cannot be fetched ('if expected and ...'). An "
-           "unverifiable bundle is currently installed. Phase 2 makes the "
-           "check fail-closed and removes this marker.",
-)
 def test_apply_update_rejects_bundle_when_checksum_cannot_be_fetched(
     updater, tmp_path, monkeypatch,
 ):
     """An unreachable / 404 / rate-limited .sha256 asset must block the apply.
 
-    Today ``_fetch_sha256`` returns ``None`` on failure and ``apply_update``
-    treats "no checksum" as "skip the check" — a fail-OPEN integrity hole.
+    The Phase 2 fail-closed integrity rule: when :func:`utils.net.require_digest`
+    raises ``NetworkError``, ``apply_update`` refuses to install the bundle
+    and surfaces a clear "could not verify" message. Replaces the
+    pre-Phase-2 silent-skip (``if expected and ...``).
     """
+    from utils import net
+
     home = tmp_path / "rrr"
     (home / "releases").mkdir(parents=True)
     monkeypatch.setenv("RRR_HOME", str(home))
@@ -187,8 +192,11 @@ def test_apply_update_rejects_bundle_when_checksum_cannot_be_fetched(
     monkeypatch.setattr(
         updater, "_download", lambda _url, dest: _make_bundle(dest, "9.9.9"),
     )
-    # Simulate the checksum asset being unreachable.
-    monkeypatch.setattr(updater, "_fetch_sha256", lambda _url: None)
+
+    def _checksum_unreachable(_url):
+        raise net.NetworkError("checksum asset unreachable (404)")
+
+    monkeypatch.setattr(updater, "_fetch_sha256", _checksum_unreachable)
 
     info = updater.UpdateInfo(
         version="9.9.9", url="https://example/r", notes="", available=True,
@@ -196,6 +204,5 @@ def test_apply_update_rejects_bundle_when_checksum_cannot_be_fetched(
         sha256_url="https://example/b.rrrupdate.sha256",
     )
     ok, message = updater.apply_update(info)
-    # DESIRED (Phase 2): no verified checksum -> refuse to install.
     assert ok is False
-    assert "verif" in message.lower()
+    assert "verify" in message.lower()

--- a/Project/utils/net.py
+++ b/Project/utils/net.py
@@ -1,0 +1,133 @@
+"""Central network policy for RRR.
+
+All outbound HTTPS in the application goes through this module so that
+timeouts, error mapping, and integrity rules live in one place and tests
+can substitute the whole network layer with a single monkeypatch.
+
+Two rules govern the helpers here:
+
+* **Fail-soft for UX operations.** The startup update check must never
+  raise into the GUI — it returns ``None`` when anything goes wrong. The
+  deployed Pi may sit in an animal nest with no internet; the app must
+  keep delivering water normally regardless.
+* **Fail-closed for security operations.** :func:`require_digest` raises
+  ``NetworkError`` when the SHA256 cannot be obtained, replacing the
+  previous "if expected and ..." silent-skip in the apply engine.
+
+Phase 2 of the offline-resilience plan.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import requests
+
+# (connect, read) tuple: connect must be short so a dead network is
+# detected quickly; read can be more generous for slow links.
+_DEFAULT_TIMEOUT: tuple[float, float] = (5, 10)
+
+# Hard ceiling for streamed bodies — guards against a runaway response
+# filling the disk. Tuned for the update bundle, which is well under 50 MB.
+_DEFAULT_MAX_BYTES: int = 200 * 1024 * 1024
+
+# Wall-clock budget for a streamed download. ``requests``' read timeout is
+# per-read, so a trickle of 1-byte reads could otherwise stall the apply
+# for an hour; this enforces a single absolute deadline.
+_DEFAULT_TOTAL_TIMEOUT: float = 600
+
+
+class NetworkError(Exception):
+    """A network operation could not be completed within its budget.
+
+    The single exception type the apply engine catches — every failure
+    mode (DNS, connection refused, HTTP error, timeout, oversize body,
+    invalid checksum format) is mapped to this one class.
+    """
+
+
+def get_json(url: str, *, timeout: tuple[float, float] = _DEFAULT_TIMEOUT,
+             headers: dict | None = None) -> dict | None:
+    """GET a JSON document. ``None`` on any failure — never raises.
+
+    Used by non-security operations that must degrade silently — the
+    startup update check is the canonical caller.
+    """
+    try:
+        response = requests.get(url, timeout=timeout, headers=headers or {})
+        response.raise_for_status()
+        return response.json()
+    except Exception:
+        return None
+
+
+def require_digest(url: str, *,
+                   timeout: tuple[float, float] = _DEFAULT_TIMEOUT) -> str:
+    """Fetch and validate a SHA256 from a ``.sha256`` asset.
+
+    Returns the lowercase 64-char hex digest. Raises :class:`NetworkError`
+    when the asset is missing, unreachable, empty, or malformed — the
+    apply engine then refuses to install. This is the fail-closed
+    integrity rule that replaces the previous silent-skip.
+    """
+    if not url:
+        raise NetworkError("no checksum URL was provided")
+    try:
+        response = requests.get(url, timeout=timeout)
+        response.raise_for_status()
+    except Exception as exc:
+        raise NetworkError(f"could not fetch checksum: {exc}") from exc
+    text = (response.text or "").strip()
+    if not text:
+        raise NetworkError("checksum response was empty")
+    digest = text.split()[0].lower()
+    if len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+        raise NetworkError(f"checksum is not a valid SHA256: {digest!r}")
+    return digest
+
+
+def stream_download(url: str, dest: str, *,
+                    connect_timeout: float = 10,
+                    read_timeout: float = 60,
+                    total_timeout: float = _DEFAULT_TOTAL_TIMEOUT,
+                    max_bytes: int = _DEFAULT_MAX_BYTES) -> None:
+    """Stream a URL to ``dest`` with wall-clock and byte caps.
+
+    Raises :class:`NetworkError` on any failure (timeout, HTTP error,
+    half-open connection, body exceeding ``max_bytes``, wall-clock
+    exceeded). On error, ``dest`` is removed so the caller never sees a
+    partial file.
+    """
+    deadline = time.monotonic() + total_timeout
+    try:
+        with requests.get(url, stream=True,
+                          timeout=(connect_timeout, read_timeout)) as resp:
+            resp.raise_for_status()
+            written = 0
+            with open(dest, "wb") as handle:
+                for chunk in resp.iter_content(1 << 16):
+                    if chunk:
+                        written += len(chunk)
+                        if written > max_bytes:
+                            raise NetworkError(
+                                f"download exceeded {max_bytes} bytes")
+                        handle.write(chunk)
+                    if time.monotonic() > deadline:
+                        raise NetworkError(
+                            f"download exceeded {total_timeout:.0f}s "
+                            f"wall-clock budget")
+    except NetworkError:
+        _safe_unlink(dest)
+        raise
+    except Exception as exc:
+        _safe_unlink(dest)
+        raise NetworkError(f"download failed: {exc}") from exc
+
+
+def _safe_unlink(path: str) -> None:
+    """``os.unlink`` that does not raise when the file is already gone."""
+    try:
+        os.unlink(path)
+    except OSError:
+        pass

--- a/Project/utils/updater.py
+++ b/Project/utils/updater.py
@@ -18,17 +18,15 @@ import subprocess
 import tarfile
 import tempfile
 
-import requests
 from PyQt5.QtCore import QObject, QThread, pyqtSignal
 
 from version import __version__ as CURRENT_VERSION
-from utils import paths
+from utils import net, paths
 
 # The repository whose Releases are the update channel.
 GITHUB_REPO = "Corticomics/rodRefReg"
 _LATEST_RELEASE_API = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
 _RELEASES_PAGE = f"https://github.com/{GITHUB_REPO}/releases"
-_REQUEST_TIMEOUT_S = 10
 
 
 def _version_tuple(text):
@@ -71,16 +69,16 @@ def fetch_latest():
     Returns an :class:`UpdateInfo`, or ``None`` if the check could not be
     completed — offline, rate-limited, or no releases published yet. Never
     raises. Pre-releases (``v*-beta``) are excluded by the GitHub endpoint.
+
+    The network call is delegated to :func:`utils.net.get_json`, which owns
+    the timeout and exception-mapping policy (Phase 2 of the
+    offline-resilience plan).
     """
-    try:
-        response = requests.get(
-            _LATEST_RELEASE_API,
-            timeout=_REQUEST_TIMEOUT_S,
-            headers={"Accept": "application/vnd.github+json"},
-        )
-        response.raise_for_status()
-        data = response.json()
-    except Exception:
+    data = net.get_json(
+        _LATEST_RELEASE_API,
+        headers={"Accept": "application/vnd.github+json"},
+    )
+    if not data:
         return None
 
     tag = data.get("tag_name", "")
@@ -188,23 +186,25 @@ def _sha256_file(path):
 
 
 def _download(url, dest):
-    with requests.get(url, stream=True, timeout=60) as resp:
-        resp.raise_for_status()
-        with open(dest, "wb") as handle:
-            for chunk in resp.iter_content(1 << 16):
-                handle.write(chunk)
+    """Download ``url`` to ``dest``.
+
+    Thin adapter over :func:`utils.net.stream_download` — kept as a stable
+    test seam (the offline-resilience test harness monkeypatches it).
+    Raises :class:`utils.net.NetworkError` on any failure; the partial
+    file is removed.
+    """
+    net.stream_download(url, dest)
 
 
 def _fetch_sha256(url):
-    """Return the expected hex digest from a .sha256 asset, or None."""
-    if not url:
-        return None
-    try:
-        resp = requests.get(url, timeout=_REQUEST_TIMEOUT_S)
-        resp.raise_for_status()
-        return resp.text.strip().split()[0]
-    except Exception:
-        return None
+    """Return the expected hex digest from a ``.sha256`` asset.
+
+    Thin adapter over :func:`utils.net.require_digest` — fail-closed:
+    raises :class:`utils.net.NetworkError` when the asset is unreachable,
+    empty, or malformed. The apply engine refuses to install in that case
+    (replaces the pre-Phase-2 silent-skip).
+    """
+    return net.require_digest(url)
 
 
 def _read_manifest(release_dir):
@@ -322,11 +322,27 @@ def apply_update(info, progress=lambda message: None):
             bundle = os.path.join(tmp, "bundle.rrrupdate")
 
             progress("Downloading update…")
-            _download(info.bundle_url, bundle)
+            try:
+                _download(info.bundle_url, bundle)
+            except net.NetworkError as exc:
+                return False, (
+                    f"Could not download the update ({exc}). Updates require "
+                    "an internet connection — check this device's network "
+                    "and try again."
+                )
 
             progress("Verifying download…")
-            expected = _fetch_sha256(info.sha256_url)
-            if expected and _sha256_file(bundle) != expected:
+            try:
+                expected = _fetch_sha256(info.sha256_url)
+            except net.NetworkError as exc:
+                # Fail-closed: an unverifiable bundle is never installed,
+                # even on flaky networks. Replaces the pre-Phase-2
+                # silent-skip ('if expected and ...').
+                return False, (
+                    "Could not verify the update — the checksum file is "
+                    f"unreachable ({exc}). The update was not installed."
+                )
+            if _sha256_file(bundle) != expected:
                 return False, "Download verification failed (checksum mismatch)."
 
             progress("Extracting…")

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.5.3"
+__version__ = "1.6.0"


### PR DESCRIPTION
…imeout (Phase 2, v1.6.0)

Phase 2 of the offline-resilience plan — the behaviour-changing phase. Three runtime defects flagged by Phase 1's strict-xfail canaries are now fixed; the canaries flip from xfail to pass.

NEW — Project/utils/net.py
  Single source of truth for every outbound HTTPS call. Three helpers,
  two policies:
  * get_json()         fail-soft  -> None on any failure (startup check)
  * require_digest()   fail-closed -> raises NetworkError (apply engine)
  * stream_download()  fail-closed, with both a byte cap (200 MB) and an
                       absolute wall-clock deadline (600 s) — fixes the
                       previous read-timeout-only path that could stall
                       an apply for an hour on a half-open connection.
  All failures map to one NetworkError exception class.

UPDATER — Project/utils/updater.py
  * fetch_latest()  -> net.get_json (silent None when offline, unchanged).
  * _download()     -> net.stream_download (wall-clock + byte cap).
  * _fetch_sha256() -> net.require_digest (now raises on failure).
  * apply_update()  fail-closed integrity:
      - removed the 'if expected and ...' silent-skip that disabled SHA256
        verification whenever the .sha256 asset was unreachable;
      - explicit "internet required" message when the bundle cannot be
        downloaded, per the project decision that updates are online-only;
      - explicit "could not verify the update" message when the checksum
        cannot be fetched (security fail-closed).

NOTIFICATIONS — Project/notifications/notifications.py
  * WebClient(token=..., timeout=10) — bounded timeout so a stalled Slack connection cannot block the relay-worker hot path that delivers water.
  * send_slack_notification() now catches every failure mode (SlackApiError and any network-level exception), not just SlackApiError. Connection / DNS / timeout failures fall back to the local pump_log.json instead of raising into the schedule worker.
  * NEW last_status attribute records the most recent outcome ({"ok": bool, "detail": str, "timestamp": iso}) — consumed by the Phase 3 GUI Slack indicator with actionable failure reasons.
  * Deleted dead code: is_internet_available (cleartext HTTP to google.com, never invoked), retry_sending_logs (infinite loop with a latent list-mutation bug, never started), start_retry_thread.

TESTS
  * Project/tests/unit/test_net.py — new, 18 tests covering get_json, require_digest, stream_download, including byte-cap and wall-clock enforcement and post-failure cleanup.
  * Phase 1 canaries flipped (xfail markers removed):
      - apply_update rejects an unverifiable bundle (fail-closed)
      - Slack notifier catches network-level failures - WebClient is constructed with an explicit timeout
  * Phase 1 fetch_latest patch targets updated from updater.requests to net.requests (same module object, more honest naming).
  * 4 new last_status tests pin the GUI indicator contract.

Full suite: 70 passed, 0 failed, 0 xfailed.

Bumps Project/version.py to 1.6.0 (MINOR — fail-closed digest is a behavioural tightening visible to callers).