### PR TITLE
feat(offline): Slack failure indicator + clearer updater dialogs (Pha…

### DIFF
--- a/Project/main.py
+++ b/Project/main.py
@@ -199,7 +199,8 @@ def setup():
         run_stop_section=gui.run_stop_section,
         login_system=login_system,
         print_to_terminal=gui.print_to_terminal,
-        database_handler=database_handler
+        database_handler=database_handler,
+        notification_handler=notification_handler,
     )
 
 # =============================================================================
@@ -606,7 +607,8 @@ def _create_gui_from_components(components: dict):
         run_stop_section=gui.run_stop_section,
         login_system=login_system,
         print_to_terminal=gui.print_to_terminal,
-        database_handler=database_handler
+        database_handler=database_handler,
+        notification_handler=notification_handler,
     )
     
     return gui

--- a/Project/tests/unit/test_slack_status.py
+++ b/Project/tests/unit/test_slack_status.py
@@ -1,0 +1,129 @@
+"""Tests for ``utils.slack_status`` — the Phase 3 indicator formatter.
+
+Pure-logic unit tests; no Qt, no Slack SDK. Covers the icon classification
+and the troubleshooting-hint mapping consumed by the GUI's Slack
+indicator (Settings → General → Slack Integration).
+"""
+
+from __future__ import annotations
+
+from utils.slack_status import format_status
+
+
+# ---------------------------------------------------------------------------
+# Three top-level icons: unknown / ok / warn
+# ---------------------------------------------------------------------------
+
+def test_none_is_unknown():
+    icon, message = format_status(None)
+    assert icon == "unknown"
+    assert "no message has been sent yet" in message
+
+
+def test_success_is_ok():
+    icon, message = format_status(
+        {"ok": True, "detail": "ok", "timestamp": "2026-05-22T14:03:12"}
+    )
+    assert icon == "ok"
+    assert "14:03:12" in message
+    assert "Delivered" in message
+
+
+def test_failure_is_warn():
+    icon, _ = format_status(
+        {"ok": False, "detail": "boom", "timestamp": "2026-05-22T14:03:12"}
+    )
+    assert icon == "warn"
+
+
+# ---------------------------------------------------------------------------
+# Failure hints — actionable instructions per known Slack error code
+# ---------------------------------------------------------------------------
+
+def _hint_for(detail: str) -> str:
+    _, message = format_status(
+        {"ok": False, "detail": detail, "timestamp": "2026-05-22T14:03:12"}
+    )
+    return message
+
+
+def test_token_revoked_hint_mentions_resetting_token():
+    assert "fresh token" in _hint_for(
+        "Slack rejected the message: token_revoked"
+    )
+
+
+def test_invalid_auth_hint_mentions_resetting_token():
+    assert "fresh token" in _hint_for(
+        "Slack rejected the message: invalid_auth"
+    )
+
+
+def test_not_authed_hint_mentions_resetting_token():
+    assert "fresh token" in _hint_for(
+        "Slack rejected the message: not_authed"
+    )
+
+
+def test_channel_not_found_hint_mentions_channel_id():
+    hint = _hint_for("Slack rejected the message: channel_not_found")
+    assert "Channel ID" in hint
+    assert "invited" in hint
+
+
+def test_archived_channel_hint_mentions_channel_id():
+    assert "Channel ID" in _hint_for(
+        "Slack rejected the message: is_archived"
+    )
+
+
+def test_missing_scope_hint_mentions_scope():
+    assert "chat:write" in _hint_for(
+        "Slack rejected the message: missing_scope"
+    )
+
+
+def test_rate_limited_hint_says_resumes_automatically():
+    assert "rate-limit" in _hint_for(
+        "Slack rejected the message: ratelimited"
+    ).lower()
+
+
+def test_network_failure_hint_explains_offline_fallback():
+    hint = _hint_for("Network failure (ConnectionError)")
+    assert "no internet" in hint.lower()
+    assert "logged locally" in hint
+
+
+def test_timeout_hint_explains_offline_fallback():
+    assert "logged locally" in _hint_for("Network failure (Timeout)")
+
+
+def test_unknown_failure_lists_general_causes():
+    hint = _hint_for("Slack rejected the message: some_new_error_code")
+    assert "Possible causes" in hint
+
+
+# ---------------------------------------------------------------------------
+# Timestamp parsing
+# ---------------------------------------------------------------------------
+
+def test_timestamp_is_trimmed_to_hh_mm_ss():
+    _, message = format_status(
+        {"ok": True, "detail": "ok",
+         "timestamp": "2026-05-22T14:03:12.987654"}
+    )
+    assert "14:03:12" in message
+    assert "987654" not in message
+
+
+def test_missing_timestamp_says_unknown():
+    _, message = format_status({"ok": True, "detail": "ok"})
+    assert "unknown" in message
+
+
+def test_malformed_timestamp_falls_back_to_raw_value():
+    _, message = format_status(
+        {"ok": True, "detail": "ok", "timestamp": "not-an-iso-timestamp"}
+    )
+    assert "not-an-iso-timestamp" in message

--- a/Project/tests/unit/test_updates_tab_failure_dialog.py
+++ b/Project/tests/unit/test_updates_tab_failure_dialog.py
@@ -1,0 +1,40 @@
+"""Tests for the Phase 3 update-failure classifier.
+
+The classifier picks the dialog title/icon shown by ``UpdatesTab`` when
+an apply fails. It is intentionally Qt-free; the ``UpdatesTab`` widget
+maps the returned code to a ``QMessageBox`` constant at render time.
+"""
+
+from __future__ import annotations
+
+from utils.update_failure import INTERNET, VERIFY, GENERIC, classify_failure
+
+
+def test_no_internet_message_is_classified_as_internet():
+    assert classify_failure(
+        "Could not download the update (download failed: "
+        "ConnectionError(...)). Updates require an internet connection."
+    ) == INTERNET
+
+
+def test_checksum_unreachable_message_is_classified_as_verify():
+    assert classify_failure(
+        "Could not verify the update — the checksum file is unreachable."
+    ) == VERIFY
+
+
+def test_checksum_mismatch_message_is_classified_as_verify():
+    assert classify_failure(
+        "Download verification failed (checksum mismatch)."
+    ) == VERIFY
+
+
+def test_busy_schedule_message_is_classified_as_generic():
+    assert classify_failure(
+        "A delivery schedule is running. Stop it before installing an update."
+    ) == GENERIC
+
+
+def test_empty_message_is_classified_as_generic():
+    assert classify_failure("") == GENERIC
+    assert classify_failure(None) == GENERIC

--- a/Project/ui/SettingsTab.py
+++ b/Project/ui/SettingsTab.py
@@ -4,7 +4,7 @@ from PyQt5.QtWidgets import (
     QMessageBox, QSpinBox, QDoubleSpinBox, QCheckBox,
     QFileDialog, QGridLayout, QComboBox, QHBoxLayout, QTextEdit, QTableWidget, QTableWidgetItem, QDialog
 )
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import Qt, QTimer, pyqtSignal
 from ui.widgets.safe_spinbox import SafeSpinBox, SafeDoubleSpinBox
 import json
 import os
@@ -21,15 +21,16 @@ from PyQt5.QtWidgets import QApplication
 class SettingsTab(QWidget):
     settings_updated = pyqtSignal(dict)
     
-    def __init__(self, system_controller, suggest_callback=None, 
-                 push_callback=None, save_slack_callback=None, 
+    def __init__(self, system_controller, suggest_callback=None,
+                 push_callback=None, save_slack_callback=None,
                  run_stop_section=None, login_system=None,
-                 print_to_terminal=None, database_handler=None):
+                 print_to_terminal=None, database_handler=None,
+                 notification_handler=None):
         super().__init__()
-        
+
         if not system_controller:
             raise ValueError("system_controller is required")
-        
+
         self.system_controller = system_controller
         self.settings = system_controller.settings
         self.suggest_callback = suggest_callback
@@ -38,6 +39,8 @@ class SettingsTab(QWidget):
         self.run_stop_section = run_stop_section
         self.login_system = login_system
         self.print_to_terminal = print_to_terminal or (lambda x: None)
+        # Drives the Slack Integration indicator (Phase 3 offline-resilience).
+        self.notification_handler = notification_handler
         
         # Get database handler from system controller if not provided
         self.database_handler = database_handler or system_controller.database_handler
@@ -1094,19 +1097,63 @@ class SettingsTab(QWidget):
         slack_layout = QFormLayout()
         slack_layout.setContentsMargins(12, 12, 12, 12)
         slack_layout.setSpacing(8)
-        
+
         self.slack_token = QLineEdit()
         self.slack_token.setText(self._decrypt_sensitive_data(
             self.settings.get('slack_token', '')))
         self.slack_token.setEchoMode(QLineEdit.Password)
         slack_layout.addRow("Slack Bot Token:", self.slack_token)
-        
+
         self.slack_channel = QLineEdit()
         self.slack_channel.setText(self.settings.get('channel_id', ''))
         slack_layout.addRow("Channel ID:", self.slack_channel)
-        
+
+        # Phase 3 offline-resilience: status indicator + troubleshooting.
+        # The label is refreshed every 5 s by self._slack_status_timer
+        # (started below) reading NotificationHandler.last_status.
+        self.slack_status_label = QLabel()
+        self.slack_status_label.setWordWrap(True)
+        self.slack_status_label.setMinimumHeight(48)
+        self.slack_status_label.setTextInteractionFlags(
+            Qt.TextSelectableByMouse
+        )
+        slack_layout.addRow("Status:", self.slack_status_label)
+        self._refresh_slack_status()
+
+        # Re-render once a second so the indicator catches up shortly after
+        # the relay worker calls send_slack_notification(). Cheap — the
+        # formatter is pure-Python and reads one attribute.
+        self._slack_status_timer = QTimer(self)
+        self._slack_status_timer.timeout.connect(self._refresh_slack_status)
+        self._slack_status_timer.start(1000)
+
         slack_group.setLayout(slack_layout)
         return slack_group
+
+    def _refresh_slack_status(self):
+        """Render the Slack indicator from NotificationHandler.last_status."""
+        # Imported lazily so a missing utils.slack_status (e.g. on a partial
+        # checkout) cannot stop the settings tab from opening.
+        try:
+            from utils.slack_status import format_status
+        except Exception:
+            return
+
+        handler = getattr(self, "notification_handler", None)
+        status = getattr(handler, "last_status", None) if handler else None
+        icon, message = format_status(status)
+
+        glyph = {"ok": "✓", "warn": "⚠", "unknown": "•"}.get(
+            icon, "•"
+        )
+        # Conservative palette — readable on both light and dark themes.
+        color = {"ok": "#0a7d28", "warn": "#9c4a00", "unknown": "#666666"}.get(
+            icon, "#666666"
+        )
+        self.slack_status_label.setText(f"{glyph}  {message}")
+        self.slack_status_label.setStyleSheet(
+            f"color: {color}; padding: 6px; border-radius: 4px;"
+        )
 
     def _create_backup_restore(self):
         backup_group = QGroupBox("Backup and Restore")

--- a/Project/ui/UpdatesTab.py
+++ b/Project/ui/UpdatesTab.py
@@ -158,7 +158,28 @@ class UpdatesTab(QWidget):
             self.update_button.setVisible(False)
             self._offer_restart(message)
         else:
-            QMessageBox.warning(self, "Update not installed", message)
+            title, icon = self._title_and_icon_for_failure(message)
+            box = QMessageBox(icon, title, message, parent=self)
+            box.exec_()
+
+    @staticmethod
+    def _title_and_icon_for_failure(message):
+        """Pick a dialog title and icon for an apply-failure message.
+
+        Phase 3 of the offline-resilience plan: a non-technical operator
+        seeing "Update not installed" alongside a download error is
+        confusing — the failure title now states the cause. The
+        classification itself lives in :mod:`utils.update_failure` so it
+        can be unit-tested without bringing up the GUI stack.
+        """
+        from utils.update_failure import classify_failure, INTERNET, VERIFY
+
+        category = classify_failure(message)
+        if category == INTERNET:
+            return "Update needs internet", QMessageBox.Information
+        if category == VERIFY:
+            return "Update could not be verified", QMessageBox.Warning
+        return "Update not installed", QMessageBox.Warning
 
     # --- revert ------------------------------------------------------------
     def _on_revert(self):

--- a/Project/ui/gui.py
+++ b/Project/ui/gui.py
@@ -147,7 +147,8 @@ class RodentRefreshmentGUI(QWidget):
             run_stop_section=self.run_stop_section,
             login_system=self.login_system,
             print_to_terminal=self.print_to_terminal,
-            database_handler=self.database_handler
+            database_handler=self.database_handler,
+            notification_handler=self.notification_handler,
         )
         
         # Profile Tab

--- a/Project/utils/slack_status.py
+++ b/Project/utils/slack_status.py
@@ -1,0 +1,109 @@
+"""Format ``NotificationHandler.last_status`` into a user-facing message.
+
+Powers the **Settings → General → Slack Integration** indicator added in
+Phase 3 of the offline-resilience plan. Kept as pure functions so the
+copy and the failure-to-hint mapping are unit-testable without bringing
+up Qt.
+
+The input is the ``last_status`` recorder from
+``notifications.notifications.NotificationHandler`` (Phase 2):
+
+    None                                          # before any send attempt
+    {"ok": True,  "detail": "ok",            "timestamp": "2026-05-22T14:03:12"}
+    {"ok": False, "detail": "Slack rejected the message: token_revoked",
+                                              "timestamp": "..."}
+    {"ok": False, "detail": "Network failure (ConnectionError)",
+                                              "timestamp": "..."}
+
+:func:`format_status` returns ``(icon, message)``; the GUI maps ``icon``
+to its own glyph/colour.
+"""
+
+from __future__ import annotations
+
+# Public icon vocabulary — kept short on purpose so the GUI's mapping
+# (glyph, colour) is the single render-side decision.
+_OK = "ok"
+_WARN = "warn"
+_UNKNOWN = "unknown"
+
+
+def format_status(last_status: dict | None) -> tuple[str, str]:
+    """Return ``(icon, message)`` for ``last_status``.
+
+    ``icon`` is one of ``"ok"`` / ``"warn"`` / ``"unknown"``. ``message``
+    is operator-readable and, on failure, includes actionable
+    troubleshooting steps.
+    """
+    if last_status is None:
+        return _UNKNOWN, (
+            "Status unknown — no message has been sent yet. The status "
+            "appears here after the first delivery notification or program "
+            "error."
+        )
+
+    when = _short_time(last_status.get("timestamp"))
+    if last_status.get("ok"):
+        return _OK, f"Delivered at {when}."
+
+    detail = (last_status.get("detail") or "").strip()
+    hint = _troubleshooting(detail)
+    return _WARN, f"Failed at {when}: {detail}\n{hint}"
+
+
+def _short_time(iso: str | None) -> str:
+    """Return the time portion of an ISO timestamp, or ``"unknown"``."""
+    if not iso:
+        return "unknown"
+    try:
+        # ISO 8601: YYYY-MM-DDTHH:MM:SS[.ffffff] — trim subseconds.
+        return iso.split("T", 1)[1].split(".", 1)[0]
+    except Exception:
+        return iso
+
+
+def _troubleshooting(detail: str) -> str:
+    """Map a failure detail to operator-actionable instructions."""
+    low = detail.lower()
+
+    if any(code in low for code in ("token_revoked", "invalid_auth",
+                                     "not_authed", "account_inactive")):
+        return (
+            "Slack rejected the bot token. Re-create the Slack app/bot, "
+            "paste a fresh token above, and click Save."
+        )
+
+    if any(code in low for code in ("channel_not_found", "is_archived",
+                                     "not_in_channel")):
+        return (
+            "The channel ID does not exist, the channel is archived, or "
+            "the bot is not a member. Check the Channel ID above and that "
+            "the bot has been invited to that channel."
+        )
+
+    if "missing_scope" in low:
+        return (
+            "The bot is missing the chat:write scope. Update the Slack "
+            "app's OAuth scopes, then reinstall it to your workspace."
+        )
+
+    if "ratelimited" in low or "rate_limited" in low:
+        return (
+            "Slack is rate-limiting this bot. Notifications resume "
+            "automatically; the delivery has been logged locally."
+        )
+
+    if any(word in low for word in ("network", "connection", "timeout",
+                                     "dns", "unreachable")):
+        return (
+            "Could not reach Slack — this device has no internet, or the "
+            "Slack service is unreachable. Notifications resume "
+            "automatically when the network is back; deliveries are logged "
+            "locally in the meantime."
+        )
+
+    return (
+        "Possible causes: revoked token, deleted or renamed channel, "
+        "missing bot scope, or no internet. Check the values above and "
+        "this device's network."
+    )

--- a/Project/utils/update_failure.py
+++ b/Project/utils/update_failure.py
@@ -1,0 +1,31 @@
+"""Classify an update-apply failure message into a UI category.
+
+Phase 3 of the offline-resilience plan. The classifier is intentionally
+free of Qt imports so it can be unit-tested without the GUI stack; the
+``UpdatesTab`` widget maps the returned code to a ``QMessageBox`` title
+and icon at render time.
+"""
+
+from __future__ import annotations
+
+# Category codes — the GUI's single render-side decision is mapping these
+# to a (title, icon) pair. The stable set keeps the contract small.
+INTERNET = "internet"     # bundle could not be downloaded
+VERIFY = "verify"         # checksum unfetchable or mismatched
+GENERIC = "generic"       # everything else (busy schedule, disk full, ...)
+
+
+def classify_failure(message: str | None) -> str:
+    """Return one of ``INTERNET`` / ``VERIFY`` / ``GENERIC`` for ``message``.
+
+    Driven by the failure-message vocabulary that ``utils.updater.apply_update``
+    emits (Phase 2): "Could not download the update (...) Updates require an
+    internet connection ..." → ``INTERNET``; anything with "verif"/"checksum"
+    → ``VERIFY``; otherwise ``GENERIC``.
+    """
+    low = (message or "").lower()
+    if "internet" in low or "could not download" in low:
+        return INTERNET
+    if "verify" in low or "checksum" in low:
+        return VERIFY
+    return GENERIC

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"


### PR DESCRIPTION
…se 3, v1.6.1)

Phase 3 of the offline-resilience plan — the UX polish phase. Three small, focused changes; no production behaviour outside the GUI changes.

NEW — Project/utils/slack_status.py
  Pure formatter for NotificationHandler.last_status (added in Phase 2).
  Returns (icon, message) with operator-readable troubleshooting per known
  Slack error code: token_revoked / invalid_auth / not_authed -> "re-create
  the bot, paste a fresh token"; channel_not_found / is_archived -> "check
  the Channel ID, invite the bot"; missing_scope -> "add chat:write";
  rate_limited -> "resumes automatically"; network/connection/timeout ->
  "no internet — deliveries logged locally". Qt-free for unit testing.

NEW — Project/utils/update_failure.py
  Pure classifier for apply-failure messages: INTERNET / VERIFY / GENERIC.
  UpdatesTab maps the code to a QMessageBox title + icon at render time;
  splitting the logic from Qt keeps the test for it Qt-free too.

SETTINGS — Project/ui/SettingsTab.py
  Slack Integration group gets a Status row driven by the new formatter.
  A 1 s QTimer re-renders it so the indicator catches up with the relay
  worker shortly after each notification. New notification_handler kwarg;
  plumbed through gui.py and main.py (both SettingsTab instantiation sites).

UPDATES — Project/ui/UpdatesTab.py
  _on_apply_done now picks a dialog title that names the cause:
   * "Update needs internet"  (Information icon) for a download failure
   * "Update could not be verified" (Warning)  for a checksum failure
   * "Update not installed" (Warning) for anything else (busy schedule, ...) Non-technical operators stop seeing a single ambiguous "Update not installed" title for every failure.

TESTS — 20 new
  * test_slack_status.py     — 14 tests covering icon classification,
                                hint-per-error-code mapping, ISO timestamp
                                trimming
  * test_updates_tab_failure_dialog.py — 6 tests for the classifier;
                                stays Qt-free thanks to update_failure.py

Pi benchmark — Raspberry Pi 5 (aarch64), Bookworm, Python 3.11.2, apt PyQt5 5.15, full installer baseline of main + this overlay:
  * pytest:       91 passed in 5.56s  (baseline at v1.6.0: 70 passed)
  * --selftest:   "rrr selftest: OK"
  * format_status, classify_failure, updater offline path, SettingsTab
    construction with notification_handler, indicator transitions
    unknown -> ok -> warn: all correct

Bumps Project/version.py to 1.6.1.