### PR TITLE
chore(audit): Phase 0 cleanup baseline (v1.6.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,23 +17,112 @@ and `bootstrap.sh`.
 - Local release dry-run: `bash scripts/release/build-bundle.sh` → inspect
   `dist/rrr-<version>.rrrupdate`.
 
+## Process gate — before every commit
+
+Run this checklist mentally on every change. If any answer is "no", stop.
+
+1. Am I on a branch off `main` (not `main` itself)?
+2. Does the branch name follow `<type>/<short-kebab-slug>`?
+3. Did I run `pytest` and confirm green (or that my new test passes / skips
+   as designed) before staging?
+4. Are the staged files only the files this PR is about — no `.DS_Store`,
+   no `secrets.json`, no `*.db`, no `settings/settings.json`?
+5. If this change affects runtime behavior on a device, did I bump
+   `Project/version.py` per the SemVer table in
+   [MAINTENANCE.md §2](Project/docs/MAINTENANCE.md#2-picking-the-version-number--semver-for-rrr)?
+6. Is the commit message Conventional Commits format
+   (`<type>(<scope>): <one-liner>`)?
+7. Am I leaving `Co-Authored-By: Claude` and "🤖 Generated with Claude Code"
+   out of the commit message and PR body?
+
 ## Hard rules (gotchas — read before acting)
 
-- **Version source of truth is `Project/version.py`.** Nothing else stores it.
-  The git tag MUST equal `v<__version__>` exactly (e.g. `v1.2.0`,
-  `v1.2.0-beta` for pre-release). CI fails the build on mismatch.
-- **Pull `main` before tagging.** `git tag` is silent about which commit it
-  marks; if local `main` is stale, you'll tag the wrong commit and CI rejects
-  it. Always `git checkout main && git pull --ff-only origin main` first.
-- **`git push origin <tag>` is the point of no return** — it publishes a real
-  GitHub Release. `git tag` alone is local and reversible.
-- **Never ship updates via `git pull`.** Tagged GitHub Releases are the only
-  supported channel; CI owns `dist/` and release assets — do not hand-edit or
-  upload manually.
-- **Never commit device data.** The SQLite DB and `settings/settings.json` are
-  excluded from git and from release bundles; keep it that way.
+### Branching, committing, reviewing
 
-Full release procedure (version bump → tag → CI workflow) and recovery for a
-mis-tagged commit: see [Project/docs/UPDATE_SYSTEM.md](Project/docs/UPDATE_SYSTEM.md)
-and the operator-facing recipe in [Project/docs/MAINTENANCE.md](Project/docs/MAINTENANCE.md).
-Hardware bring-up procedure for a new device: [Project/docs/HARDWARE_SETUP.md](Project/docs/HARDWARE_SETUP.md).
+- **Never commit directly to `main`.** Always branch off `main` with
+  `<type>/<short-kebab-slug>` (`feat/`, `fix/`, `refactor/`, `test/`,
+  `docs/`, `chore/`, `style/`, `perf/`, `ci/` — see
+  [MAINTENANCE.md §7](Project/docs/MAINTENANCE.md#7-branch--commit-conventions)),
+  push the branch, open a PR, merge through GitHub. Applies to **every**
+  change — code, tests, docs, tooling, gitignore tweaks.
+- **One concern per PR.** If the diff spans unrelated topics, split it.
+- **Conventional Commits.** `<type>(<scope>): <one-line subject>`; body
+  explains *why*, not *what*. For release-bound work, mention the target
+  version in the subject (`feat(offline): … (Phase 3, v1.6.1)`).
+- **No AI attribution in git.** Never add `Co-Authored-By: Claude` /
+  `Co-Authored-By: Anthropic` trailers; never add "🤖 Generated with
+  Claude Code" lines to commit messages or PR bodies.
+- **Never amend a pushed commit and never force-push to `main`.** If a
+  pre-commit hook rejects a commit, **fix the issue and create a NEW
+  commit** — do not `--amend` (the original commit didn't happen, so
+  amend modifies the previous commit and can destroy work).
+- **Pull `main` before branching or tagging.** `git checkout main &&
+  git pull --ff-only origin main` first. `git tag` is silent about which
+  commit it marks; on a stale `main` you'll tag the wrong commit and CI
+  will reject it (see [MAINTENANCE.md §6.2](Project/docs/MAINTENANCE.md#62-you-pushed-a-bad-tag-no-release-exists-yet-ci-rejected-it)).
+
+### Versioning (`Project/version.py`) and releases
+
+- **Version source of truth is `Project/version.py`.** Nothing else
+  stores it. The git tag MUST equal `v<__version__>` exactly (`v1.2.0`,
+  `v1.2.0-beta` for pre-release). CI fails the build on mismatch.
+- **Bump `Project/version.py` for every release-bound change**, using the
+  SemVer table in [MAINTENANCE.md §2](Project/docs/MAINTENANCE.md#2-picking-the-version-number--semver-for-rrr):
+  - PATCH — bug fix, dep security pin, anything user-invisible
+  - MINOR — new feature, new sub-tab, new driver opt-in
+  - MAJOR — breaking change, schema migration, GPIO/hardware change
+  - In doubt → bump the higher level.
+  - **If the user explicitly lists "bump version" in their instructions
+    for this PR, do it — do not skip citing §3c.** The explicit
+    instruction overrides the test/doc-only exemption.
+- **Test-only / doc-only PRs default to no version bump and no tag**
+  per [MAINTENANCE.md §1](Project/docs/MAINTENANCE.md#1-when-to-release-and-when-not-to)
+  / §3c — unless the user instructs otherwise (see above).
+- **Pre-release tags use `-beta`** (`v1.7.0-beta`, `-beta.2`). CI flags
+  them as pre-release; the in-app updater ignores them unless the
+  device opts into the beta channel.
+- **`git push origin <tag>` is the point of no return** — it publishes a
+  real GitHub Release. `git tag` alone is local and reversible. Pause
+  before that command.
+- **Never ship updates via `git pull`.** Tagged GitHub Releases are the
+  only supported channel; CI owns `dist/` and release assets — do not
+  hand-edit `dist/` or upload assets manually (rule H5).
+- **Never commit device data.** The SQLite DB, `settings/settings.json`,
+  and `secrets.json` are excluded from git and from release bundles
+  (`.gitignore` + `build-bundle.sh` enforce this); keep it that way.
+
+### Editing code — test before you ship
+
+- **Never edit code without testing it.** "Tested" means at minimum:
+  - `pytest` runs green locally (or the new test you added does), AND
+  - for UI/runtime changes touching anything beyond a doc, the change
+    has been exercised — at least a headless smoke (`QT_QPA_PLATFORM=
+    offscreen`) and ideally a real Pi for hardware-adjacent paths.
+  Static checks don't validate feature correctness. If a UI change
+  can't be exercised in your environment, **say so explicitly** in the
+  PR description rather than claiming success.
+- **Add a test alongside any non-trivial code change.** A regression
+  that ships and breaks a device costs more than a 5-minute unit test.
+- **Never disable, skip, or weaken an existing test to make a PR pass.**
+  Either fix the production code, or write a focused replacement test
+  and explain in the PR description why the old one was wrong.
+- **Hooks are not optional.** Never use `--no-verify`, `--no-gpg-sign`,
+  or `-c commit.gpgsign=false` unless explicitly asked. If a pre-commit
+  hook fails, investigate the underlying issue; do not bypass.
+
+### Files and paths to never touch casually
+
+| Path | Why |
+|---|---|
+| `Project/settings/settings.json`, `*.db`, `secrets.json` | Operator data + Slack credentials; leak risk |
+| `dist/` | CI owns it — never hand-edit or upload (rule H5) |
+| Anything under `~/rrr/` on a device | Live deployment surface; touched only by the launcher and update applier |
+| `.github/workflows/*.yml` | Changes here affect every release downstream |
+| `Project/version.py` | Only edit as part of a deliberate version bump |
+
+Full release procedure (version bump → tag → CI workflow), recovery for
+a mis-tagged commit, and the SemVer decision tables: see
+[Project/docs/MAINTENANCE.md](Project/docs/MAINTENANCE.md) (operator-friendly
+recipe book) and [Project/docs/UPDATE_SYSTEM.md](Project/docs/UPDATE_SYSTEM.md)
+(full design). Hardware bring-up for a new device:
+[Project/docs/HARDWARE_SETUP.md](Project/docs/HARDWARE_SETUP.md).

--- a/Project/tests/unit/test_gui_smoke.py
+++ b/Project/tests/unit/test_gui_smoke.py
@@ -1,0 +1,111 @@
+"""Headless smoke tests for the PyQt5 UI tree.
+
+Phase 0 of the stale-code cleanup. Constructs the widgets that the
+forthcoming Tier-0/Tier-1 removals touch, so any regression that drops a
+still-referenced symbol breaks CI immediately. Runs offscreen via
+``QT_QPA_PLATFORM=offscreen``; no display server required.
+
+Coverage:
+
+* every module under ``Project/ui/`` imports cleanly (catches broken
+  intra-package imports and dangling references to removed files),
+* ``ui.__init__`` re-exports every name in its ``__all__``,
+* ``ProjectsSection`` constructs and exposes the four live tabs —
+  ``SchedulesHub``, ``AnimalsTab``, ``WizardTab``, ``CagesVisualizationTab`` —
+  via the attribute names that callers (``main.py``, ``SettingsTab``) use.
+
+The test skips when PyQt5 is not importable so the suite still passes on a
+developer machine without the system Qt bindings. CI installs
+``python3-pyqt5`` from apt, so the test always runs there.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import pkgutil
+from pathlib import Path
+
+import pytest
+
+# Skip the whole module when PyQt5 is unavailable (e.g. a dev laptop without
+# the system bindings). The conftest fixtures import models lazily, so this
+# guard does not affect any other test in the suite.
+pytest.importorskip("PyQt5")
+
+# Headless Qt: must be set before QApplication is constructed.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    """Module-scoped QApplication so widgets can construct.
+
+    Qt requires exactly one ``QApplication`` per process. Reusing one across
+    tests is faster and matches how the real app runs.
+    """
+    from PyQt5.QtWidgets import QApplication  # noqa: PLC0415
+
+    app = QApplication.instance() or QApplication([])
+    yield app
+    # No teardown: tearing the QApplication down mid-suite breaks any later
+    # widget test in the same process.
+
+
+def _ui_module_names() -> list[str]:
+    """Return every importable module name under ``ui`` (top-level only)."""
+    ui_dir = Path(__file__).resolve().parents[2] / "ui"
+    names: list[str] = []
+    for entry in pkgutil.iter_modules([str(ui_dir)]):
+        # Skip subpackages (components/, widgets/, style/) — they are
+        # imported transitively by the modules that depend on them, so
+        # walking only the top-level catches the same regressions without
+        # importing unrelated nested packages.
+        if entry.ispkg:
+            continue
+        names.append(f"ui.{entry.name}")
+    return names
+
+
+def test_ui_package_imports_cleanly(qapp):
+    """``import ui`` runs every re-export in ``ui/__init__.py``."""
+    ui = importlib.import_module("ui")
+    # Every name listed in ``__all__`` must resolve. Catches the case where
+    # ``__init__.py`` re-exports a class that has been deleted.
+    for name in getattr(ui, "__all__", []):
+        assert hasattr(ui, name), f"ui.__all__ lists {name!r} but it is missing"
+
+
+@pytest.mark.parametrize("modname", _ui_module_names())
+def test_ui_module_imports(qapp, modname):
+    """Every top-level ``ui.*`` module imports without error."""
+    importlib.import_module(modname)
+
+
+def test_projects_section_constructs(qapp, database_handler):
+    """``ProjectsSection`` builds and exposes the four live tabs.
+
+    Pins the contract main.py and SettingsTab rely on: ``schedules_tab``
+    must be a ``SchedulesHub`` (not the legacy ``SchedulesTab``),
+    ``animals_tab`` an ``AnimalsTab``, ``wizard_tab`` a ``WizardTab``,
+    ``cages_tab`` a ``CagesVisualizationTab``.
+    """
+    from models.login_system import LoginSystem  # noqa: PLC0415
+    from ui.animals_tab import AnimalsTab  # noqa: PLC0415
+    from ui.cages_visualization_tab import CagesVisualizationTab  # noqa: PLC0415
+    from ui.projects_section import ProjectsSection  # noqa: PLC0415
+    from ui.schedules_hub import SchedulesHub  # noqa: PLC0415
+    from ui.wizard_tab import WizardTab  # noqa: PLC0415
+
+    login_system = LoginSystem(database_handler)
+    section = ProjectsSection(
+        settings={},
+        print_to_terminal=lambda _msg: None,
+        database_handler=database_handler,
+        login_system=login_system,
+    )
+
+    assert isinstance(section.schedules_tab, SchedulesHub)
+    assert isinstance(section.animals_tab, AnimalsTab)
+    assert isinstance(section.wizard_tab, WizardTab)
+    assert isinstance(section.cages_tab, CagesVisualizationTab)

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.6.1"
+__version__ = "1.6.2"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,5 @@
 #   ~/rrr/shared/venv/bin/python3 -m pytest
 
 pytest>=7.0
+# Phase-0 dead-code audit baseline; not used at runtime.
+vulture>=2.11


### PR DESCRIPTION
Adds a headless PyQt5 smoke test under Project/tests/unit/ that constructs the live UI tree (ProjectsSection + SchedulesHub / AnimalsTab / WizardTab / CagesVisualizationTab) and asserts every name in ui.__init__.__all__ resolves. Pins the contract that main.py and SettingsTab depend on, so the upcoming Tier-0/Tier-1 dead-code removals break CI immediately if they drop a still-referenced symbol.

Skips on dev machines without PyQt5 via pytest.importorskip; runs in CI because tests.yml apt-installs python3-pyqt5.

Adds vulture>=2.11 to requirements-dev.txt so the audit baseline is reproducible (dev-only — never shipped to devices).

Expands CLAUDE.md with the full process gate: branch off main, no AI attribution in git, conventional commits, never amend pushed commits, explicit version-bump rules, never-edit-without-testing, and the list of paths to never touch casually. The previous version of CLAUDE.md left most of these implicit; making them explicit so they survive across sessions.

PATCH bump per MAINTENANCE.md §2 — no operator-visible behavior change, but per the user's release-flow instruction every PR on this branch bumps the version (explicit override of §3c).