### PR TITLE
ci(tests): install python3-pandas via apt to mirror Pi (v1.6.3)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install system PyQt5 (mirrors --system-site-packages on the Pi)
+      - name: Install apt-provided Python deps (mirrors --system-site-packages on the Pi)
         run: |
+          # Same packages the Pi installer pulls via apt and exposes through
+          # --system-site-packages. Keeping CI on apt (not pip) matches the
+          # device install path, so "works in CI, broken on Pi" can't happen
+          # via a pandas/numpy/PyQt5 ABI skew. python3-numpy is a transitive
+          # dep of python3-pandas, so apt resolves it automatically.
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends python3-pyqt5
+          sudo apt-get install -y --no-install-recommends python3-pyqt5 python3-pandas
 
       - name: Install pinned Python deps + dev deps
         run: |

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"


### PR DESCRIPTION
PR #62's smoke test parametrizes an import over every ui/*.py module. That transitively pulls SettingsTab.py:14 → `import pandas as pd`, which fails on the GitHub Actions runner because pandas wasn't in the test environment.

Fix mirrors the design already documented in requirements.txt: PyQt5/pandas/numpy/RPi.GPIO/gpiozero come from apt on the Pi and are deliberately not pinned in requirements.txt to avoid pip clobbering the apt builds. CI follows the same pattern by apt-installing the matching packages. python3-numpy is pulled in as a transitive dep of python3-pandas, so apt resolves it automatically.

Bumped to 1.6.3 even though this is CI-only per the explicit release-flow rule now in CLAUDE.md.