### PR TITLE
chore(skills): add .claude/skills for AI-assistant context (v1.6.5)

### DIFF
--- a/.claude/skills/device-installer/SKILL.md
+++ b/.claude/skills/device-installer/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: device-installer
+description: Install or repair RRR on a Raspberry Pi OS Bookworm device — the modular bash installer in scripts/install/[0-9][0-9]-*.sh, the bootstrap.sh one-liner entry, blue-green layout under ~/rrr, and the systemd --user launcher. Use when the user reports "install failed", asks how to add or modify an install step, debugs an apt/udev/I²C-enable problem, or needs to re-run one stage. Covers `--dry-run`, `--only`, `--skip`, and the reboot-handling logic.
+---
+
+# Device installer
+
+The installer is **modular bash**, not a Python script. Entry points:
+
+- [`bootstrap.sh`](bootstrap.sh) — one-line curl install (clones the repo,
+  then execs `install.sh`).
+- [`install.sh`](install.sh) — runs every `scripts/install/[0-9][0-9]-*.sh`
+  module in order.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Corticomics/rodRefReg/main/bootstrap.sh | bash
+```
+
+## The eight modules (in order)
+
+| # | File | Owns |
+|---|---|---|
+| 00 | [`00-preflight.sh`](scripts/install/00-preflight.sh) | OS = Bookworm check, arch, disk space, network |
+| 10 | [`10-apt.sh`](scripts/install/10-apt.sh) | `apt install` PyQt5, pandas, numpy, RPi.GPIO, etc. |
+| 20 | [`20-repo.sh`](scripts/install/20-repo.sh) | Sync the checkout to the requested branch (never auto-stashes) |
+| 25 | [`25-layout.sh`](scripts/install/25-layout.sh) | Build the blue-green tree under `~/rrr/` |
+| 30 | [`30-python.sh`](scripts/install/30-python.sh) | `venv --system-site-packages` + `pip install -r requirements.txt` |
+| 40 | [`40-hardware.sh`](scripts/install/40-hardware.sh) | Enable I²C, install SM16relind driver, install udev rule for `/dev/teensy_flow` |
+| 50 | [`50-services.sh`](scripts/install/50-services.sh) | Launcher at `~/.local/bin/rrr`, desktop entry, optional systemd `--user` unit |
+| 60 | [`60-verify.sh`](scripts/install/60-verify.sh) | Smoke-test imports + `16relind 0 board`; warnings only, never fatal |
+
+One-liner per module: [`references/module-cheatsheet.md`](references/module-cheatsheet.md).
+
+## Flags every operator should know
+
+```bash
+./install.sh --dry-run              # print every action, change nothing
+./install.sh -y / --yes             # non-interactive (no prompts)
+./install.sh --only 40-hardware     # run a single module
+./install.sh --skip 50-services     # skip a stage; repeatable
+./install.sh --branch dev           # install from a non-main branch
+```
+
+Module discovery is in `install.sh`:
+```bash
+mapfile -t MODULES < <(find "$MODULE_DIR" -maxdepth 1 -type f -name '[0-9][0-9]-*.sh' | sort)
+```
+
+Names not matching `[0-9][0-9]-*.sh` are silently ignored — useful for
+helper libs (`lib.sh`, `ui.sh`, `ui.theme.sh`, `layout.sh`) that get
+sourced but aren't standalone stages.
+
+## Blue-green layout
+
+After 25-layout, the device has:
+
+```
+~/rrr/
+├── current   → releases/v1.6.4       (symlink)
+├── previous  → releases/v1.6.3       (symlink)
+├── releases/
+│   ├── v1.6.4/   (Project/ + scripts/)
+│   └── v1.6.3/
+├── shared/
+│   ├── venv/     (one venv across all releases)
+│   ├── data/     (DB + settings.json + secrets.json + logs)
+│   └── logs/
+└── state/
+    └── boot.json   (release name + fail_count)
+```
+
+[`scripts/runtime/launch.sh`](scripts/runtime/launch.sh) reads `boot.json`,
+increments `fail_count` on each launch, and rolls `current` back to
+`previous` when `fail_count >= 2`. The app resets the counter to 0 once
+it starts cleanly.
+
+Details: [`references/blue-green-layout.md`](references/blue-green-layout.md).
+
+## Reboot policy
+
+Modules can flag a reboot as needed by setting `_RRR_REBOOT_REQUIRED=1`
+and pushing a reason into `_RRR_REBOOT_REASONS`. The installer summary
+prints the reasons and (in interactive mode) asks whether to reboot
+immediately. Under `-y` or in a piped-from-curl session, it never
+auto-reboots — it just prints the recommendation.
+
+Typical reasons: changing `consoleblank=0`, enabling I²C via
+`raspi-config` (the device node `/dev/i2c-1` is available without reboot
+in most cases, but group membership in `i2c` only takes effect after the
+user logs out and back in).
+
+## Logs
+
+Every run writes to `~/.local/state/rrr/install-<timestamp>.log`. Find
+the latest:
+
+```bash
+ls -t ~/.local/state/rrr/install-*.log | head -1
+```
+
+The installer mirrors stdout+stderr through `tee`; in "rich" UI mode
+(`_UI_MODE=rich`) the terminal output is styled and the log file is
+stripped of ANSI escapes.
+
+## When something fails
+
+- A non-zero exit kills `install.sh` (set `-Eeuo pipefail` at top).
+- An `EXIT` trap prints the per-module summary so you always know where
+  it died.
+- Re-run with `--only <module>` to retry just the failed stage; modules
+  are idempotent by design (apt is `--no-install-recommends`, layout.sh
+  doesn't clobber existing data, etc.).
+
+## Don't do this
+
+- Don't shell out to `sudo apt install` from a Python module at runtime.
+  All apt installs live in `10-apt.sh`. The Pi installs system packages;
+  the venv uses `--system-site-packages` to expose them. See the
+  comment in [`requirements.txt`](requirements.txt#L3-L5).
+- Don't add `set +e` to a module unless you've also added explicit
+  error handling. The strict-mode flags from `install.sh` are
+  load-bearing.
+- Don't add a numbered module that's not in the `[0-9][0-9]-*.sh`
+  pattern. The discovery glob skips it silently and your stage will
+  never run.
+- Don't write data into the release directory (`~/rrr/current/...`).
+  That tree gets swapped on every update. Persistent data lives under
+  `~/rrr/shared/data/` and is referenced via `RRR_DATA`
+  ([`Project/utils/paths.py`](Project/utils/paths.py)).

--- a/.claude/skills/device-installer/references/blue-green-layout.md
+++ b/.claude/skills/device-installer/references/blue-green-layout.md
@@ -1,0 +1,105 @@
+# Blue-green layout
+
+RRR uses a blue-green deployment under `~/rrr/` so updates are atomic and
+rollbackable. Full design in
+[Project/docs/UPDATE_SYSTEM.md §13](Project/docs/UPDATE_SYSTEM.md).
+
+## The tree
+
+```
+~/rrr/
+├── current   → releases/v1.6.4       (symlink — the live release)
+├── previous  → releases/v1.6.3       (symlink — rollback target)
+├── releases/
+│   ├── v1.6.4/
+│   │   ├── Project/
+│   │   └── scripts/
+│   └── v1.6.3/
+├── shared/
+│   ├── venv/        (one venv across all releases)
+│   ├── data/        (DB + settings.json + secrets.json)
+│   └── logs/        (rrr_app_debug.log, etc.)
+└── state/
+    └── boot.json    ({"release": "v1.6.4", "fail_count": 0})
+```
+
+## Why this shape
+
+- **Atomic swap.** Updating means writing the new release into
+  `releases/v<new>/`, then atomically repointing the `current` symlink
+  via `ln -sfn` + `mv -T`. No half-applied state.
+- **Cheap rollback.** `previous` is just another symlink. If the new
+  release fails to boot, swap them back.
+- **Shared data and venv.** Releases are stateless app code; the venv
+  (slow to rebuild) and the data (operator-owned) live under `shared/`
+  and survive every release swap.
+
+## The launcher and the boot sentinel
+
+The stable shim `~/.local/bin/rrr` execs
+[`scripts/runtime/launch.sh`](scripts/runtime/launch.sh) inside the
+**current** release. The launcher's job:
+
+1. Read `state/boot.json` — get `release` and `fail_count`.
+2. If `fail_count >= 2` and `previous` exists → roll back by repointing
+   `current` at `previous`. Reset `fail_count = 0`. Re-exec.
+3. Otherwise → increment `fail_count`, write `boot.json`, then exec the
+   app: `~/rrr/shared/venv/bin/python3 ~/rrr/current/Project/main.py`.
+4. The app, once it has started cleanly, resets `fail_count` to 0.
+
+So a release that crashes during startup will only get two retries
+before the device falls back to the previous version. From the
+operator's point of view, the title bar reverts to the older version
+and the app keeps working — no manual intervention required.
+
+The launcher also exports the data path so the app can find it:
+
+```bash
+export RRR_HOME
+export RRR_DATA="$RRR_HOME/shared/data"
+```
+
+[`Project/utils/paths.py`](Project/utils/paths.py) reads `RRR_DATA` for
+every path (`database_path()`, `settings_path()`, `secrets_path()`, etc.)
+and falls back to legacy locations when unset — that's how a
+dev-from-clone run still works.
+
+## How an in-app update lands
+
+[`Project/utils/updater.py`](Project/utils/updater.py) does:
+
+1. Poll `latest.json` from the GitHub Release.
+2. Compare versions; if a new one exists, download the
+   `.rrrupdate` bundle (`tar.gz`) + `.sha256`.
+3. Verify checksum.
+4. Extract to `releases/v<new>/`.
+5. `pip install -r requirements.txt` *if* `requirements_hash` in the
+   bundle's `manifest.json` changed since the live release. Skipped
+   otherwise — most releases don't touch deps.
+6. Atomic symlink swap: `previous ← current ← v<new>`.
+7. Tell the app to quit; launch.sh starts the new release on next
+   invocation.
+
+If anything fails before step 6, the working release is untouched.
+
+## Files you must never touch on a device
+
+- `~/rrr/current/...` — gets overwritten on every release.
+- `~/rrr/shared/data/rrr_database.db` — the live SQLite DB. Operator data.
+- `~/rrr/shared/data/secrets.json` — Slack credentials, mode 0600.
+- `~/rrr/state/boot.json` — overwriting this can re-trigger a rollback.
+
+The installer is the only thing that should write under `~/rrr/`; the
+running app reads from `~/rrr/current/Project/` and reads/writes under
+`~/rrr/shared/data/` via `RRR_DATA`.
+
+## Recovering a stuck device
+
+The boot sentinel handles "release won't start" automatically. For other
+failure modes:
+
+| Symptom | Fix |
+|---|---|
+| Stuck on an old version, won't update | Check `~/.local/state/rrr/install-*.log` for the last installer run; re-run `./install.sh --only 25-layout` |
+| Data corrupt after a bad release | `~/rrr/shared/data/` is preserved across rollback; restore from `~/rrr/shared/data/rrr_database.db.bak-*` if available |
+| `current` symlink missing | `./install.sh` is idempotent — re-running re-creates it from the local checkout |

--- a/.claude/skills/device-installer/references/module-cheatsheet.md
+++ b/.claude/skills/device-installer/references/module-cheatsheet.md
@@ -1,0 +1,118 @@
+# Installer module cheatsheet
+
+One-line summary of each numbered module. Source-of-truth lives in
+[`scripts/install/`](scripts/install/) — read the file when the cheatsheet
+disagrees.
+
+## 00-preflight.sh
+
+[`scripts/install/00-preflight.sh`](scripts/install/00-preflight.sh) —
+sanity checks before any mutation.
+
+- OS = Raspberry Pi OS **Bookworm** (reads `/etc/os-release`).
+- Arch = `aarch64` (warn-only otherwise).
+- Free disk space.
+- Internet reachable (used by apt + git later).
+
+Failures here are fatal — the rest of the installer assumes Bookworm
+semantics (PEP 668, `/boot/firmware/config.txt`, etc.).
+
+## 10-apt.sh
+
+[`scripts/install/10-apt.sh`](scripts/install/10-apt.sh) — single source
+of truth for OS-level dependencies.
+
+- `apt install` the `APT_PACKAGES` list: git, curl, build-essential,
+  PyQt5, pandas, numpy, RPi.GPIO, gpiozero, i2c-tools, dialog, etc.
+- Uses `--no-install-recommends` to keep the install small.
+- Why apt and not pip: PEP 668 on Bookworm forbids global pip; we expose
+  apt-installed packages to the venv via `--system-site-packages` in
+  `30-python.sh`. Matches the comment in
+  [`requirements.txt`](requirements.txt#L3-L5).
+
+## 20-repo.sh
+
+[`scripts/install/20-repo.sh`](scripts/install/20-repo.sh) — sync the
+git checkout.
+
+- Refuses to touch a dirty tree (no auto-stash).
+- `--branch` flag switches branch *only* if the tree is clean.
+- No-op if the checkout is already on the requested branch and clean.
+
+## 25-layout.sh
+
+[`scripts/install/25-layout.sh`](scripts/install/25-layout.sh) — build
+the blue-green `~/rrr/` tree.
+
+- Creates `~/rrr/releases/v<__version__>/` and rsync's the working
+  checkout into it.
+- Atomically repoints `~/rrr/current` to the new release (and `previous`
+  to the prior `current`).
+- Migrates data: copies `Project/rrr_database.db` → `~/rrr/shared/data/`
+  on first install only.
+
+Idempotent — re-running for the same version is a refresh.
+
+## 30-python.sh
+
+[`scripts/install/30-python.sh`](scripts/install/30-python.sh) —
+the Python venv.
+
+- Creates `~/rrr/shared/venv` with `--system-site-packages` so PyQt5,
+  pandas, numpy, RPi.GPIO from apt are visible.
+- `pip install -r requirements.txt` for everything else (cryptography,
+  jsonschema, slack_sdk, smbus2, …).
+- venv lives under `shared/` so it survives release swaps (not
+  rebuilt per release).
+
+## 40-hardware.sh
+
+[`scripts/install/40-hardware.sh`](scripts/install/40-hardware.sh) —
+hardware enablement.
+
+- Enables I²C via `raspi-config nonint do_i2c 0` (canonical path).
+- Edits `/boot/firmware/config.txt` for `dtparam=i2c_arm=on`,
+  `consoleblank=0`.
+- Clones + makes the Sequent Microsystems 16-relay HAT driver (the
+  `16relind` CLI), Pi-4 and Pi-5 compatible.
+- Installs the udev rule that creates `/dev/teensy_flow` (stable symlink
+  for the Teensy flow-sensor bridge).
+- Adds the user to the `i2c` and `dialout` groups.
+- May flag `_RRR_REBOOT_REQUIRED=1` if `consoleblank=0` changed.
+
+## 50-services.sh
+
+[`scripts/install/50-services.sh`](scripts/install/50-services.sh) —
+launcher, menu entry, optional autostart.
+
+- Installs `~/.local/bin/rrr` shim (it execs
+  [`scripts/runtime/rrr-shim.sh`](scripts/runtime/rrr-shim.sh) →
+  [`scripts/runtime/launch.sh`](scripts/runtime/launch.sh)).
+- Drops a `.desktop` entry under `~/.local/share/applications/` so the
+  app appears in the Raspberry Pi OS menu.
+- Optionally installs a systemd `--user` unit for autostart on login.
+
+No system-level service — RRR is a GUI app, so it runs under the user
+session, not as root.
+
+## 60-verify.sh
+
+[`scripts/install/60-verify.sh`](scripts/install/60-verify.sh) —
+post-install smoke.
+
+- `python3 -c "import PyQt5"`, `import pandas`, `import RPi.GPIO`, etc.
+- Calls `16relind 0 board` and warns if the HAT isn't visible (could be
+  legitimately absent on a dev install).
+- Non-fatal — warnings only. The summary line tells the operator what
+  worked.
+
+## Helper files (not numbered, sourced)
+
+- [`scripts/install/lib.sh`](scripts/install/lib.sh) — `die`, `warn`,
+  `info`, `section`, `ui_banner`, `ui_confirm`, `boot_firmware_dir`, etc.
+- [`scripts/install/layout.sh`](scripts/install/layout.sh) — blue-green
+  path helpers used by `25-layout.sh` and `50-services.sh`.
+- [`scripts/install/ui.sh`](scripts/install/ui.sh) /
+  [`ui.theme.sh`](scripts/install/ui.theme.sh) — rich-mode TUI rendering.
+- [`scripts/install/test_install.sh`](scripts/install/test_install.sh) —
+  unit-test scaffold for the lib functions.

--- a/.claude/skills/flow-delivery-strategies/SKILL.md
+++ b/.claude/skills/flow-delivery-strategies/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: flow-delivery-strategies
+description: Understand and modify how RRR turns "deliver N mL to animal X" into actual valve/pump actions. Two strategies live behind the DeliveryStrategy Protocol — SolenoidFlowStrategy (canonical, Teensy-bridged flow sensor) and PumpStrategy (legacy time-based). Selection happens in StrategyFactory by hardware_mode. Use when wiring a new dispensing path, choosing between continuous and pulse mode, debugging "delivered 0 mL", working with the SLF3S-0600F or Teensy UART bridge, or running the per-cage pulse calibration pipeline.
+---
+
+# Flow / delivery strategies
+
+The RRR architecture isolates "how do we actually move water" behind a
+single Protocol. The scheduling layer only knows "deliver N mL to relay
+unit K" — it doesn't care whether that means firing a pump for 800 ms or
+holding a solenoid open until the flow sensor integrates to N.
+
+## The Protocol
+
+[`Project/strategies/delivery_strategy.py`](Project/strategies/delivery_strategy.py)
+defines:
+
+```python
+@runtime_checkable
+class DeliveryStrategy(Protocol):
+    async def deliver(self, relay_unit_id: int,
+                      target_volume_ml: float,
+                      triggers_hint: Optional[int] = None) -> bool: ...
+
+    async def clean(self, relay_unit_id: int, to_waste: bool = True) -> None: ...
+```
+
+Two concrete implementations:
+
+| Strategy | File | When |
+|---|---|---|
+| `SolenoidFlowStrategy` | [`Project/strategies/solenoid_flow_strategy.py`](Project/strategies/solenoid_flow_strategy.py) | canonical — global master valve + per-cage solenoids + flow sensor |
+| `PumpStrategy` | [`Project/strategies/pump_strategy.py`](Project/strategies/pump_strategy.py) | legacy — peristaltic pump fired for N triggers per `volume_calculator` |
+
+## The factory
+
+[`Project/strategies/factory.py`](Project/strategies/factory.py)
+`StrategyFactory.create()` picks the strategy from `hardware_mode`
+(a `system_settings` key):
+
+```python
+mode = (hardware_mode or "pump").strip().lower()
+if mode == "pump":
+    return PumpStrategy(pump_controller, volume_calculator)
+if mode == "solenoid":
+    return SolenoidFlowStrategy(...)
+```
+
+Unknown values fall back to `pump` (defensive default). Selection rules
+and what each mode requires: [`references/strategy-selection.md`](references/strategy-selection.md).
+
+## SolenoidFlowStrategy has two sub-modes
+
+Auto-selected from `settings['use_pulse_delivery']`:
+
+- **Continuous mode** (Lee Company LHD valves, legacy) — open the
+  solenoid, integrate the flow sensor, close when the integral hits
+  target with a predictive cutoff.
+- **Pulse mode** (Parker Series 3 valves, recommended) — fire timed
+  micro-pulses (10-500 ms each) using empirical per-valve
+  pulse-to-volume calibration. Precision: ~±0.003 mL.
+
+The pulse profile lives in
+[`Project/utils/pulse_calibration.py`](Project/utils/pulse_calibration.py)
+and is filled per cage by the calibration wizard.
+
+## Flow sensors — two drivers, one shape
+
+| Driver | Class | Path |
+|---|---|---|
+| Direct I²C (legacy) | `SLF3S0600FDriver` | [`Project/drivers/flow_sensor.py:17`](Project/drivers/flow_sensor.py#L17) |
+| Teensy UART bridge (canonical) | `UARTFlowSensor` | [`Project/drivers/uart_flow_sensor.py`](Project/drivers/uart_flow_sensor.py) |
+
+Picked by
+[`Project/drivers/flow_sensor_factory.py`](Project/drivers/flow_sensor_factory.py)
+`create_flow_sensor(settings)` based on `flow_sensor_type` (`'i2c'` or
+`'uart'`).
+
+Why we moved off direct-I²C: the SLF3S-0600F sometimes wedges the I²C
+bus, and Bookworm's smbus2 has been less reliable on the Pi 5 than the
+Pi 4. The Teensy bridge isolates the sensor on its own I²C bus and
+streams samples over USB-serial at `/dev/teensy_flow` (the udev rule is
+in [`scripts/install/40-hardware.sh`](scripts/install/40-hardware.sh)).
+
+## Calibration pipeline
+
+Per-cage pulse-to-volume calibration:
+
+1. Operator opens the calibration wizard from the UI:
+   [`Project/ui/CalibrationWizard.py`](Project/ui/CalibrationWizard.py).
+2. The wizard runs N fixed pulses, records the integrated volume per
+   pulse via the flow sensor.
+3. `pulse_calibration.py` writes the empirical
+   `pulse_width_ms`/`volume_per_pulse_ml` pair to the
+   `valve_calibration` table (also appended to `valve_calibration_history`).
+4. Future deliveries through `SolenoidFlowStrategy` read the calibration
+   per cage via `DatabaseHandler.get_valve_calibration(cage_id)`.
+
+Priming the line (filling tubing without metering volume) is its own
+flow:
+[`Project/ui/PrimingControlWidget.py`](Project/ui/PrimingControlWidget.py)
+exposes a "prime" action that opens the cage solenoid until the operator
+hits stop. No flow integration; it doesn't count against the schedule.
+
+Full procedure: [`references/calibration-pipeline.md`](references/calibration-pipeline.md).
+
+## Don't do this
+
+- Don't add a third strategy by editing `RelayWorker` directly. The
+  point of the Protocol is that `RelayWorker` doesn't import strategies
+  — `StrategyFactory` does, and the worker holds an opaque reference.
+- Don't import `RPi.GPIO` or `smbus2` at the top of a strategy module.
+  Hardware imports are lazy ([threading-checklist](../pyqt5-ui-conventions/references/threading-checklist.md#4-hardware-imports-are-lazy)) — top-level imports kill `test_gui_smoke.py`.
+- Don't write to `valve_calibration` from a strategy. Calibration writes
+  are wizard-driven; strategies read.
+- Don't assume the flow sensor is always present in pulse mode either
+  — the `SolenoidFlowStrategy` constructor accepts `flow_sensor=None`
+  for calibration-only mode (you fire pulses without verifying volume).
+  Treat `None` defensively in any new code that reads flow.
+
+## Where to start when "delivered 0 mL"
+
+1. Read [`hardware-gpio-debug`](../hardware-gpio-debug/SKILL.md) first
+   — relay HAT not detected is the most common cause.
+2. Check the flow sensor path:
+   `python3 -c "from drivers.flow_sensor_factory import create_flow_sensor; ..."`
+3. If solenoid mode with pulse delivery: confirm the cage has a row in
+   `valve_calibration`. Without calibration, the strategy can't translate
+   target volume into pulse count.
+4. Check `delivery_mode` on the schedule itself — staggered vs instant
+   uses different code paths in `RelayWorker`.

--- a/.claude/skills/flow-delivery-strategies/references/calibration-pipeline.md
+++ b/.claude/skills/flow-delivery-strategies/references/calibration-pipeline.md
@@ -1,0 +1,109 @@
+# Calibration pipeline
+
+Per-cage pulse-to-volume calibration for `SolenoidFlowStrategy` in pulse
+mode. Without this, the strategy can't translate "deliver 0.2 mL" into a
+pulse count.
+
+## What gets calibrated
+
+For each cage that has a solenoid + flow sensor, we measure:
+
+- `pulse_width_ms` — duration of a single pulse (operator-chosen, usually
+  10-500 ms)
+- `volume_per_pulse_ml` — empirical mean volume delivered per pulse at
+  that width
+- `stddev_ml` — variability across pulses
+- `coefficient_of_variation_pct` — `stddev / mean * 100`
+- `num_samples` — pulses fired during calibration (typically 50-100)
+
+These are persisted to the `valve_calibration` table (one row per cage,
+unique on `cage_id`) and appended to `valve_calibration_history` (audit
+trail).
+
+Schema reference:
+[`schedule-database-ops/references/schema.md`](../../schedule-database-ops/references/schema.md)
+under "valve_calibration".
+
+## The flow (UI side)
+
+1. Operator opens the calibration wizard from the Settings tab or from
+   the Cages visualization.
+   Entry point: [`Project/ui/CalibrationWizard.py`](Project/ui/CalibrationWizard.py).
+2. Selects a cage, sets `pulse_width_ms` and `num_samples`.
+3. Wizard primes the line (see priming below).
+4. Wizard fires N pulses, integrating volume per pulse from the flow
+   sensor between pulses.
+5. Wizard computes mean / stddev / CV, shows the operator a preview.
+6. On accept, writes via
+   [`Project/utils/pulse_calibration.py`](Project/utils/pulse_calibration.py)
+   → `DatabaseHandler.save_valve_calibration(...)`
+   ([`database_handler.py:1558`](Project/models/database_handler.py#L1558)).
+
+The write is atomic — both `valve_calibration` (upsert by `cage_id`) and
+`valve_calibration_history` (insert) happen in one transaction.
+
+## Priming the line
+
+Before calibration starts, the line between the master valve and the
+cage solenoid must be full of water — otherwise the first few pulses
+deliver air and ruin the mean.
+
+[`Project/ui/PrimingControlWidget.py`](Project/ui/PrimingControlWidget.py)
+exposes a "prime" action that:
+
+- Opens the master valve + the selected cage solenoid.
+- Holds them open until the operator stops.
+- Reports flow rate live (helps operator know when air is purged).
+- **Does not count against the schedule** — priming volume is wasted
+  to drain, not delivered to the animal.
+
+The widget is independent of any delivery strategy; it talks directly to
+the relay handler + flow sensor.
+
+## Reading calibration at delivery time
+
+`SolenoidFlowStrategy` in pulse mode reads via the calibration store:
+
+```python
+cal = db.get_valve_calibration(cage_id)
+if cal is None:
+    raise NoCalibrationError(...)
+pulse_count = math.ceil(target_volume_ml / cal['volume_per_pulse_ml'])
+```
+
+If `cal` is `None` (cage was never calibrated), pulse mode has no way to
+make a defensible decision. Either:
+
+- Fall back to continuous mode for that cage (current behavior, with a
+  warning in the log), OR
+- Refuse to deliver (planned, gated on a setting)
+
+Continuous mode doesn't need calibration — it integrates the flow sensor
+in real time.
+
+## When to recalibrate
+
+- After replacing a solenoid (mechanical wear → different bore characteristics)
+- After major plumbing changes (line length, fittings)
+- When CV creeps above ~5% in routine deliveries (the audit log in
+  `dispensing_history` is the signal here — compare commanded vs
+  delivered volume per cage over time)
+- Quarterly as a default cadence
+
+The `valve_calibration_history` table preserves prior calibrations for
+audit, so re-calibrating doesn't lose history.
+
+## Don't do this
+
+- Don't calibrate with the cage's lickspout connected — water spits into
+  the cage and skews the measurement. Calibrate to a graduated vial.
+- Don't trust calibration that ran with the flow sensor uncalibrated.
+  The SLF3S-0600F ships factory-calibrated, but if the line has air or
+  the sensor was bumped during installation, the integration is bogus.
+- Don't tweak `pulse_width_ms` mid-experiment. Operator-visible behavior
+  must match the recorded calibration. If you need a different width,
+  start a new calibration session for that cage and accept a new
+  history row.
+- Don't bypass `pulse_calibration.py` and write directly to the table.
+  The util enforces a basic sanity check (CV < threshold, num_samples
+  > 0) before committing.

--- a/.claude/skills/flow-delivery-strategies/references/strategy-selection.md
+++ b/.claude/skills/flow-delivery-strategies/references/strategy-selection.md
@@ -1,0 +1,100 @@
+# Strategy selection
+
+How `StrategyFactory.create()` picks a strategy and what each mode
+requires.
+
+## The `hardware_mode` setting
+
+A `system_settings` key (default `'pump'`):
+
+| Value | Strategy | Notes |
+|---|---|---|
+| `'pump'` | `PumpStrategy` | legacy time-based; relay HAT only |
+| `'solenoid'` | `SolenoidFlowStrategy` | canonical; relay + solenoids + flow sensor |
+| anything else | `PumpStrategy` | defensive fallback ([`factory.py`](Project/strategies/factory.py)) |
+
+The setting comes from `SystemController.settings['hardware_mode']` which
+in turn reads from the `system_settings` table (Phase 2.5a). Operators
+set it from
+[`Project/ui/SettingsTab.py`](Project/ui/SettingsTab.py) under the
+"Hardware" subtab.
+
+## Pump mode — what it needs
+
+`StrategyFactory.create(hardware_mode='pump', ...)` requires:
+
+- `pump_controller` — a `PumpController` instance. Owns the relay-clicking
+  logic and trigger pulse generator.
+- `volume_calculator` — a `VolumeCalculator` instance. Converts mL into
+  pump trigger counts using `pump_volume_ul` (µL per click).
+
+Hardware footprint: just the Sequent Microsystems 16-relay HAT. No flow
+sensor, no master valve, no solenoids. Cheapest setup, lowest precision
+(trigger counts are nominal — actual delivered volume drifts with tubing
+wear).
+
+## Solenoid mode — what it needs
+
+`StrategyFactory.create(hardware_mode='solenoid', ...)` requires:
+
+- `solenoid_controller` — owns master-valve and per-cage solenoid timing.
+- `flow_sensor` — optional. `SLF3S0600FDriver` or `UARTFlowSensor`. May be
+  `None` for calibration-only mode (the strategy still fires pulses; you
+  just can't verify volume).
+- `calibration_store` — optional. Provides the per-cage
+  pulse-to-volume calibration. In practice this wraps
+  `DatabaseHandler.get_valve_calibration(cage_id)`.
+- `settings` — required. Drives the continuous-vs-pulse sub-mode:
+  `settings['use_pulse_delivery'] = True | False`.
+
+Hardware footprint:
+
+- Relay HAT (drives the master valve + per-cage solenoid drivers)
+- One global master valve (typically Parker Series 3, 12V)
+- Per-cage solenoids
+- SLF3S-0600F flow sensor (mounted between master and manifold)
+- Teensy 4.1 (if `flow_sensor_type='uart'`) bridging the sensor over USB
+
+## Sub-mode: continuous vs pulse (solenoid only)
+
+`use_pulse_delivery=False` (continuous):
+
+- Open master + cage solenoid.
+- Stream samples from flow sensor at ~50 Hz; integrate.
+- Apply predictive cutoff (close ~closing_lag_ms before integral hits
+  target).
+- Verify post-close volume; warn if outside tolerance.
+- Good for Lee Company LHD valves.
+
+`use_pulse_delivery=True` (pulse, recommended):
+
+- Look up per-cage pulse profile from `valve_calibration`.
+- Compute pulse count = `ceil(target_mL / volume_per_pulse_ml)`.
+- Fire pulses with `pulse_width_ms` per pulse.
+- Optionally verify final integral against the flow sensor.
+- Good for Parker Series 3 valves. Higher precision.
+
+## Decision tree
+
+```
+Do you have a flow sensor + solenoids?
+├── No  → 'pump' mode
+└── Yes → 'solenoid' mode
+         │
+         ├── Lee Company LHD valves?
+         │   └── set use_pulse_delivery = False (continuous)
+         │
+         └── Parker Series 3 valves?
+             └── set use_pulse_delivery = True (pulse) — recommended
+                 │
+                 └── Did you run per-cage calibration?
+                     ├── No  → calibrate first (see calibration-pipeline.md)
+                     └── Yes → ready to deliver
+```
+
+## Why pump-mode is still around
+
+Some lab rigs ship with only the relay HAT. Phasing it out would force
+those operators to buy solenoid hardware. The strategy is kept as a
+first-class implementation, not a deprecated fallback — but
+`SolenoidFlowStrategy` is what new rigs should use.

--- a/.claude/skills/hardware-gpio-debug/SKILL.md
+++ b/.claude/skills/hardware-gpio-debug/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: hardware-gpio-debug
+description: Diagnose RRR hardware path failures — Sequent Microsystems 16-relay HAT not detected, I²C errors (errno 121 / 5 / 110), Pi 4 vs Pi 5 GPIO differences, mock-vs-real seam in gpio/, and the lazy-init pattern used by RelayWorker. Use when the user reports "relays not clicking", "Hardware control will not work", "pump not firing", an I²C exception, or asks how to test the relay path before running a schedule.
+---
+
+# Hardware / GPIO debugging
+
+The water-delivery hot path is:
+
+```
+Schedule → ScheduleController → DeliveryQueueController → RelayWorker (QThread)
+       → RelayHandler → SM16relind (or MockSM16relind) → I²C bus
+       → 16-channel relay HAT → pump or solenoid → animal
+```
+
+A failure anywhere on this chain manifests as "no water delivered." Diagnose
+**top-down** — schedule UI, then controllers, then GPIO, then I²C, then board.
+
+## First-pass triage (always do these)
+
+```bash
+# Is the bus alive and does the kernel see addresses 0x20–0x27?
+i2cdetect -y 1                # Pi 4 + 5
+
+# Sequent Microsystems CLI sanity (installed by scripts/install/40-hardware.sh)
+16relind 0 board              # stack 0 board info
+16relind 0 read 1             # read relay 1 (expect 0 or 1)
+16relind 0 write 1 1; sleep 1; 16relind 0 write 1 0   # click test
+
+# RRR's own selftest (used by the update applier; safe to run manually)
+~/rrr/shared/venv/bin/python3 ~/rrr/current/Project/main.py --selftest
+```
+
+If `i2cdetect` shows no devices → bus or wiring (check 3.3 V, SDA/SCL, common
+ground). If `16relind` works but RRR doesn't → it's a Python-layer problem.
+
+## Key files and their responsibilities
+
+| File | What it owns |
+|---|---|
+| [Project/gpio/gpio_handler.py](Project/gpio/gpio_handler.py) `RelayHandler` | Public façade. Owns the per-HAT `SM16relind` instances; routes trigger commands; tolerates missing hardware by falling back to `MockSM16relind`. |
+| [Project/gpio/relay_worker.py](Project/gpio/relay_worker.py) `RelayWorker(QObject)` | Lives on a `QThread`. **Lazy-imports** the flow-sensor and solenoid drivers inside method bodies (line ~215) so GUI startup doesn't pull hardware modules. |
+| [Project/gpio/mock_gpio_handler.py](Project/gpio/mock_gpio_handler.py) `MockSM16relind` | Drop-in stand-in when `sm_16relind` isn't installed or hardware is absent. Logs the call instead of clicking. |
+| [Project/gpio/custom_SM16relind.py](Project/gpio/custom_SM16relind.py) | Project-local wrapper used for Pi 5 — upstream lib originally Pi-4-only. |
+| [Project/drivers/i2c_coordinator.py](Project/drivers/i2c_coordinator.py) `I2CCoordinator` | Single mutex-guarded I²C handle shared by the relay HAT and flow sensor; prevents address-collision deadlocks. |
+
+## The mock-vs-real seam
+
+`RelayHandler.__init__` tries `from sm_16relind import SM16relind` and falls back
+to `MockSM16relind` on `ImportError` or board-not-found errors. **Do not** add
+new hardware imports at module top-level — they break boot on a dev Mac and
+the headless smoke test. Follow the lazy-import pattern at
+[Project/gpio/relay_worker.py:215](Project/gpio/relay_worker.py#L215):
+
+```python
+def _do_dispense(self, ...):
+    from drivers.flow_sensor_factory import create_flow_sensor  # noqa: PLC0415
+    from drivers.uart_flow_sensor import TeensyUnavailableError
+    ...
+```
+
+## Common errors and what they mean
+
+| Symptom | Likely cause | Where to look |
+|---|---|---|
+| `OSError: [Errno 121] Remote I/O error` | HAT not at expected I²C address; jumpers wrong | `i2cdetect`, check stack-level jumpers per the 16-RELAYS vendor manual |
+| `OSError: [Errno 5] Input/output error` | Bus glitch, loose SDA/SCL, ground loop | Reseat HAT, re-crimp wires, check common ground |
+| `OSError: [Errno 110] Connection timed out` | I²C clock conflict (often if `i2c-dev` was just modprobed) | `sudo modprobe i2c-dev` then retry; reboot if persistent |
+| `ImportError: No module named 'sm_16relind'` | apt package not installed (or venv not seeing system packages) | Run `scripts/install/40-hardware.sh`; check venv uses `--system-site-packages` |
+| GUI says "Hardware control will not work" | `RelayHandler` fell back to mock — likely on a dev machine, but **suspicious on a Pi** | grep startup logs for which branch was taken |
+
+## Pi 4 vs Pi 5 differences
+
+- Pi 5 changed the I²C bus number for the user-facing 40-pin header. Check
+  `i2cdetect -y 1` first; if that's empty, try `-y 13` on Pi 5 with certain
+  HATs. `scripts/install/40-hardware.sh` configures the right one.
+- `custom_SM16relind.py` exists because the upstream lib hard-coded a `/dev/i2c-1`
+  open that broke on Pi 5 in earlier firmware. Don't delete it.
+
+## Threading rule (load-bearing)
+
+Hardware calls happen on `RelayWorker`'s `QThread`. Never call `RelayHandler`
+methods from a slot connected via the default `AutoConnection`; use
+`Qt.QueuedConnection` to marshal the call onto the worker thread. The pattern
+is at [Project/main.py:319, 359, 376, 388](Project/main.py#L319). Breaking
+this rule manifests as intermittent crashes only seen under real schedules.
+
+See [`references/i2c-cheatsheet.md`](references/i2c-cheatsheet.md) for the
+full address map, [`references/diagnostic-commands.md`](references/diagnostic-commands.md)
+for shell-level hardware probes, and
+[`references/threading-pattern.md`](references/threading-pattern.md) for the
+QThread/QueuedConnection pattern.
+
+## Don't do this
+
+- Don't add `RPi.GPIO` or `sm_16relind` to `requirements.txt` — they come
+  from apt (see [requirements.txt:3-5](requirements.txt#L3-L5)).
+- Don't bypass `RelayHandler` and call `SM16relind` directly from a
+  controller or widget — the mock fallback only works through the handler.
+- Don't change the mock surface to add behavior the real driver lacks; the
+  mock is a *seam* not a *simulator*.

--- a/.claude/skills/hardware-gpio-debug/references/diagnostic-commands.md
+++ b/.claude/skills/hardware-gpio-debug/references/diagnostic-commands.md
@@ -1,0 +1,59 @@
+# Shell-level hardware diagnostics
+
+Operator-friendly commands. Run from any shell on the device; no Python needed.
+
+## Bus and HAT presence
+
+```bash
+# Bus 1, addresses 0x03–0x77
+i2cdetect -y 1
+
+# Sequent Microsystems CLI: board info / relay state / individual relays
+16relind 0 board                # stack 0 = first HAT
+16relind 0 read 1               # 0 = off, 1 = on
+16relind 0 write 1 1            # click on
+16relind 0 write 1 0            # click off
+```
+
+`16relind` is the vendor's own tool and bypasses RRR's entire stack — useful
+to isolate "is it the hardware?" from "is it our code?". If `16relind`
+works and RRR doesn't, the fault is in `RelayHandler`/`RelayWorker`.
+
+## Teensy flow sensor (UART)
+
+```bash
+ls -l /dev/teensy_flow          # stable udev symlink; installer creates it
+ls -l /dev/serial/by-id/*Teensy*
+
+# Tail the protocol bytes
+stty -F /dev/teensy_flow 115200 raw
+cat /dev/teensy_flow | head -c 200 | xxd
+```
+
+If `/dev/teensy_flow` is missing, the udev rule from
+[scripts/install/40-hardware.sh](scripts/install/40-hardware.sh) didn't apply —
+re-run with `./install.sh --only 40-hardware`.
+
+## Mock-fallback detection
+
+```bash
+# Tail the app's debug log; "MockSM16relind" means we're not on real hardware
+tail -F ~/rrr_app_debug.log | grep -i mock
+
+# On an installed device data root:
+tail -F "$HOME/rrr/shared/logs/rrr_app_debug.log" | grep -i mock
+```
+
+If you see `MockSM16relind` lines while running on a real Pi, the
+`sm_16relind` import failed — usually means the venv was built without
+`--system-site-packages` or the apt package isn't installed.
+
+## I²C bus reset (last resort)
+
+```bash
+sudo modprobe -r i2c_dev i2c_bcm2835
+sudo modprobe i2c_bcm2835 i2c_dev
+```
+
+This kicks a stuck I²C controller. Won't fix wiring; will sometimes recover
+from a clock-stretching deadlock after a hot-swap.

--- a/.claude/skills/hardware-gpio-debug/references/i2c-cheatsheet.md
+++ b/.claude/skills/hardware-gpio-debug/references/i2c-cheatsheet.md
@@ -1,0 +1,47 @@
+# I²C cheatsheet
+
+Quick reference for the I²C topology RRR expects.
+
+## Address map
+
+| Device | Default address | Notes |
+|---|---|---|
+| Sequent Microsystems 16-relay HAT | `0x20–0x27` | Stack level selected via on-board jumpers JP1–JP3. Stack 0 = `0x20`. |
+| Sensirion SLF3S-0600F flow sensor | `0x08` | Legacy direct-I²C path; superseded by Teensy UART bridge but still supported as fallback (see [Project/drivers/flow_sensor.py](Project/drivers/flow_sensor.py)). |
+
+If `i2cdetect -y 1` shows neither, the bus itself is the problem — not the
+device.
+
+## Stack-level jumpers (16-RELAYS)
+
+| JP1 | JP2 | JP3 | Address | Stack level |
+|---|---|---|---|---|
+| open | open | open | `0x20` | 0 |
+| short | open | open | `0x21` | 1 |
+| open | short | open | `0x22` | 2 |
+| short | short | open | `0x23` | 3 |
+
+Authoritative reference: [Project/docs/16-RELAYS-UsersGuide_d5e24457-bdd9-4e16-a307-7f90bbd668bb.pdf](Project/docs/16-RELAYS-UsersGuide_d5e24457-bdd9-4e16-a307-7f90bbd668bb.pdf).
+
+## Bus numbers (Pi-version-dependent)
+
+| Pi | User header bus | Notes |
+|---|---|---|
+| 4 | `/dev/i2c-1` | Stable across releases. |
+| 5 | `/dev/i2c-1` (default) | Some early firmware exposed it on `/dev/i2c-13`; the installer pins the right one. |
+
+## When the bus looks dead
+
+1. `dmesg | grep -i i2c` — kernel-level errors?
+2. `ls -l /dev/i2c-*` — does the device node exist? (Group should be `i2c`.)
+3. `groups` — is your user in the `i2c` group? `scripts/install/50-services.sh` adds
+   you; **you must log out and back in for the new group to apply**.
+4. `sudo i2cdetect -y 1` — sudo bypass; if this works and the unprivileged
+   call doesn't, it's group membership.
+
+## Two devices on one bus — clock conflict
+
+RRR's flow-sensor + relay HAT share bus 1. `I2CCoordinator`
+([Project/drivers/i2c_coordinator.py](Project/drivers/i2c_coordinator.py)) holds
+a `threading.Lock` around every read/write. Bypassing it causes intermittent
+`OSError: [Errno 110]` under load. Always go through the coordinator.

--- a/.claude/skills/hardware-gpio-debug/references/threading-pattern.md
+++ b/.claude/skills/hardware-gpio-debug/references/threading-pattern.md
@@ -1,0 +1,53 @@
+# Hardware threading pattern
+
+PyQt5 + hardware = one thread for the UI, one thread for the relays. Crossing
+that boundary without `Qt.QueuedConnection` causes random crashes that only
+show up under real schedules.
+
+## The pattern
+
+`RelayWorker(QObject)` lives on a `QThread`. The main thread connects to its
+signals/slots using `Qt.QueuedConnection`, which marshals the call onto the
+worker's event loop.
+
+Reference call sites in [Project/main.py](Project/main.py):
+
+```python
+# Volume updates flow UI ← worker thread
+worker.volume_updated.connect(_on_volume_updated, Qt.QueuedConnection)  # ~L359
+worker.finished.connect(_on_finished, Qt.QueuedConnection)              # ~L376
+
+# Stop requests cross the other way
+control_signals.stop_requested.connect(worker.stop, Qt.QueuedConnection) # ~L388
+```
+
+## Why it matters
+
+- Without `QueuedConnection`, the slot runs **synchronously on the calling
+  thread**. If the GUI emits and the slot then touches I²C, you've now
+  blocked the event loop on a hardware call.
+- Worse, if the slot touches Qt widget state from the worker thread, you
+  get `QObject::startTimer: Timers cannot be started from another thread`
+  or a silent crash.
+
+## What "lazy import" means here
+
+`RelayWorker._do_dispense` defers the flow-sensor and solenoid imports until
+the method actually runs ([Project/gpio/relay_worker.py:215](Project/gpio/relay_worker.py#L215)).
+Two reasons:
+
+1. **Boot speed** — the GUI starts before hardware drivers initialize, so
+   the splash appears instantly even when the Teensy is slow to enumerate.
+2. **Test isolation** — `test_gui_smoke.py` can import the whole `ui`
+   package without pulling `RPi.GPIO` / `sm_16relind` / `pyserial`.
+
+Don't move these imports to the top of `relay_worker.py`. The cost is a
+one-line import inside the hot path; the benefit is the smoke test stays
+runnable on any machine.
+
+## Cleanup order
+
+`RelayHandler.cleanup()` must run **before** `QApplication.quit()`. The
+pattern in [main.py](Project/main.py) chains: stop signal → worker exits
+event loop → `thread.wait()` → handler cleanup → app quit. Reverse that
+order and Qt complains about destroyed objects.

--- a/.claude/skills/pyqt5-ui-conventions/SKILL.md
+++ b/.claude/skills/pyqt5-ui-conventions/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: pyqt5-ui-conventions
+description: Apply the RRR project's PyQt5 conventions when building or editing UI — RodentRefreshmentGUI main window, ProjectsSection tabs (SchedulesHub + AnimalsTab + WizardTab + CagesVisualizationTab), SettingsTab sub-tabs, dialog patterns, login gating via LoginGateWidget, and the threading boundary between widgets and RelayWorker. Use when adding a tab, a dialog, a widget, hooking up a signal, or touching any file under Project/ui/.
+---
+
+# PyQt5 UI conventions
+
+The UI is a single `RodentRefreshmentGUI` window holding a `QTabWidget`.
+Every user-facing screen is a tab, a sub-tab, or a modal dialog. This skill
+captures the conventions so new UI lands consistently.
+
+## The main window contract
+
+[Project/ui/gui.py](Project/ui/gui.py) `RodentRefreshmentGUI.__init__` takes
+these collaborators and stores them as attributes — **the UI never
+constructs them itself**:
+
+```python
+RodentRefreshmentGUI(
+    run_callback, stop_callback, change_relay_callback,
+    system_controller, database_handler, login_system,
+    relay_handler, notification_handler,
+)
+```
+
+Construction is in [Project/main.py](Project/main.py)'s `setup()` /
+`_create_gui_from_components()`. New widgets that need data should
+accept the relevant handler in their `__init__` — never reach into
+`gui.parent()` or use globals.
+
+## Live tab tree (truth, post-Phase-1)
+
+```
+RodentRefreshmentGUI (QTabWidget)
+├── ProjectsSection      ─── QTabWidget
+│   ├── SchedulesHub         (card grid; replaces legacy SchedulesTab)
+│   ├── AnimalsTab
+│   ├── WizardTab            (wraps ScheduleCreationWizard)
+│   └── CagesVisualizationTab (relay-board layout + inline cage naming)
+├── SettingsTab          ─── QTabWidget
+│   ├── Delivery (Hardware/Pump)
+│   ├── Calibration         (per-cage; opens CalibrationWizard)
+│   ├── Priming             (embeds PrimingControlWidget)
+│   ├── General
+│   └── Updates             (UpdatesTab; in-app updater)
+├── UserTab                  (login / profile)
+└── HelpTab                  (uses HelpContentManager)
+```
+
+**Do not** instantiate `SchedulesTab`, `CageManagerWidget`,
+`AdvancedSettingsSection`, `LoginDialog`, `ProfileDialog`, `IntervalSettings`,
+`EditScheduleDialog`, `RelayContainer`, `DragDropContainer`, or
+`ScheduleCreationWidget` — they were deleted in Phase 1 as orphans. If you
+find a reference to one, treat it as a bug.
+
+## Login gating
+
+[Project/ui/login_gate_widget.py](Project/ui/login_gate_widget.py)
+`LoginGateWidget` wraps any inner widget and hides/shows it based on
+`LoginSystem.is_logged_in()`. `gui.py` uses it to gate `ProjectsSection`.
+
+```python
+self.login_gate = LoginGateWidget(self.projects_section, self.login_system)
+left_layout.addWidget(self.login_gate)
+```
+
+The pattern is: connect `login_system.login_status_changed` →
+widget refresh. Don't poll `is_logged_in()`.
+
+## Signal/slot conventions
+
+- **Signals are defined on the class**, not on instances. Use type hints
+  in the `pyqtSignal(...)` declaration when the payload is non-trivial.
+- **Cross-thread signals require `Qt.QueuedConnection`**. The relay
+  worker thread is the only non-main-thread Qt object you should
+  routinely encounter; see the threading skill.
+- **One signal, one concern.** `wizard_tab.schedule_created` emits a
+  `dict`; `schedules_hub.create_requested` emits nothing — it just asks
+  the parent to switch tabs.
+
+Reference pattern (from [projects_section.py:99](Project/ui/projects_section.py#L99)):
+
+```python
+self.wizard_tab.schedule_created.connect(self._on_wizard_schedule_created)
+self.schedules_tab.create_requested.connect(self._switch_to_wizard)
+```
+
+## Card-based components
+
+Card-style UI lives in [Project/ui/components/](Project/ui/components/):
+
+- `card.py` `Card(QFrame)` — non-interactive container with `Card` objectName for QSS.
+- `interactive_card.py` `InteractiveCard`, `SelectableCardGroup` — clickable selection.
+- `primary_button.py` `PrimaryButton` — branded button.
+- `wizard.py` `WizardContainer`, `WizardStep` — used by `schedule_wizard.py`.
+
+The card pattern replaces the older drag-drop schedule UI. If you're
+about to write `QListWidget` + drag/drop for a list of *project entities*
+(schedules, animals, cages), use cards instead.
+
+## Styling
+
+Centralized QSS in [Project/ui/style/theme.py](Project/ui/style/theme.py)
+`StyleManager` + `app-light.qss` / `app-dark.qss`. **No per-widget
+`setStyleSheet`** unless the rule is genuinely one-off.
+Set `objectName` to a QSS-friendly identifier (`InfoButton`, `Card`,
+`Title`) and target it in the global stylesheet.
+
+## Dialogs
+
+See [`references/dialog-template.md`](references/dialog-template.md) for the
+standard pattern. Two notes:
+
+- Dialogs that need the database/login system **receive them in
+  `__init__`** — don't reach up through `parent()`.
+- For schedule editing, the canonical dialog is `ScheduleEditDialog`
+  defined **inside** [schedules_hub.py:36](Project/ui/schedules_hub.py#L36),
+  not the deleted standalone `EditScheduleDialog`.
+
+## Tabs
+
+See [`references/tab-template.md`](references/tab-template.md) for adding a
+new sub-tab. Settings sub-tabs go in `SettingsTab.init_ui`; Projects sub-tabs
+go in `ProjectsSection.__init__`. **Do not add a new top-level tab on
+`RodentRefreshmentGUI` casually** — that's a significant UX change.
+
+## Threading from a widget
+
+A widget that needs to do non-trivial work should not block the UI thread.
+The standard pattern is a `QObject` worker moved to a `QThread`, with
+signals using `Qt.QueuedConnection`. See
+[`references/threading-checklist.md`](references/threading-checklist.md)
+and the implementation in
+[Project/gpio/relay_worker.py](Project/gpio/relay_worker.py).
+
+## Don't do this
+
+- Don't import `pandas`/`numpy` from a widget that needs to import cheaply
+  (e.g. nothing on the hot import path of the smoke test). `SettingsTab`
+  already pulls pandas at top level — accept the existing cost, don't add
+  more.
+- Don't re-export deleted classes from `Project/ui/__init__.py`. The
+  current `__all__` is the public surface; touching it bumps the project
+  to a MINOR per MAINTENANCE.md.
+- Don't call `QMessageBox.exec_()` from a slot connected to a worker-thread
+  signal without `QueuedConnection` — dialogs must run on the main thread.
+- Don't add a new `*.ui` (Qt Designer XML) file or `.qrc` resource.
+  Current code builds widgets in Python; introducing the XML build step
+  is a deliberate decision, not an incremental change.

--- a/.claude/skills/pyqt5-ui-conventions/references/dialog-template.md
+++ b/.claude/skills/pyqt5-ui-conventions/references/dialog-template.md
@@ -1,0 +1,65 @@
+# Dialog template
+
+Standard pattern for modal dialogs in RRR. Two real-world references:
+
+- [`Project/ui/schedules_hub.py:36`](Project/ui/schedules_hub.py) `ScheduleEditDialog`
+  — the canonical schedule-edit dialog (lives *inside* `schedules_hub.py`,
+  not as a standalone file).
+- [`Project/ui/edit_animal_dialog.py`](Project/ui/edit_animal_dialog.py)
+  `EditAnimalDialog` — simpler form-only dialog, parameterized on the
+  animal record dict.
+
+## Constructor signature
+
+Always accept the collaborators the dialog needs as explicit arguments;
+never reach up through `parent()` to find them.
+
+```python
+class MyEditDialog(QDialog):
+    def __init__(self, entity, database_handler, system_controller=None, parent=None):
+        super().__init__(parent)
+        self._entity = entity
+        self._database_handler = database_handler
+        self._system_controller = system_controller
+
+        self.setWindowTitle(f"Edit: {entity.name}")
+        self.setMinimumSize(800, 600)
+        self.setModal(True)
+
+        self._load_data()      # DB reads up-front, not inside _init_ui
+        self._init_ui()
+```
+
+## Why `setModal(True)` and not `exec_()` only
+
+`setModal(True)` plus `exec_()` blocks input to the parent window while the
+dialog is open. Using `show()` instead leaves the parent clickable and is a
+common source of double-save bugs (operator double-clicks the underlying
+list while the dialog still has a pending write).
+
+## Loading data
+
+Pre-fetch from `DatabaseHandler` in a dedicated `_load_*` method called
+*before* `_init_ui`, so widget construction has all the values it needs.
+Don't query the DB inside paint events, slot bodies, or model
+`data()` callbacks — those run on every repaint.
+
+## Saving — return through `accept()`
+
+Connect the OK button to a `_on_accept` slot that:
+
+1. Validates input (raise `QMessageBox.warning` and return early on bad data),
+2. Writes via the handler (`self._database_handler.update_xxx(...)`),
+3. Calls `self.accept()` to close with `QDialog.Accepted`.
+
+Callers use `if dlg.exec_() == QDialog.Accepted: refresh_list()` to react.
+
+## Don't do this
+
+- Don't write to the DB from `__init__` — operators expect "Cancel" to mean
+  "nothing changed."
+- Don't subclass the deleted `EditScheduleDialog` from
+  `Project/ui/edit_schedule_dialog.py` — that file was removed in Phase 1.
+  Use the in-hub `ScheduleEditDialog` as the template instead.
+- Don't store the dialog instance on the parent (`self.dlg = ...`) and reuse
+  it. Modal dialogs are short-lived; construct on demand, let Python GC.

--- a/.claude/skills/pyqt5-ui-conventions/references/tab-template.md
+++ b/.claude/skills/pyqt5-ui-conventions/references/tab-template.md
@@ -1,0 +1,57 @@
+# Adding a new tab
+
+Three flavors, depending on where the new screen belongs.
+
+## A. New sub-tab under SettingsTab
+
+Settings sub-tabs are the cheapest UI to add — they reuse the existing
+`SettingsTab.tab_widget` and the auto-save plumbing.
+
+1. Add a `_create_<name>_tab(self) -> QWidget` method to `SettingsTab`.
+2. Wire it in `SettingsTab.init_ui` next to the existing sub-tabs:
+   ```python
+   self.my_tab = self._create_my_tab()
+   self.tab_widget.addTab(self.my_tab, "My Tab")
+   ```
+3. If the tab has widgets the user can edit, connect them to
+   `_auto_save_settings` in `_connect_auto_save_handlers()`. The auto-save
+   reads every widget at once, so you only add the connection, not the
+   read logic.
+4. Add new keys to the `updated_settings` dict in `_auto_save_settings`
+   if you introduce new persistable values; they must be listed in
+   `SystemController` as managed keys (see schedule-database-ops skill).
+
+## B. New sub-tab under ProjectsSection
+
+For a new project-wide screen alongside Schedules/Animals/Wizard/Cages.
+
+1. Build a `QWidget` subclass in `Project/ui/<name>_tab.py` that takes
+   `(settings, print_to_terminal, database_handler, login_system,
+   system_controller=None)` in `__init__` — same shape as siblings.
+2. Add it in `ProjectsSection.__init__`:
+   ```python
+   self.my_tab = MyTab(settings, self.print_to_terminal, database_handler, login_system)
+   self.my_tab_index = self.tab_widget.addTab(self.my_tab, "My Tab")
+   ```
+3. Connect any cross-tab signals at the bottom of `ProjectsSection.__init__`
+   (e.g. wizard's `schedule_created` → schedules hub's `refresh`).
+4. **Do not** add a top-level tab on `RodentRefreshmentGUI` for a project
+   concept — that breaks the Schedules/Animals/Wizard/Cages mental model.
+
+## C. New top-level tab on RodentRefreshmentGUI
+
+Reserved for cross-cutting concerns (Settings, Help, User). Adding one is
+a deliberate UX decision; loop in the user before doing it. Pattern:
+
+1. Build the widget the same way as a project sub-tab but with the
+   collaborators the top-level tab needs (often `system_controller`).
+2. Add in `RodentRefreshmentGUI.init_ui` next to the existing
+   `self.settings_tab` / `self.user_tab` / `self.help_tab` block.
+3. If the tab depends on login state, wrap it in `LoginGateWidget`.
+
+## Smoke test
+
+`Project/tests/unit/test_gui_smoke.py` parametrizes over every
+`Project/ui/*.py`. A new tab module is picked up automatically and
+verified to import cleanly + appear in `ui.__init__.__all__` if exported.
+Run locally: `pytest Project/tests/unit/test_gui_smoke.py -v`.

--- a/.claude/skills/pyqt5-ui-conventions/references/threading-checklist.md
+++ b/.claude/skills/pyqt5-ui-conventions/references/threading-checklist.md
@@ -1,0 +1,77 @@
+# Threading checklist
+
+Before merging any code that spawns a `QThread` or moves a `QObject` worker
+off the main thread, confirm every item below.
+
+## 1. Worker is a `QObject` moved to a `QThread`
+
+Not a `QThread` subclass. The Qt-recommended pattern (and what RRR uses) is:
+
+```python
+worker = MyWorker(...)              # QObject subclass
+thread = QThread()
+worker.moveToThread(thread)
+thread.started.connect(worker.run)
+worker.finished.connect(thread.quit)
+worker.finished.connect(worker.deleteLater)
+thread.finished.connect(thread.deleteLater)
+thread.start()
+```
+
+Reference: [Project/main.py](Project/main.py) `setup_program()` around the
+`RelayWorker` construction (~L300-L395). [Project/gpio/relay_worker.py](Project/gpio/relay_worker.py)
+`RelayWorker(QObject)`.
+
+## 2. Every cross-thread signal uses `Qt.QueuedConnection`
+
+Default `AutoConnection` will run a slot **synchronously on the emitter's
+thread** if connection happens to be made within one thread, which causes
+intermittent crashes. Always be explicit.
+
+Real call sites:
+
+```python
+worker.volume_updated.connect(_on_volume_updated, Qt.QueuedConnection)   # main.py:L359
+worker.finished.connect(_on_finished, Qt.QueuedConnection)               # main.py:L376
+control_signals.stop_requested.connect(worker.stop, Qt.QueuedConnection) # main.py:L388
+```
+
+## 3. No widget touch from the worker thread
+
+Slots that read or mutate widgets must run on the GUI (main) thread. Verify
+by reading the slot body — does it call `setText`, `addItem`, `show`,
+`hide`, `setEnabled`? If yes, the signal that triggers it must use
+`QueuedConnection`.
+
+## 4. Hardware imports are lazy
+
+Don't top-level-import `RPi.GPIO`, `sm_16relind`, or `pyserial` from a UI
+module. Import inside the method body so `test_gui_smoke.py` can construct
+the widget without hardware deps. Pattern from
+[Project/gpio/relay_worker.py:215](Project/gpio/relay_worker.py#L215):
+
+```python
+def _do_dispense(self, ...):
+    from drivers.flow_sensor_factory import create_flow_sensor  # noqa: PLC0415
+    from drivers.uart_flow_sensor import TeensyUnavailableError
+    ...
+```
+
+## 5. Cleanup order: stop signal → wait → handler cleanup → quit
+
+`RelayHandler.cleanup()` must run **before** `QApplication.quit()`. The
+correct chain is:
+
+1. Emit `stop_requested` to the worker.
+2. `thread.quit()` and `thread.wait(timeout_ms)` to let the event loop drain.
+3. Call `relay_handler.cleanup()` to release I²C resources.
+4. `app.quit()`.
+
+Reverse this order and you'll see `QObject::~QObject: Timers cannot be
+stopped from another thread` warnings on shutdown.
+
+## 6. No `QMessageBox.exec_()` from worker-connected slots without `QueuedConnection`
+
+Modal dialogs must run on the main thread. If you connect a worker
+signal to a slot that pops a dialog, that connection **must** be
+`QueuedConnection`.

--- a/.claude/skills/release-and-versioning/SKILL.md
+++ b/.claude/skills/release-and-versioning/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: release-and-versioning
+description: Cut a release of RRR safely — bump Project/version.py, tag, push, let CI build the .rrrupdate bundle. Use when the user says "release", "tag", "ship", "bump the version", "cut a version", or asks how the in-app updater finds new builds. Covers SemVer for RRR, when to bump vs. not, recovery from a bad tag, and the hard "tag == v<version>" CI invariant.
+---
+
+# Release and versioning
+
+The version lives in **one file**:
+[`Project/version.py`](Project/version.py). Everything else (the git tag,
+the bundle filename, the GitHub Release title, the in-app updater check)
+derives from it.
+
+## The one invariant CI enforces
+
+The git tag MUST equal `v<__version__>` at the tagged commit, byte for
+byte. [`.github/workflows/release.yml`](.github/workflows/release.yml)
+fails the build otherwise:
+
+```yaml
+- name: Verify tag matches Project/version.py
+  run: |
+    if [[ "${{ steps.ver.outputs.tag }}" != "v${{ steps.ver.outputs.app_version }}" ]]; then
+      echo "::error::tag ${{ steps.ver.outputs.tag }} does not match v${{ steps.ver.outputs.app_version }} from Project/version.py"
+      exit 1
+    fi
+```
+
+Pre-release tags use `-beta` (e.g. `v1.7.0-beta`, `v1.7.0-beta.2`); CI
+flags them as pre-release, and the in-app updater ignores them unless the
+device has opted into the beta channel.
+
+## When to bump (per [MAINTENANCE.md §2](Project/docs/MAINTENANCE.md))
+
+| Level | When | Examples |
+|---|---|---|
+| PATCH `1.6.x → 1.6.x+1` | bug fix, security pin, internal refactor — anything user-invisible | fix a crash, pin a dep version, tighten an error message |
+| MINOR `1.x.y → 1.x+1.0` | new feature, new sub-tab, new opt-in driver | add a tab, ship a new calibration mode |
+| MAJOR `x.y.z → x+1.0.0` | breaking change, schema migration that can't roll back, GPIO/hardware change | drop a column for real, change pin layout |
+
+**In doubt → bump the higher level.** It's free to publish a "1.7.0" that
+turned out to be PATCH-equivalent; it's expensive to publish "1.6.4"
+that was actually breaking.
+
+## When NOT to bump ([§1](Project/docs/MAINTENANCE.md))
+
+- Test-only changes that don't change production code
+- Pure documentation
+- `.gitignore` / dev-tooling tweaks (per [§3c](Project/docs/MAINTENANCE.md))
+- Anything not yet validated on a real Pi
+
+But — there's an explicit override now codified in
+[`CLAUDE.md`](CLAUDE.md):
+
+> If the user explicitly lists "bump version" in their instructions for
+> this PR, do it — do not skip citing §3c. The explicit instruction
+> overrides the test/doc-only exemption.
+
+So if your prompt says "branch, commit, push, PR, bump version", bump.
+
+## The release flow (full recipe in [`references/release-recipe.md`](references/release-recipe.md))
+
+```
+1. branch off main with <type>/<slug>
+2. make changes, commit conventionally
+3. push branch, open PR
+4. merge PR through GitHub UI
+5. on local main: git pull --ff-only
+6. bump Project/version.py     ← if this PR is release-bound
+7. git tag v<new_version>       ← still local; reversible
+8. git push origin v<new_version>   ← POINT OF NO RETURN
+```
+
+After step 8 the GitHub Actions release workflow builds the bundle
+(via [`scripts/release/build-bundle.sh`](scripts/release/build-bundle.sh)),
+creates the GitHub Release with the `.rrrupdate` + `.sha256` + `latest.json`
+assets attached, and devices on the stable channel see "Update available"
+in [`Project/ui/UpdatesTab.py`](Project/ui/UpdatesTab.py).
+
+## What the bundle contains
+
+`scripts/release/build-bundle.sh` runs `git archive HEAD Project scripts
+requirements.txt` and packs it as `rrr-<version>.rrrupdate` (tar.gz).
+That means:
+
+- Top-level `README.md`, `CLAUDE.md`, `install.sh`, `bootstrap.sh`, and
+  `legacy_installer/` are **not shipped** to devices via the update path.
+- `Project/settings/settings.json`, `*.db`, and `.DS_Store` are stripped
+  even if you accidentally tracked them.
+- The bundle reflects committed state, not your working tree. **Always
+  commit before tagging.**
+
+## When something goes wrong
+
+`references/recovery-recipes.md` covers:
+
+- mis-tagged commit, tag not yet pushed → just retag locally
+- pushed a bad tag, CI rejected → delete the local + remote tag, fix,
+  retry
+- a bad release IS published → bump and ship a fix; don't try to
+  unpublish
+- CI says "tag does not match" → re-read [§6.4](Project/docs/MAINTENANCE.md#64-ci-rejected-the-tag-with-tag-does-not-match-projectversionpy)
+
+## Hard rules
+
+- Pull `main` before tagging. `git tag` is silent about which commit
+  it marks; on a stale `main` you tag the wrong commit and CI rejects
+  it ([§6.2](Project/docs/MAINTENANCE.md#62-you-pushed-a-bad-tag-no-release-exists-yet-ci-rejected-it)).
+- Never amend a pushed commit; never force-push to `main`. If a hook
+  rejects a commit, fix the issue and create a NEW commit.
+- Never ship updates via `git pull` to a device. Tagged GitHub Releases
+  are the only supported channel; CI owns `dist/`.
+- Never tag a commit whose Tests workflow is red. The release workflow
+  itself doesn't gate on it, so this is a discipline rule, not a CI rule.
+- Never publish a release that hasn't been validated on a real Pi
+  (§1, rule above).

--- a/.claude/skills/release-and-versioning/references/recovery-recipes.md
+++ b/.claude/skills/release-and-versioning/references/recovery-recipes.md
@@ -1,0 +1,91 @@
+# Recovery recipes
+
+When a release goes sideways. Full procedures live in
+[MAINTENANCE.md §6](Project/docs/MAINTENANCE.md#6-recovery-procedures);
+this file is a fast index.
+
+## I tagged the wrong commit (tag not yet pushed)
+
+Easy. Tags are local until pushed. Delete and re-tag.
+
+```bash
+git tag -d v1.7.0                 # remove local
+git checkout <correct-commit>
+git tag v1.7.0
+```
+
+See [§6.1](Project/docs/MAINTENANCE.md#61-you-tagged-the-wrong-commit--tag-not-yet-pushed).
+
+## I pushed a bad tag and CI rejected it (no Release exists)
+
+Common cause: `Project/version.py` says `1.6.3` but you tagged `v1.6.4`.
+Fix:
+
+```bash
+git tag -d v1.6.4                       # delete locally
+git push origin :refs/tags/v1.6.4       # delete from remote
+# fix version.py or pick a different tag, commit, then retag
+```
+
+`refs/tags/v1.6.4` is the explicit ref-name form — required for delete.
+See [§6.2](Project/docs/MAINTENANCE.md#62-you-pushed-a-bad-tag-no-release-exists-yet-ci-rejected-it).
+
+## A bad release IS published and devices may have it
+
+**Don't try to unpublish.** Devices may already have downloaded the
+bundle, and `latest.json` on a future request from a slow device might
+still point at the bad version.
+
+Instead, ship a fix forward:
+
+1. Bump `Project/version.py` (PATCH if the fix is small).
+2. Cut a new release with the corrected behavior.
+3. Devices on the bad release will hit it within the polling window
+   (default 1 h, see `Project/utils/updater.py`).
+4. The boot sentinel in
+   [`scripts/runtime/launch.sh`](scripts/runtime/launch.sh) auto-rolls
+   back any release that fails to start twice — so a *truly* broken
+   release self-recovers without operator action.
+
+Full guidance: [§6.3](Project/docs/MAINTENANCE.md#63-a-bad-release-is-published-and-devices-may-have-it).
+
+## CI rejected: "tag does not match Project/version.py"
+
+The check in
+[`.github/workflows/release.yml`](.github/workflows/release.yml) lines
+27-33 enforces `tag == v<version>` byte-for-byte. Common gotchas:
+
+- Trailing whitespace in `version.py` (`__version__ = "1.6.4 "`).
+- Forgot to pull `main` before tagging → tagged an old commit whose
+  `version.py` is older than the new tag.
+- Bumped `version.py` on the branch but never merged it.
+
+Fix locally, delete + re-push the tag (see "bad tag" recipe above).
+[§6.4](Project/docs/MAINTENANCE.md#64-ci-rejected-the-tag-with-tag-does-not-match-projectversionpy).
+
+## The bundle won't download or verify on a device
+
+Symptoms: app says "checksum mismatch" or "download failed". Check:
+
+1. [`Project/utils/update_failure.py`](Project/utils/update_failure.py)
+   classifies the failure. `INTERNET` = network; `VERIFY` = checksum
+   or signature; `GENERIC` = anything else.
+2. The bundle's `.sha256` and the actual asset must agree —
+   `build-bundle.sh` writes both atomically, so a mismatch usually means
+   the upload to GitHub Release was partial. Solution: re-upload the
+   assets via `gh release upload` or cut a new release.
+3. If the bundle downloads but the signature is null in `latest.json`,
+   that's expected — signing is Phase 3 future work. The app does not
+   reject on null signature.
+
+[§6.5](Project/docs/MAINTENANCE.md#65-the-bundle-wont-download-or-verify-on-a-device).
+
+## A device got stuck on a bad release and rolled back
+
+The blue-green layout means `~/rrr/current` is a symlink. On two failed
+starts, [`scripts/runtime/launch.sh`](scripts/runtime/launch.sh) repoints
+it at `~/rrr/previous` and restarts. The operator sees the older version
+in the title bar — that's the rollback succeeding, not the bug.
+
+To recover forward, push a fixed release (see "bad release is published"
+above). The device will pick it up on the next polling cycle.

--- a/.claude/skills/release-and-versioning/references/release-recipe.md
+++ b/.claude/skills/release-and-versioning/references/release-recipe.md
@@ -1,0 +1,111 @@
+# Release recipe (the happy path)
+
+Step-by-step. Pause at the line marked "point of no return" before
+running it. Long form lives in
+[MAINTENANCE.md §3a](Project/docs/MAINTENANCE.md#3a-standard-release--code-change-shipping-to-devices).
+
+## 0. Decide if this is even a release-bound PR
+
+Read [MAINTENANCE.md §1](Project/docs/MAINTENANCE.md#1-when-to-release-and-when-not-to).
+If this is test-only, doc-only, or `.gitignore`-only and the user didn't
+ask for a bump, **stop here**. Land the PR with no version change.
+
+## 1. Branch & change
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git checkout -b <type>/<short-kebab-slug>   # feat/, fix/, chore/, etc.
+# … edit code …
+pytest                                      # green or new-test-passes
+```
+
+## 2. Conventional commit
+
+```bash
+git add <only-the-files-this-PR-touches>
+git commit -m "<type>(<scope>): <one-line subject>"
+```
+
+No `Co-Authored-By: Claude`, no Claude tagline. The body explains *why*
+(not *what*); for a release-bound subject include the target version,
+e.g. `feat(offline): … (Phase 3, v1.7.0)`.
+
+## 3. Push & open PR
+
+```bash
+git push -u origin <branch>
+# Open PR through GitHub UI or `gh pr create`
+```
+
+Wait for CI to go green. Review. Squash-merge through the GitHub UI.
+
+## 4. Sync local main
+
+```bash
+git checkout main
+git pull --ff-only origin main
+```
+
+This is the step where forgetting will tag the wrong commit. Don't skip it.
+
+## 5. Bump the version
+
+Edit [`Project/version.py`](Project/version.py) to the new `__version__`
+string. Commit:
+
+```bash
+git add Project/version.py
+git commit -m "chore(version): bump to v<new>"
+git push origin main
+```
+
+(Or fold the bump into the release-bound PR itself, before merging — the
+recent RRR convention is to bump in the same PR that introduces the
+behavior change. Either works as long as `main` has the bumped value at
+the moment you tag.)
+
+## 6. Tag locally (still reversible)
+
+```bash
+git tag v<new_version>
+git log -1 v<new_version>     # sanity: confirms tag points at HEAD
+```
+
+The tag must equal `v` + the exact string from `Project/version.py` —
+case sensitive, no extra whitespace.
+
+## 7. Push the tag — **point of no return**
+
+```bash
+git push origin v<new_version>
+```
+
+This kicks off [`.github/workflows/release.yml`](.github/workflows/release.yml):
+
+1. Verifies `tag == v<version>` (rejects otherwise).
+2. Runs `scripts/release/build-bundle.sh` to produce
+   `dist/rrr-<version>.rrrupdate`, `.sha256`, and `latest.json`.
+3. Creates the GitHub Release with those three assets attached.
+4. Marks pre-release if the tag has `-beta`.
+
+## 8. Verify on a device
+
+- Open the app's Updates tab (`Project/ui/UpdatesTab.py`).
+- It should show the new version as available within ~60 s of the
+  Release going live.
+- Apply, watch the boot sentinel
+  ([`scripts/runtime/launch.sh`](scripts/runtime/launch.sh)) NOT roll
+  back. If it rolls back twice in a row, devices are now on the previous
+  release — investigate via `~/rrr/state/boot.json`.
+
+## Anti-recipe — pre-release / beta
+
+For `1.7.0-beta` etc., everything's the same except:
+
+- `__version__ = "1.7.0-beta"` in `version.py`
+- Tag: `v1.7.0-beta`
+- GitHub flags it as pre-release
+- Stable-channel devices ignore it
+
+Full pre-release rules: [MAINTENANCE.md §2 "Pre-releases"](Project/docs/MAINTENANCE.md#pre-releases--170-beta).

--- a/.claude/skills/schedule-database-ops/SKILL.md
+++ b/.claude/skills/schedule-database-ops/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: schedule-database-ops
+description: Safely query and migrate the RRR SQLite database (rrr_database.db) — animals, schedules (staggered + instant + cycle tracking), dispensing history, system settings, valve calibration, cage naming, and trainers/login. Use when adding columns or tables, writing migrations, debugging schedule-creation, querying watering history, validating schedule assignments, or recovering from a corrupted settings state. Enforces the project's DatabaseHandler-only access rule and the idempotent-migration pattern.
+---
+
+# Schedule & database operations
+
+The RRR app persists everything to a single SQLite file. The database
+location follows the `RRR_DATA` environment contract — on an installed
+device it sits at `~/rrr/shared/data/rrr_database.db`; on a dev clone it
+falls back to `Project/rrr_database.db`. Path resolution is in
+[`Project/utils/paths.py`](Project/utils/paths.py) `database_path()`.
+
+## The hard rule
+
+**All database access goes through
+[`Project/models/database_handler.py`](Project/models/database_handler.py)
+`DatabaseHandler` (1989 LOC).** Never `import sqlite3` from UI, controller,
+or strategy code. Reasons:
+
+- `DatabaseHandler` owns connection lifecycle, schema versioning, FK
+  pragma, and error handling.
+- Tests inject a temp-dir-backed handler via the `database_handler` fixture
+  in [`Project/tests/unit/conftest.py`](Project/tests/unit/conftest.py).
+  A raw `sqlite3.connect` from a controller bypasses that and writes to
+  the real DB during tests.
+
+## Schema at a glance
+
+14 tables, FK-linked:
+
+```
+trainers ──< schedules ─┬─< schedule_animals >─── animals
+                        ├─< schedule_desired_outputs
+                        ├─< schedule_instant_deliveries >─ relay_units
+                        ├─< schedule_staggered_windows
+                        ├─< cycle_tracking
+                        └─< dispensing_history     (also FKs relay_units)
+
+trainers ──< logs
+
+system_settings   (k/v with type tag; standalone)
+valve_calibration / valve_calibration_history    (per-cage, FKs trainers)
+cage_names        (user-friendly names per cage_id)
+```
+
+Full column-level reference: [`references/schema.md`](references/schema.md).
+
+## Two delivery modes, two tables
+
+Schedules have a `delivery_mode` column:
+
+- `staggered` (default) → uses `schedule_desired_outputs` (per-animal
+  volume + interval) and `schedule_staggered_windows` (per-window
+  progress) and `cycle_tracking` (per-cycle progress).
+- `instant` → uses `schedule_instant_deliveries` (explicit
+  `delivery_datetime` rows, marked `completed BOOLEAN`).
+
+Both modes write to `dispensing_history` on every actual relay click —
+that's the audit log a researcher would query later.
+
+## Settings persistence (Phase 2.5a)
+
+`system_settings` is the live store for everything that used to live in
+the legacy `settings/settings.json`. It's a typed key-value table —
+[`Project/controllers/system_controller.py`](Project/controllers/system_controller.py)
+`SystemController` owns reads/writes via `_write_setting_to_db()` and
+`_load_database_settings()`. Type tags: `bool` / `int` / `float` / `str`
+/ `json` (lists and dicts go through JSON).
+
+A one-time legacy-JSON migration runs on first load and writes a sentinel
+row so it never runs twice. The pattern is tested in
+[`Project/tests/unit/test_settings_persistence.py`](Project/tests/unit/test_settings_persistence.py).
+
+## Idempotent schema (the contract)
+
+`DatabaseHandler.create_tables` is called on **every** app startup. It
+must therefore be safe to re-run:
+
+- Every `CREATE TABLE` uses `IF NOT EXISTS`.
+- Adding a column on an existing install uses the `PRAGMA table_info` →
+  `ALTER TABLE ADD COLUMN` pattern (see the `sex` column on `animals`
+  at [`database_handler.py:260-269`](Project/models/database_handler.py#L260-L269)).
+- Never drop a column. SQLite's `ALTER TABLE DROP COLUMN` is partial; for
+  RRR we mark columns deprecated in comments and leave them.
+
+Recipes for safe migrations: [`references/migration-recipes.md`](references/migration-recipes.md).
+
+## Common queries
+
+The patterns operators actually need (history per animal, schedules per
+trainer, today's deliveries, etc.) live in
+[`references/common-queries.md`](references/common-queries.md). All of
+them go through existing `DatabaseHandler` methods —
+**don't add a new method for a one-off query**; assemble from existing
+ones, or extend an existing method by a kwarg.
+
+## Don't do this
+
+- Don't open `sqlite3.connect(...)` outside `DatabaseHandler`.
+- Don't store secrets (`slack_token`, `slack_channel_id`) in
+  `system_settings`. Secrets live in `secrets.json` at `paths.secrets_path()`.
+  See [`Project/utils/secrets.py`](Project/utils/secrets.py).
+- Don't commit the `.db` file. `.gitignore` excludes `*.db` and
+  `build-bundle.sh` strips it from release bundles — keep it that way.
+- Don't write a destructive migration without a sentinel — if it runs
+  twice, it must be a no-op.
+- Don't `DROP TABLE` or `DELETE FROM <table>` without a `WHERE`. There's
+  no migration framework here; once you've shipped a bad migration,
+  recovery is manual.
+
+## When testing
+
+Use the `database_handler` fixture
+([`conftest.py:36`](Project/tests/unit/conftest.py#L36)). It builds a
+fresh handler against `RRR_DATA = <tmp_path>/data` via `monkeypatch.setenv`,
+so every test gets a pristine SQLite file. The `system_controller` fixture
+layers `SystemController` on top.

--- a/.claude/skills/schedule-database-ops/references/common-queries.md
+++ b/.claude/skills/schedule-database-ops/references/common-queries.md
@@ -1,0 +1,116 @@
+# Common queries
+
+Recipes operators and developers actually need. All go through existing
+`DatabaseHandler` methods — find one before writing a new one.
+
+## "Show me all schedules I authored"
+
+```python
+schedules = db.get_schedules_by_trainer(trainer_id)
+# returns list of Schedule objects with delivery_mode, status, animal IDs
+# implementation: database_handler.py:631
+```
+
+## "What's the dispensing history for a specific animal?"
+
+There's no direct method. The canonical pattern is to pull the animal,
+then walk schedules:
+
+```python
+# Higher-level query — preferred path
+for sched in db.get_all_schedules():
+    progress = db.get_schedule_progress(sched.schedule_id)
+    # progress is a dict keyed by animal_id with delivered_volume, status
+```
+
+`get_schedule_progress` is at [`database_handler.py:1320`](Project/models/database_handler.py#L1320).
+If you genuinely need a flat `dispensing_history` query, add a method on
+`DatabaseHandler` — don't run raw SQL from the UI.
+
+## "What's running right now?"
+
+```python
+active = db.get_active_schedules()
+# returns rows where dispensing_status = 'active'
+# implementation: database_handler.py:960
+```
+
+## "Get all pending instant deliveries"
+
+```python
+pending = db.get_pending_schedule_instants(schedule_id=None)
+# schedule_id=None returns across all schedules
+# rows have delivery_id, animal_id, delivery_datetime, water_volume,
+# relay_unit_id, completed (always 0 here)
+# implementation: database_handler.py:1005
+```
+
+After firing, mark complete:
+
+```python
+db.mark_instant_completed(instant_id, volume_dispensed)
+# database_handler.py:1036
+```
+
+## "What's the calibration for cage 7?"
+
+```python
+cal = db.get_valve_calibration(cage_id=7)
+# returns dict with pulse_width_ms, volume_per_pulse_ml, stddev, etc.
+# or None if cage was never calibrated.
+# implementation: database_handler.py:1618
+```
+
+## "Read a system setting"
+
+Always through `SystemController`, never directly. The controller handles
+type tagging and merges secrets from `secrets.json`:
+
+```python
+num_hats = system_controller.settings.get('num_hats', 1)  # in-memory cache
+# To force a fresh read from DB:
+system_controller.load_settings()
+```
+
+## "Write a system setting"
+
+```python
+system_controller.save_settings({'num_hats': 4, 'theme': 'dark'})
+# Only managed keys get persisted; unknown keys are dropped silently.
+# Managed-key list is the union of:
+#   - _create_default_settings() keys
+#   - _SECRET_KEYS (routed to secrets.json instead of DB)
+```
+
+The persist path is in
+[`Project/controllers/system_controller.py`](Project/controllers/system_controller.py)
+`save_settings()` (L37) → `_save_database_settings()` → `_write_setting_to_db()`.
+
+## "Authenticate a user"
+
+```python
+trainer = db.authenticate_trainer(username, password)
+# returns dict {trainer_id, trainer_name, role} on success, None on failure
+# database_handler.py:704
+```
+
+## "Add a new schedule"
+
+```python
+schedule_id = db.add_schedule(schedule)        # staggered (default)
+# or for instant mode:
+schedule_id = db.add_instant_schedule(schedule_name, created_by,
+                                       is_super_user, deliveries)
+# implementations: database_handler.py:349 and :1071
+```
+
+## Cage names for the UI dropdown
+
+```python
+opts = db.get_cages_for_dropdown(num_hats=1, master_relay=16)
+# returns [{'cage_id': N, 'display_name': str}, ...]
+# database_handler.py:1932
+```
+
+`master_relay` excludes the master valve from the dropdown so operators
+can't accidentally assign animals to it.

--- a/.claude/skills/schedule-database-ops/references/migration-recipes.md
+++ b/.claude/skills/schedule-database-ops/references/migration-recipes.md
@@ -1,0 +1,124 @@
+# Migration recipes
+
+The RRR project has **no migration framework**. Schema changes go in
+`DatabaseHandler.create_tables`, which runs on every app startup. The
+recipes below are the patterns proven safe across upgrade paths.
+
+## Recipe 1 — Add a new table
+
+Append to `create_tables` with `IF NOT EXISTS`. Safe to re-run; safe on
+older installs that lack the table.
+
+```python
+cursor.execute('''
+    CREATE TABLE IF NOT EXISTS my_new_table (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        ...
+    )
+''')
+```
+
+## Recipe 2 — Add a column to an existing table
+
+SQLite can't conditionally `ADD COLUMN`, so probe with `PRAGMA table_info`
+first. Reference implementation: the `sex` column added to `animals` at
+[`database_handler.py:260-269`](Project/models/database_handler.py#L260-L269).
+
+```python
+cursor.execute("PRAGMA table_info(animals)")
+columns = [col[1] for col in cursor.fetchall()]
+
+if 'sex' not in columns:
+    cursor.execute('''
+        ALTER TABLE animals
+        ADD COLUMN sex TEXT CHECK(sex IN ('male', 'female')) DEFAULT NULL
+    ''')
+```
+
+Rules:
+
+- New columns **must** be nullable or have a `DEFAULT` — otherwise the
+  migration fails on rows that already exist.
+- Don't combine "create table if not exists" + "add column" for the same
+  column; only the `PRAGMA` path handles both new and existing installs
+  correctly.
+
+## Recipe 3 — One-time data migration with a sentinel
+
+For data fixups that should run exactly once across the lifetime of a
+device — e.g. the legacy `settings.json` → `system_settings` migration in
+[`Project/controllers/system_controller.py`](Project/controllers/system_controller.py).
+
+```python
+SENTINEL_KEY = '_migrated_legacy_settings_v1'
+
+# Read sentinel
+already_done = db.get_system_settings().get(SENTINEL_KEY) == 'true'
+if already_done:
+    return
+
+# Do the migration (idempotently if possible)
+migrate_legacy(...)
+
+# Write sentinel
+db.update_system_setting(SENTINEL_KEY, 'true', 'bool')
+```
+
+Tested in
+[`Project/tests/unit/test_settings_persistence.py::test_migration_writes_sentinel_even_with_no_legacy_file`](Project/tests/unit/test_settings_persistence.py).
+
+The sentinel uses a leading underscore so it sorts above operator-visible
+keys when someone browses `system_settings` by hand.
+
+## Recipe 4 — Backfill computed values
+
+When you add a column whose value should be derived from existing rows
+(e.g. `volume_per_interval = desired_output / N`), backfill in the same
+startup pass right after the `ALTER TABLE`:
+
+```python
+if 'volume_per_interval' not in columns:
+    cursor.execute('ALTER TABLE schedule_desired_outputs ADD COLUMN volume_per_interval REAL')
+    cursor.execute('''
+        UPDATE schedule_desired_outputs
+        SET volume_per_interval = desired_output * 1.0 / NULLIF(...interval_count..., 0)
+        WHERE volume_per_interval IS NULL
+    ''')
+```
+
+Use `NULLIF(x, 0)` to avoid divide-by-zero, and `WHERE col IS NULL` so
+the backfill is idempotent.
+
+## What NOT to do
+
+- **Never `DROP TABLE`** in `create_tables`. Once a table has shipped,
+  it's permanent. Rename the table conceptually; leave the row format.
+- **Never `DROP COLUMN`** without a sentinel. SQLite supports
+  `ALTER TABLE … DROP COLUMN` only since 3.35; the Pi may run older
+  versions, and there's no safe rollback.
+- **Never write a migration without a test.** Add a case to
+  `test_settings_persistence.py` (or a sibling) that asserts the new
+  column/table exists and the backfill produced the right values.
+- **Never change column types in place.** If you must change a type,
+  create a new column, backfill, and stop reading the old one — but leave
+  the old column in the schema as deprecated. SQLite's column-rename
+  path is fragile.
+
+## Testing a migration
+
+The `database_handler` fixture in
+[`Project/tests/unit/conftest.py`](Project/tests/unit/conftest.py) builds
+a fresh handler against a tmp directory, so every test runs the migration
+on a clean DB. To test the "existing install" path, write a pre-migration
+state first:
+
+```python
+def test_my_migration_adds_column(database_handler):
+    # Force a pre-migration state by manually executing a CREATE TABLE
+    # that lacks the new column, then re-instantiate DatabaseHandler to
+    # trigger create_tables again.
+    ...
+```
+
+In practice you'll only need this for non-trivial migrations; for a
+plain `ADD COLUMN` the default fixture is enough.

--- a/.claude/skills/schedule-database-ops/references/schema.md
+++ b/.claude/skills/schedule-database-ops/references/schema.md
@@ -1,0 +1,161 @@
+# Schema reference
+
+Authoritative source: [`Project/models/database_handler.py`](Project/models/database_handler.py)
+`create_tables` (line 24). This file is a fast lookup; if it disagrees with
+`create_tables`, the code wins.
+
+## trainers (L60)
+
+| col | type | notes |
+|---|---|---|
+| `trainer_id` | INTEGER PRIMARY KEY AUTOINCREMENT | |
+| `trainer_name` | TEXT UNIQUE NOT NULL | login identifier |
+| `salt` | TEXT NOT NULL | per-user salt |
+| `password` | TEXT NOT NULL | hash (not plaintext) |
+| `role` | TEXT DEFAULT 'normal' | `'normal'` or `'super'` |
+
+## animals (L71)
+
+| col | type | notes |
+|---|---|---|
+| `animal_id` | INTEGER PRIMARY KEY AUTOINCREMENT | |
+| `lab_animal_id` | TEXT UNIQUE NOT NULL | operator-facing ID |
+| `name` | TEXT NOT NULL | |
+| `initial_weight` | REAL | grams |
+| `last_weight` | REAL | grams |
+| `last_weighted` | TEXT | ISO datetime |
+| `last_watering` | TEXT | ISO datetime |
+| `last_water_volume` | REAL | mL |
+| `trainer_id` | INTEGER → trainers | owner |
+| `sex` | TEXT CHECK IN ('male','female') | added via ALTER on existing installs |
+
+## relay_units (L88)
+
+| col | type | notes |
+|---|---|---|
+| `relay_unit_id` | INTEGER PRIMARY KEY AUTOINCREMENT | |
+| `relay_ids` | TEXT NOT NULL | JSON list of physical relay numbers |
+
+## schedules (L96)
+
+| col | type | notes |
+|---|---|---|
+| `schedule_id` | INTEGER PRIMARY KEY AUTOINCREMENT | |
+| `name` | TEXT NOT NULL | |
+| `water_volume` | REAL NOT NULL | mL — total per animal across schedule |
+| `start_time` | TEXT NOT NULL | ISO datetime |
+| `end_time` | TEXT NOT NULL | ISO datetime |
+| `created_by` | INTEGER → trainers | author |
+| `is_super_user` | BOOLEAN DEFAULT 0 | |
+| `delivery_mode` | TEXT DEFAULT 'staggered' | `'staggered'` or `'instant'` |
+| `dispensing_status` | TEXT DEFAULT 'pending' | `'pending'` / `'active'` / `'completed'` / `'failed'` |
+
+## schedule_animals (L112)
+
+Junction. PRIMARY KEY (schedule_id, animal_id).
+
+| col | type | notes |
+|---|---|---|
+| `schedule_id` | INTEGER → schedules | |
+| `animal_id` | INTEGER → animals | |
+| `relay_unit_id` | INTEGER → relay_units | nullable; set at execution time |
+
+## schedule_desired_outputs (L125, staggered mode)
+
+Per-animal target. PRIMARY KEY (schedule_id, animal_id).
+
+| col | type | notes |
+|---|---|---|
+| `desired_output` | REAL NOT NULL | mL total |
+| `interval_minutes` | INTEGER DEFAULT 60 | between deliveries |
+| `volume_per_interval` | REAL | computed = desired_output / N intervals |
+
+## schedule_instant_deliveries (L139, instant mode)
+
+| col | type | notes |
+|---|---|---|
+| `delivery_id` | INTEGER PRIMARY KEY AUTOINCREMENT | |
+| `delivery_datetime` | TEXT NOT NULL | scheduled wallclock |
+| `water_volume` | REAL NOT NULL | mL |
+| `relay_unit_id` | INTEGER → relay_units | nullable |
+| `completed` | BOOLEAN DEFAULT 0 | flipped by `mark_instant_completed` |
+
+## schedule_staggered_windows (L167)
+
+Per-window state for staggered mode.
+
+| col | type | notes |
+|---|---|---|
+| `window_id` | INTEGER PRIMARY KEY AUTOINCREMENT | |
+| `start_time` / `end_time` | TEXT | ISO |
+| `target_volume` | REAL NOT NULL | mL |
+| `delivered_volume` | REAL DEFAULT 0 | running total |
+| `status` | TEXT DEFAULT 'pending' | `'pending'` / `'active'` / `'completed'` |
+
+## cycle_tracking (L183)
+
+Per-cycle progress within a staggered window.
+
+| col | type | notes |
+|---|---|---|
+| `tracking_id` | INTEGER PRIMARY KEY | |
+| `cycle_index` | INTEGER NOT NULL | 0-based |
+| `target_volume` / `delivered_volume` | REAL | |
+| `status` | TEXT DEFAULT 'pending' | |
+| `completed_at` | TEXT | ISO when status flipped to completed |
+
+## dispensing_history (L37)
+
+Append-only audit log; one row per relay click that actually delivered.
+
+| col | type | notes |
+|---|---|---|
+| `history_id` | INTEGER PRIMARY KEY AUTOINCREMENT | |
+| `timestamp` | TEXT NOT NULL | ISO |
+| `volume_dispensed` | REAL NOT NULL | mL |
+| `status` | TEXT NOT NULL | typically `'completed'` or error code |
+| `cycle_index` | INTEGER | nullable; populated for staggered cycles |
+
+## logs (L155)
+
+| col | type | notes |
+|---|---|---|
+| `log_id` | INTEGER PK AUTOINCREMENT | |
+| `timestamp` / `action` / `details` | TEXT | |
+| `super_user_id` | INTEGER → trainers | |
+
+## system_settings (L201) — Phase 2.5a typed K/V
+
+| col | type | notes |
+|---|---|---|
+| `setting_key` | TEXT PRIMARY KEY | |
+| `setting_value` | TEXT NOT NULL | stringified value |
+| `setting_type` | TEXT NOT NULL | `'bool'` / `'int'` / `'float'` / `'str'` / `'json'` |
+| `updated_at` | TEXT NOT NULL | ISO |
+
+## valve_calibration (L211) and valve_calibration_history (L229)
+
+Per-cage pulse-to-volume calibration. The non-`_history` table holds the
+current calibration; every save also appends to history.
+
+| col | type | notes |
+|---|---|---|
+| `cage_id` | INTEGER UNIQUE | live table; not unique in history |
+| `relay_id` | INTEGER | physical relay |
+| `pulse_width_ms` | INTEGER | pulse duration |
+| `volume_per_pulse_ml` | REAL | empirical |
+| `stddev_ml` / `coefficient_of_variation_pct` | REAL | quality metrics |
+| `num_samples` | INTEGER | calibration trial count |
+| `calibration_date` | TEXT | ISO |
+| `calibrated_by` | INTEGER → trainers | |
+| `notes` | TEXT | |
+
+## cage_names (L250)
+
+| col | type | notes |
+|---|---|---|
+| `cage_id` | INTEGER PRIMARY KEY | |
+| `relay_id` | INTEGER NOT NULL | physical |
+| `name` | TEXT NOT NULL DEFAULT '' | operator-friendly |
+| `description` | TEXT DEFAULT '' | |
+| `created_at` / `updated_at` | TEXT NOT NULL | ISO |

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.6.4"
+__version__ = "1.6.5"


### PR DESCRIPTION
Adds 6 skill directories (21 files total) describing the live architecture of RRR for AI assistants and onboarding:

  hardware-gpio-debug       relay HAT, I2C, mock seam, threading
  pyqt5-ui-conventions      tab tree, signals/slots, dialogs, login gate
  schedule-database-ops     DatabaseHandler, 14-table schema, migrations
  release-and-versioning    version.py source of truth, tag = v<ver>
  device-installer          scripts/install/[0-9][0-9]-*.sh modules
  flow-delivery-strategies  Strategy protocol, solenoid vs pump

Skills cite real file paths and line numbers from current main (post-Phase-1 deletions). No code changes.

Documentation-only; PATCH per the bump-every-PR rule in CLAUDE.md.