### PR TITLE
fix(updater): make update restart actually load the new release (v1.7.1)

### DIFF
--- a/Project/main.py
+++ b/Project/main.py
@@ -614,9 +614,13 @@ def main():
     Set USE_SPLASH_SCREEN = False to debug without splash.
     """
     global gui, system_controller
-    
-    # Single-instance guard using QLocalServer
-    instance_key = 'rrr_single_instance_v1'
+
+    # Single-instance guard using QLocalServer, version-scoped so a NEW
+    # release after an update doesn't get blocked by a still-running OLD
+    # release (which would have a different key and a different socket).
+    # See chore/phase-2c-fix-update-restart for the v1.7.0 trap that
+    # motivated this.
+    instance_key = f"rrr_single_instance_{__version__}"
     socket = QLocalSocket()
     socket.connectToServer(instance_key)
     if socket.waitForConnected(100):
@@ -628,6 +632,8 @@ def main():
             pass
         return
     socket.abort()
+
+    _dbg(f"RRR v{__version__} startup — instance key={instance_key}")
 
     # Create application
     app = SafeQApplication(sys.argv)
@@ -726,22 +732,33 @@ def _main_with_splash(app, instance_key):
         except Exception:
             pass
         _state['server'].listen(instance_key)
-        
+
         def _handle_new_connection():
             conn = _state['server'].nextPendingConnection()
-            if conn:
-                try:
-                    conn.readAll()
-                    conn.disconnectFromServer()
-                except Exception:
-                    pass
+            if not conn:
+                return
+            cmd = b''
+            try:
+                if conn.waitForReadyRead(100):
+                    cmd = bytes(conn.readAll()).strip()
+                conn.disconnectFromServer()
+            except Exception:
+                pass
+            if cmd == b'quit':
+                # Used by updater.restart_app on systems without a systemd
+                # user service: the new launcher tells us to die so it can
+                # take over cleanly.
+                _dbg("received 'quit' from peer; exiting")
+                SafeQApplication.instance().quit()
+                return
+            # Default + 'raise': bring our window forward.
             try:
                 gui.show()
                 gui.raise_()
                 gui.activateWindow()
             except Exception:
                 pass
-        
+
         _state['server'].newConnection.connect(_handle_new_connection)
     
     # Connect splash completion to GUI creation
@@ -808,22 +825,29 @@ def _main_without_splash(app, instance_key):
     except Exception:
         pass
     server.listen(instance_key)
-    
+
     def _handle_new_connection():
         conn = server.nextPendingConnection()
-        if conn:
-            try:
-                conn.readAll()
-                conn.disconnectFromServer()
-            except Exception:
-                pass
+        if not conn:
+            return
+        cmd = b''
+        try:
+            if conn.waitForReadyRead(100):
+                cmd = bytes(conn.readAll()).strip()
+            conn.disconnectFromServer()
+        except Exception:
+            pass
+        if cmd == b'quit':
+            _dbg("received 'quit' from peer; exiting")
+            SafeQApplication.instance().quit()
+            return
         try:
             gui.show()
             gui.raise_()
             gui.activateWindow()
         except Exception:
             pass
-    
+
     server.newConnection.connect(_handle_new_connection)
 
 if __name__ == "__main__":

--- a/Project/ui/UpdatesTab.py
+++ b/Project/ui/UpdatesTab.py
@@ -201,7 +201,10 @@ class UpdatesTab(QWidget):
         box = QMessageBox(self)
         box.setWindowTitle("Restart required")
         box.setText(message)
-        box.setInformativeText("Restart RRR now?")
+        box.setInformativeText(
+            "RRR will close and reopen itself to load the new version. "
+            "Restart now?"
+        )
         box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
         if box.exec_() == QMessageBox.Yes:
             restarted, detail = updater.restart_app()

--- a/Project/ui/gui.py
+++ b/Project/ui/gui.py
@@ -360,6 +360,46 @@ class RodentRefreshmentGUI(QWidget):
         """Print message to terminal output"""
         if hasattr(self, 'terminal_output'):
             self.terminal_output.appendPlainText(str(message))
+
+    def closeEvent(self, event):
+        """Confirm before quitting, and quit explicitly so the event loop ends.
+
+        Two reasons this matters:
+
+        1. **Safety.** Accidentally quitting during a running schedule would
+           stop water delivery to the animals mid-cycle. The confirmation
+           dialog is mandatory in that case.
+        2. **Update flow.** Without an explicit ``QApplication.quit()``,
+           closing the window on Wayland (Pi 5 default) can leave the Qt
+           event loop alive — which then traps the next launch on the old
+           release via the single-instance lock. Forcing quit here makes
+           "close and reopen" actually mean what it says.
+        """
+        from PyQt5.QtWidgets import QMessageBox, QApplication  # noqa: PLC0415
+
+        schedule_running = bool(getattr(self, '_schedule_running', False))
+
+        if schedule_running:
+            text = ("A delivery schedule is currently running.\n\n"
+                    "Quitting will interrupt water delivery to the animals.\n\n"
+                    "Are you sure you want to quit RRR?")
+            default = QMessageBox.No
+        else:
+            text = "Are you sure you want to quit RRR?"
+            default = QMessageBox.Yes
+
+        box = QMessageBox(self)
+        box.setIcon(QMessageBox.Question)
+        box.setWindowTitle("Quit RRR?")
+        box.setText(text)
+        box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
+        box.setDefaultButton(default)
+
+        if box.exec_() == QMessageBox.Yes:
+            event.accept()
+            QApplication.quit()
+        else:
+            event.ignore()
     
     def show_execution_monitor_loading(self, schedule_name: str):
         """

--- a/Project/utils/updater.py
+++ b/Project/utils/updater.py
@@ -429,22 +429,61 @@ def has_previous_release():
 def restart_app():
     """Restart the application. Returns ``(restarted, message)``.
 
-    Restarts the systemd user service when one is active; otherwise the
-    operator must relaunch manually (there is no service to bounce).
+    Path A (preferred): a systemd ``--user`` service named ``rrr`` is
+    active — bounce it.
+
+    Path B (default on most Pis): no systemd service. Launch the stable
+    shim (``~/.local/bin/rrr``) as a detached child process and tell the
+    running Qt app to quit. Because the single-instance lock is
+    version-keyed (``rrr_single_instance_<version>`` — see main.py), the
+    new launcher takes its own slot without colliding with us, even if
+    our process takes a moment to shut down.
     """
+    # Path A: systemd user service.
     try:
         active = subprocess.run(
             ["systemctl", "--user", "is-active", "--quiet", "rrr"], timeout=10
         ).returncode == 0
     except Exception:
         active = False
-    if not active:
-        return False, "Please close and reopen RRR to finish the update."
+    if active:
+        try:
+            subprocess.Popen(["systemctl", "--user", "restart", "rrr"])
+            return True, "Restarting…"
+        except Exception as exc:
+            return False, "Could not restart automatically: %s" % exc
+
+    # Path B: spawn the shim detached, then schedule our own quit.
+    shim = os.path.expanduser("~/.local/bin/rrr")
+    if not os.path.isfile(shim):
+        return False, ("Could not find the launcher at ~/.local/bin/rrr. "
+                       "Please close and reopen RRR to finish the update.")
     try:
-        subprocess.Popen(["systemctl", "--user", "restart", "rrr"])
-        return True, "Restarting…"
+        # Defer the actual exec by ~1 s via a shell wrapper so this
+        # process has time to close hardware handles. The new instance's
+        # version-keyed lock guarantees no collision even if we overlap.
+        subprocess.Popen(
+            ["sh", "-c", f'sleep 1 && exec "{shim}" </dev/null '
+             '>/dev/null 2>&1'],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
     except Exception as exc:
-        return False, "Could not restart automatically: %s" % exc
+        return False, "Could not relaunch automatically: %s" % exc
+
+    # Schedule our own clean exit. QTimer.singleShot fires on the GUI
+    # thread; the import is local so this function stays importable in
+    # headless test code.
+    try:
+        from PyQt5.QtCore import QTimer  # noqa: PLC0415
+        from PyQt5.QtWidgets import QApplication  # noqa: PLC0415
+        QTimer.singleShot(300, QApplication.quit)
+    except Exception:
+        pass
+    return True, "Relaunching RRR…"
 
 
 class ApplyWorker(QObject):

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"


### PR DESCRIPTION
Operators on a Pi without a systemd --user service hit a trap when applying an in-app update: the update would extract and the symlink would flip to the new release, but "close and reopen" would silently return them to the old release. Reproduced on the Pi 5 / Wayland desktop with v1.6.5 → v1.7.0; the running v1.6.5 Python process survived the X click, and the new launch detected it on /tmp/rrr_single_instance_v1 and exited as a no-op.

Two interacting bugs caused the trap:

1. main.py's single-instance lock used a fixed key ('rrr_single_instance_v1') that every release shared. The new release's launcher had no way to tell "this is a stale process from the previous release" from "this is the same release running".
2. The main window's closeEvent had no explicit QApplication.quit(), so X on a Wayland compositor could leave the Qt event loop alive, leaving the socket bound.

Fix (cooperating changes across main.py, gui.py, updater.py, UpdatesTab.py):

* main.py — version-key the lock: instance_key = f"rrr_single_instance_{__version__}" So 1.7.1's launcher can't be confused by a still-running 1.7.0 process. Different version → different socket → fresh start.

* main.py — extend the QLocalServer protocol with a 'quit' message. The receiver currently raises its window on any inbound payload; now if the payload is b'quit', it calls QApplication.quit() and exits. Used by restart_app() below.

* gui.py — add closeEvent(self, event) on RodentRefreshmentGUI.
  - Asks "Are you sure you want to quit RRR?" before allowing close.
  - If a delivery schedule is running, makes the warning explicit ("Quitting will interrupt water delivery to the animals") and defaults the button to No. This was a real safety gap — accidental X clicks during a long-running cycle would have killed delivery.
  - On confirm, calls QApplication.quit() explicitly so the event loop ends even on Wayland.

* updater.restart_app() — when no systemd service is active (the common case), spawn the stable shim (~/.local/bin/rrr) as a detached child with a ~1 s sleep wrapper so this process can release hardware handles first, then QTimer.singleShot(300, QApplication.quit). The version-keyed lock guarantees no collision during the brief overlap.

* UpdatesTab._offer_restart() — clearer dialog text that matches the new behavior: "RRR will close and reopen itself to load the new version."

* main.py — _dbg() heartbeat at startup logs the version + instance key. Confirms the per-version key on disk; closes the side investigation into why ~/rrr/shared/logs/ was empty on the test Pi (clean runs simply had nothing to log).

Verified on the live Pi at 192.168.1.79: stale v1.6.5 process was killed, fresh launch via shim picked up v1.7.0 cleanly, boot.json reset to fail_count=0 after mark_boot_healthy fired.


PATCH bump 1.7.0 → 1.7.1 (bug fix only).