### PR TITLE
fix(ui): hard-block quit while a delivery is running (v1.7.2)

### DIFF
--- a/Project/ui/gui.py
+++ b/Project/ui/gui.py
@@ -362,38 +362,57 @@ class RodentRefreshmentGUI(QWidget):
             self.terminal_output.appendPlainText(str(message))
 
     def closeEvent(self, event):
-        """Confirm before quitting, and quit explicitly so the event loop ends.
+        """Confirm before quitting; HARD-BLOCK while a delivery is running.
 
-        Two reasons this matters:
+        Three behaviors:
 
-        1. **Safety.** Accidentally quitting during a running schedule would
-           stop water delivery to the animals mid-cycle. The confirmation
-           dialog is mandatory in that case.
-        2. **Update flow.** Without an explicit ``QApplication.quit()``,
-           closing the window on Wayland (Pi 5 default) can leave the Qt
-           event loop alive — which then traps the next launch on the old
-           release via the single-instance lock. Forcing quit here makes
-           "close and reopen" actually mean what it says.
+        1. **Delivery running** — refuse to quit. Show an OK-only dialog
+           directing the operator to the Stop button. Animals depend on
+           the worker thread completing its cycle; an accidental close
+           would interrupt water delivery mid-pour. Operator must
+           explicitly Stop before quitting.
+        2. **Idle** — confirm with a simple Yes/No (default Yes).
+        3. On any confirmed quit, call ``QApplication.quit()`` explicitly
+           so the Qt event loop ends even on Wayland (Pi 5 default). This
+           also keeps the in-app update restart path working — see
+           ``utils.updater.restart_app``.
+
+        The busy check uses :func:`utils.updater.is_busy`, which is wired
+        at startup to the actual ``RelayWorker`` thread state, not the
+        UI's lagging ``_schedule_running`` flag. The UI flag is consulted
+        only as a fallback if the updater module isn't importable.
         """
         from PyQt5.QtWidgets import QMessageBox, QApplication  # noqa: PLC0415
 
-        schedule_running = bool(getattr(self, '_schedule_running', False))
+        try:
+            from utils import updater  # noqa: PLC0415
+            delivery_running = updater.is_busy()
+        except Exception:
+            delivery_running = bool(getattr(self, '_schedule_running', False))
 
-        if schedule_running:
-            text = ("A delivery schedule is currently running.\n\n"
-                    "Quitting will interrupt water delivery to the animals.\n\n"
-                    "Are you sure you want to quit RRR?")
-            default = QMessageBox.No
-        else:
-            text = "Are you sure you want to quit RRR?"
-            default = QMessageBox.Yes
+        if delivery_running:
+            # HARD BLOCK — no Yes/No, no escape. Operator must Stop first.
+            box = QMessageBox(self)
+            box.setIcon(QMessageBox.Warning)
+            box.setWindowTitle("Cannot quit — delivery in progress")
+            box.setText("A delivery schedule is currently running.")
+            box.setInformativeText(
+                "Click the <b>Stop</b> button to end the schedule before "
+                "quitting RRR.<br><br>"
+                "Quitting now would interrupt water delivery to the animals."
+            )
+            box.setStandardButtons(QMessageBox.Ok)
+            box.exec_()
+            event.ignore()
+            return
 
+        # Idle — simple confirm.
         box = QMessageBox(self)
         box.setIcon(QMessageBox.Question)
         box.setWindowTitle("Quit RRR?")
-        box.setText(text)
+        box.setText("Are you sure you want to quit RRR?")
         box.setStandardButtons(QMessageBox.Yes | QMessageBox.No)
-        box.setDefaultButton(default)
+        box.setDefaultButton(QMessageBox.Yes)
 
         if box.exec_() == QMessageBox.Yes:
             event.accept()

--- a/Project/utils/updater.py
+++ b/Project/utils/updater.py
@@ -177,6 +177,22 @@ def set_busy_check(fn):
     _busy_check = fn
 
 
+def is_busy():
+    """Public, defensive wrapper around the registered busy-check.
+
+    Returns True iff the registered check says a delivery worker is active.
+    Used by the GUI's ``closeEvent`` to hard-block quit while a schedule is
+    running. Defensive about both shapes of failure: the check not being
+    registered yet (returns False — never falsely block) and the check
+    itself raising (returns False — same reasoning, safer to let the user
+    quit than to permanently trap them).
+    """
+    try:
+        return bool(_busy_check())
+    except Exception:
+        return False
+
+
 def _sha256_file(path):
     digest = hashlib.sha256()
     with open(path, "rb") as handle:

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"


### PR DESCRIPTION
Closes a safety gap in the closeEvent introduced in v1.7.1. Before this change, X-clicking the window during a running schedule showed a "Quitting will interrupt water delivery — are you sure?" Yes/No confirmation. An operator could still click Yes and kill delivery mid-cycle.

New behavior: if a delivery is in progress, the X click cannot quit at all. The operator sees an OK-only message directing them to the Stop button. To quit, they must explicitly Stop the schedule first. This is the right primitive for a lab-animal water-delivery system: never let an accidental click interrupt a cycle.

The busy check uses ``utils.updater.is_busy()`` (new public wrapper around the existing ``_busy_check`` already wired to the actual ``RelayWorker`` thread state via ``set_busy_check`` in main.setup()). That's the authoritative source — the UI's ``_schedule_running`` flag lags briefly during start/stop and can drift on worker crash. The UI flag is consulted only as a fallback if the updater module is unimportable (paranoid; should never happen in practice).

Idle behavior unchanged: simple "Are you sure you want to quit RRR?" Yes/No, default Yes.

PATCH 1.7.1 -> 1.7.2 (safety fix only).