### PR TITLE
docs(comments): trim stale test-file refs from production code

### DIFF
--- a/Project/drivers/teensy_serial_protocol.py
+++ b/Project/drivers/teensy_serial_protocol.py
@@ -4,7 +4,7 @@ Teensy Serial Protocol for SLF3S-0600F Flow Sensor
 ==================================================
 
 Canonical implementation of serial communication with Teensy 4.1 flow sensor bridge.
-Based on validated test_sensor_wiring.py implementation (99% frame delivery).
+Validated against hardware-bench tests at 99% frame-delivery rate.
 
 Hardware References:
 - Teensy 4.1: https://www.pjrc.com/store/teensy41.html
@@ -21,7 +21,7 @@ Serial Protocol:
 - Commands: {"cmd": "start|stop|status|ping|reset", "rate": float}
 - Responses: {"type": "measurement|error|status|pong", ...}
 
-Best Practices (from test_sensor_wiring.py):
+Best Practices (validated against hardware):
 1. Wait 3.5s after serial.Serial() for Teensy USB CDC enumeration (Pi-specific)
 2. Flush input buffer before sending commands to avoid stale data
 3. Allow 100ms+ after "start" command before expecting first measurement
@@ -56,7 +56,7 @@ class TeensySerialProtocol:
     """
     Serial communication protocol for Teensy 4.1 + SLF3S-0600F flow sensor.
     
-    Implements best practices validated in test_sensor_wiring.py (99% frame delivery).
+    Implements best practices validated against hardware (99% frame delivery).
     Thread-safe for background reading. Handles USB CDC enumeration delays.
     
     Usage:
@@ -103,7 +103,7 @@ class TeensySerialProtocol:
         """
         Establish serial connection to Teensy.
         
-        Implements best practices from test_sensor_wiring.py:
+        Implements best practices validated against hardware:
         - Extended wait for Teensy USB CDC enumeration
         - Ping test to verify connection before proceeding
         
@@ -286,7 +286,7 @@ class TeensySerialProtocol:
         """
         Read one JSON message from Teensy.
         
-        Implements best practices from test_sensor_wiring.py:
+        Implements best practices validated against hardware:
         - Handles newline-delimited JSON
         - Validates JSON before returning
         - Returns None on timeout (not an error)

--- a/Project/ui/CalibrationWizard.py
+++ b/Project/ui/CalibrationWizard.py
@@ -45,12 +45,12 @@ class CalibrationWizard(QDialog):
         """
         super().__init__(parent)
         
-        # CRITICAL: Use default QDialog behavior - don't modify window flags!
-        # The working test_dialog_crash.py proves this is all we need:
-        # - Default QDialog is already a proper child dialog
-        # - Has close button by default
-        # - Won't trigger app quit when closed
-        # - Doesn't need WA_DeleteOnClose flag
+        # CRITICAL: Use default QDialog behavior — don't modify window flags.
+        # Default QDialog is already a proper child dialog with a close
+        # button, won't trigger app quit when closed, and doesn't need
+        # WA_DeleteOnClose. Setting custom flags here previously caused
+        # the wizard to crash the parent app on close; the simpler default
+        # is correct.
         
         # Set modal to block interaction with parent while wizard is open
         self.setModal(True)

--- a/Project/utils/pulse_calibration.py
+++ b/Project/utils/pulse_calibration.py
@@ -16,7 +16,7 @@ Architecture:
 - PulseCalibrator: Runs characterization tests
 - UI Integration: Button in Priming tab
 
-Reference: test_valve_characterization.py
+Originally derived from the valve-characterization bench tests.
 """
 
 from __future__ import annotations
@@ -240,7 +240,7 @@ class PulseCalibrator:
     Runs pulse characterization tests to measure valve behavior.
     
     Best Practices:
-    - Reuse existing code: Leverage test_valve_characterization.py logic
+    - Reuse existing code: built on the valve-characterization bench-test logic
     - Progress reporting: Emit signals for UI updates
     - Fail-safe: Continue if individual tests fail
     - Idempotent: Can run multiple times safely
@@ -341,7 +341,7 @@ class PulseCalibrator:
         """
         Calibrate a single pulse width.
         
-        Logic from test_valve_characterization.py Test 4.
+        Logic adapted from the valve-characterization bench tests (Test 4).
         """
         volumes = []
         


### PR DESCRIPTION
Three production files cited hardware-diagnostic test scripts as if they were authoritative implementation references — inviting future readers to chase dead breadcrumbs into Project/tests/test_*.py (which are operator-diagnostic CLIs, not authoritative spec).

Rewords without changing semantics:

- ui/CalibrationWizard.py:49 — drop "test_dialog_crash.py proves this"; keep the actual rule (use default QDialog, no custom window flags, it crashed the parent app before this fix).
- drivers/teensy_serial_protocol.py — 5 occurrences across module docstring, class docstring, and method docstrings of "from test_sensor_wiring.py" → "validated against hardware".
- utils/pulse_calibration.py — 3 occurrences of "test_valve_ characterization.py" → "valve-characterization bench tests".

Intent preserved (the code was validated against real hardware bench runs); just no longer pretends a diagnostic CLI is the spec.

No version bump (comments-only per MAINTENANCE.md §1 / §3c).