### PR TITLE
refactor(updater): collapse UpdateNotifier dual path (v1.7.4)

### DIFF
--- a/Project/main.py
+++ b/Project/main.py
@@ -812,10 +812,10 @@ def _main_without_splash(app, instance_key):
     # Check for updates
     try:
         from ui.update_notifier import UpdateNotifier
-        UpdateNotifier.check_for_updates()
+        UpdateNotifier.check_for_updates(gui)
     except Exception:
         pass
-    
+
     gui.show()
     
     # Local server

--- a/Project/ui/update_notifier.py
+++ b/Project/ui/update_notifier.py
@@ -1,139 +1,33 @@
-"""Update notifications.
+"""Update notification entry point.
 
-Two things live here:
+Single responsibility: on launch, ask GitHub whether a newer release
+exists. If so, the GUI shows a dismissable banner; an offline device
+silently gets no banner. See docs/UPDATE_SYSTEM.md.
 
-1. The startup *update check* (Phase 1 of the update system) — on launch it
-   asks GitHub whether a newer release exists and, if so, shows a dismissable
-   banner on the main window. See docs/UPDATE_SYSTEM.md.
+main.py calls :meth:`UpdateNotifier.check_for_updates` with the main
+window after the GUI is created.
 
-2. A legacy local "UI Improvements Applied" dialog driven by a ``ui_updated.json``
-   file. This predates the update system; it is kept for backward
-   compatibility and is a candidate for removal once unused.
-
-main.py calls :meth:`UpdateNotifier.check_for_updates` (with the main window)
-after the GUI is created.
+The pre-update-system "UI Improvements Applied" dialog driven by a
+local ``ui_updated.json`` file was removed in v1.7.4 — confirmed
+unused on the deployed fleet.
 """
-
-import os
-import json
-
-from PyQt5.QtWidgets import (
-    QDialog, QVBoxLayout, QLabel, QPushButton, QScrollArea, QWidget
-)
 
 from utils.updater import run_check
 
 
 class UpdateNotifier:
-    """Update notifications: GitHub release check + legacy local changelog."""
+    """Thin entry point for the GitHub release update check."""
 
     @classmethod
-    def check_for_updates(cls, gui=None):
-        """Run update checks. Safe to call unconditionally.
+    def check_for_updates(cls, gui):
+        """Start a background GitHub release check.
 
-        - Always runs the legacy local-changelog check.
-        - When ``gui`` is given, also starts a background GitHub release
-          check; if a newer version exists, ``gui`` shows an update banner.
-          An offline device silently gets no banner.
+        If a newer version exists, ``gui`` shows an update banner via
+        its ``_on_update_check_result`` callback. An offline device
+        silently gets no banner. Update checks must never interfere
+        with app startup, so all failures are swallowed.
         """
-        cls._check_local_changelog()
-
-        if gui is None:
-            return
         try:
             run_check(gui, gui._on_update_check_result)
         except Exception:
-            # An update check must never interfere with app startup.
             pass
-
-    # ------------------------------------------------------------------
-    # Legacy: local "UI Improvements Applied" dialog (pre-update-system).
-    # ------------------------------------------------------------------
-    @classmethod
-    def _check_local_changelog(cls):
-        """Show the legacy changelog dialog if ui_updated.json flags an update."""
-        update_file = os.path.join(
-            os.path.dirname(os.path.dirname(__file__)), 'ui_updated.json'
-        )
-        if not os.path.exists(update_file):
-            return
-
-        try:
-            with open(update_file, 'r') as f:
-                update_data = json.load(f)
-
-            if update_data.get('updated', False):
-                cls.show_update_notification(update_data)
-
-                # Reset the flag so the dialog shows only once.
-                update_data['updated'] = False
-                with open(update_file, 'w') as f:
-                    json.dump(update_data, f, indent=4)
-        except Exception as e:
-            print(f"Error checking for UI updates: {e}")
-
-    @staticmethod
-    def show_update_notification(update_data):
-        """Show a nicely formatted dialog with legacy update information."""
-        dialog = QDialog()
-        dialog.setWindowTitle("UI Improvements Applied")
-        dialog.setMinimumWidth(400)
-        dialog.setMinimumHeight(300)
-
-        layout = QVBoxLayout()
-
-        # Title
-        title_label = QLabel("UI Improvements Applied")
-        title_label.setStyleSheet("""
-            font-size: 16px;
-            font-weight: bold;
-            color: #1a73e8;
-            margin-bottom: 10px;
-        """)
-        layout.addWidget(title_label)
-
-        # Date
-        date_label = QLabel(f"Updated on: {update_data.get('date', 'Unknown')}")
-        date_label.setStyleSheet("font-style: italic; color: #5f6368;")
-        layout.addWidget(date_label)
-
-        # Create scrollable area for changes
-        scroll_area = QScrollArea()
-        scroll_area.setWidgetResizable(True)
-        scroll_content = QWidget()
-        scroll_layout = QVBoxLayout(scroll_content)
-
-        # Add change list
-        changes_label = QLabel("Changes:")
-        changes_label.setStyleSheet("font-weight: bold; margin-top: 10px;")
-        scroll_layout.addWidget(changes_label)
-
-        for change in update_data.get('changes', []):
-            change_item = QLabel(f"• {change}")
-            change_item.setWordWrap(True)
-            scroll_layout.addWidget(change_item)
-
-        scroll_layout.addStretch()
-        scroll_area.setWidget(scroll_content)
-        layout.addWidget(scroll_area)
-
-        # OK button
-        ok_button = QPushButton("OK")
-        ok_button.clicked.connect(dialog.accept)
-        ok_button.setStyleSheet("""
-            QPushButton {
-                background-color: #1a73e8;
-                color: white;
-                border: none;
-                border-radius: 4px;
-                padding: 8px 16px;
-                font-size: 14px;
-            }
-            QPushButton:hover {
-                background-color: #1658c5;
-            }
-        """)
-        layout.addWidget(ok_button)
-
-        dialog.setLayout(layout)
-        dialog.exec_()

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.7.3"
+__version__ = "1.7.4"


### PR DESCRIPTION
UpdateNotifier carried two parallel notification paths:

1. The active path — startup GitHub release check via utils.updater.run_check, shows a banner on the main window.
2. A legacy local-changelog dialog driven by a project-relative ui_updated.json file. Predates the update system; no deployed device has ever had the file (confirmed). Pure dead code.

Remove the legacy branch and everything that supported it: the _check_local_changelog classmethod, the show_update_notification dialog builder, and the os/json/QDialog/QVBoxLayout/QLabel/QPushButton/ QScrollArea/QWidget imports that existed only to render that dialog.

The remaining UpdateNotifier is a 12-line thin entry point that delegates the actual work to utils.updater.run_check.

Drive-by fix discovered while tracing callers: main.py:815 (the ACTIVE non-splash startup path, since USE_SPLASH_SCREEN=False) was calling `UpdateNotifier.check_for_updates()` without a `gui` argument. The old behavior was "only the legacy local-changelog branch runs in this path"; removing that branch would have silently dropped the GitHub update check from the active startup. Pass `gui` so the GitHub check actually runs.

Update_notifier.py: 140 -> 32 lines.
main.py:        -2 +2 (just the gui argument).

PATCH 1.7.3 -> 1.7.4.