### PR TITLE
fix(ui): refresh Cages tab on Change Relay Hats without restart (v1.7.5)

### DIFF
--- a/Project/main.py
+++ b/Project/main.py
@@ -509,12 +509,12 @@ def stop_program():
 # change_relay_hats() and helpers
 # =============================================================================
 def change_relay_hats():
-    """Persist a new hat count and re-sync the hardware layer.
+    """Persist a new hat count, re-sync the hardware layer, refresh UI.
 
-    Wired to the "Change Relay Hats" button in RunStopSection. Updates
-    settings + hardware layer; the UI does not currently auto-refresh on
-    hat-count change, so operators may need to restart the app to see
-    the new count reflected in the Cages tab — a deliberate deferral.
+    Wired to the "Change Relay Hats" button in RunStopSection. Order
+    matters: hardware first (so the new layout is live before any UI
+    queries it), persist, release stale handles, refresh the Cages tab
+    so the operator sees the new count immediately without a restart.
     """
     global relay_handler, app_settings
     num_hats, ok = QInputDialog.getInt(None, "Number of Relay Hats",
@@ -527,6 +527,12 @@ def change_relay_hats():
     relay_handler.update_relay_units(relay_unit_manager.get_all_relay_units(), num_hats)
     system_controller.save_settings(app_settings)
     cleanup()
+    # Refresh hat-count-aware UI. Defensive about attribute access in
+    # case the projects section hasn't built its cages tab yet.
+    try:
+        gui.projects_section.cages_tab.refresh()
+    except Exception as exc:
+        gui.print_to_terminal(f"Cages tab refresh failed: {exc}")
     gui.print_to_terminal(f"Relay hats updated to {num_hats} hats.")
 
 def create_relay_pairs(num_hats):

--- a/Project/ui/cages_visualization_tab.py
+++ b/Project/ui/cages_visualization_tab.py
@@ -489,5 +489,16 @@ class CagesVisualizationTab(QWidget):
             self._print_to_terminal(f"[CagesTab] Save error: {e}")
     
     def refresh(self) -> None:
-        """Reload cage data."""
+        """Re-read settings, then reload cage data.
+
+        Pulls ``num_hats`` and ``global_master_relay_id`` fresh from
+        ``system_controller.settings`` so that "Change Relay Hats"
+        actually reflects in the status label and the cages query.
+        Without this re-read the cached values from ``__init__`` would
+        keep the old count visible until the next app launch.
+        """
+        if self._system_controller and hasattr(self._system_controller, 'settings'):
+            settings = self._system_controller.settings
+            self._num_hats = int(settings.get('num_hats', self._num_hats))
+            self._master_relay = int(settings.get('global_master_relay_id', self._master_relay))
         self._load_cage_data()

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.7.4"
+__version__ = "1.7.5"


### PR DESCRIPTION
Closes the known limitation documented in change_relay_hats()'s v1.6.4 docstring: the operator had to close + reopen RRR to see a new hat count reflected in the Cages tab. Settings + hardware sync worked correctly, only the UI lagged.

Two coordinated changes:

main.py - after save_settings + cleanup, call
gui.projects_section.cages_tab.refresh(). Defensive about the attribute access (try/except prints to terminal) in case the projects section hasn't built its cages tab yet — should never happen in the live app but the cheap guard is worth the line.

ui/cages_visualization_tab.py - extend refresh() to re-read num_hats and global_master_relay_id from system_controller.settings before reloading. The cached values from __init__ would otherwise keep the old count in the status label even after a fresh _load_cage_data() call.

The drop-stale-comment in change_relay_hats() is also worth noting: the docstring no longer claims "needs restart". After this PR, it genuinely does not.

PATCH 1.7.4 -> 1.7.5.