### PR TITLE
fix(ui): wire system_controller through ProjectsSection (v1.7.6)

### DIFF
--- a/Project/tests/unit/test_gui_smoke.py
+++ b/Project/tests/unit/test_gui_smoke.py
@@ -82,13 +82,19 @@ def test_ui_module_imports(qapp, modname):
     importlib.import_module(modname)
 
 
-def test_projects_section_constructs(qapp, database_handler):
+def test_projects_section_constructs(qapp, database_handler, system_controller):
     """``ProjectsSection`` builds and exposes the four live tabs.
 
     Pins the contract main.py and SettingsTab rely on: ``schedules_tab``
     is a ``SchedulesHub``, ``animals_tab`` an ``AnimalsTab``,
     ``wizard_tab`` a ``WizardTab``, ``cages_tab`` a
     ``CagesVisualizationTab``.
+
+    Also asserts ``cages_tab._system_controller`` is the same instance
+    that was passed in — guards against the Phase 3.4 regression where
+    ``gui.py`` forgot to forward ``system_controller`` to
+    ``ProjectsSection``, leaving ``CagesVisualizationTab.refresh()`` a
+    silent no-op that fell back to ``num_hats=1``.
     """
     from models.login_system import LoginSystem  # noqa: PLC0415
     from ui.animals_tab import AnimalsTab  # noqa: PLC0415
@@ -103,9 +109,14 @@ def test_projects_section_constructs(qapp, database_handler):
         print_to_terminal=lambda _msg: None,
         database_handler=database_handler,
         login_system=login_system,
+        system_controller=system_controller,
     )
 
     assert isinstance(section.schedules_tab, SchedulesHub)
     assert isinstance(section.animals_tab, AnimalsTab)
     assert isinstance(section.wizard_tab, WizardTab)
     assert isinstance(section.cages_tab, CagesVisualizationTab)
+
+    # Phase 3.4a contract: system_controller propagates to cages_tab.
+    # Without this, refresh() falls back silently to num_hats=1.
+    assert section.cages_tab._system_controller is system_controller

--- a/Project/ui/gui.py
+++ b/Project/ui/gui.py
@@ -106,12 +106,17 @@ class RodentRefreshmentGUI(QWidget):
         # This is adjusted dynamically when switching to Execution Monitor
         left_layout.setStretch(0, 1)  # Terminal area (compact by default)
         
-        # Projects section with login gate
+        # Projects section with login gate.
+        # system_controller is required for hat-count-aware refresh
+        # paths inside CagesVisualizationTab and ScheduleCreationWizard.
+        # Forgetting to pass it caused the Phase 3.4 "Change Relay Hats"
+        # refresh to silently no-op (the tab fell back to num_hats=1).
         self.projects_section = ProjectsSection(
             self.settings,
             self.print_to_terminal,
             self.database_handler,
-            self.login_system
+            self.login_system,
+            system_controller=self.system_controller,
         )
         self.login_gate = LoginGateWidget(self.projects_section, self.login_system)
         left_layout.addWidget(self.login_gate)

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.7.5"
+__version__ = "1.7.6"


### PR DESCRIPTION
Phase 3.4a of the multi-hat repair. gui.py was constructing ProjectsSection without forwarding self.system_controller. The parameter is optional with a None default, so this silently dropped on the floor every release — making CagesVisualizationTab's system_controller-gated code paths permanently dead.

Concrete impact this unblocks:

The Phase 3.4 (v1.7.5) refresh() code in CagesVisualizationTab was guarded by `if self._system_controller and hasattr(...)`. Because system_controller was always None in the live app, the body never ran, num_hats stayed at the __init__ default of 1, and the "Change Relay Hats" terminal log proved it: "Initialized default cage names for 1 HAT(s)" after a 1→2 change. With this PR, the guard passes and the refresh actually reads settings.

This PR does NOT fix the deeper bugs:
- RelayUnitManager still ignores num_hats when cage_relays is populated (bug to be fixed in 3.4b).
- CagesVisualizationTab still hard-codes a 16-relay 2-col board (bug to be fixed in 3.4c).

But it's the precondition for both of those to be testable.

Smoke test extension: assert
`section.cages_tab._system_controller is system_controller`. Locks the contract so a future refactor that forgets the kwarg fails CI.

PATCH 1.7.5 -> 1.7.6.