### PR TITLE
fix(safety): hardware-first stop sequence (v1.8.1)

### DIFF
--- a/Project/main.py
+++ b/Project/main.py
@@ -20,6 +20,7 @@ from ui.SettingsTab import SettingsTab
 from ui.style.theme import StyleManager
 from version import __version__
 from utils import updater
+from utils import stop_sequence
 
 # =============================================================================
 # Global exception hook and stream redirection (unchanged)
@@ -445,42 +446,50 @@ def cleanup():
 # =============================================================================
 # stop_program() – called when the user clicks "Stop."
 # =============================================================================
+def _show_stopping_dialog():
+    """Modal indeterminate progress dialog while the worker tears down.
+
+    Shown then ``processEvents()`` is pumped so it actually paints before
+    the (briefly) blocking wait. No cancel button — Stop must complete.
+    The safety-critical *ordering* lives in utils.stop_sequence; this is
+    only the Qt presentation piece, injected as a dialog factory.
+    Returns None if Qt isn't available.
+    """
+    try:
+        from PyQt5.QtWidgets import QProgressDialog  # noqa: PLC0415
+        from PyQt5.QtCore import Qt  # noqa: PLC0415
+        dialog = QProgressDialog(
+            "Stopping schedule…\nHardware is safe; closing the worker.",
+            None, 0, 0,
+        )
+        dialog.setWindowTitle("Stopping")
+        dialog.setWindowModality(Qt.ApplicationModal)
+        dialog.setCancelButton(None)
+        dialog.setMinimumDuration(0)
+        dialog.show()
+        QApplication.processEvents()
+        return dialog
+    except Exception:
+        return None
+
+
 def stop_program():
+    """Stop the active delivery. Wired to RunStopSection's Stop button.
+
+    Thin wrapper around :func:`utils.stop_sequence.execute_stop_sequence`
+    that supplies the module-level worker / thread / handler globals and
+    the Qt dialog factory. The safety-critical ordering and bounded-wait
+    policy live in that module so they can be unit-tested without Qt or
+    hardware. See the v1.8.0 incident write-up there.
+    """
     global thread, worker, relay_handler
     try:
-        print("[DEBUG] Starting stop sequence")
-        
-        # Safely request worker stop
-        if worker:
-            try:
-                control_signals.stop_requested.emit()
-                print("[DEBUG] Worker stop() called")
-            except RuntimeError:
-                print("[DEBUG] Worker already deleted")
-        
-        # Safely handle thread stop
-        if thread is not None:
-            try:
-                if hasattr(thread, 'isRunning') and callable(getattr(thread, 'isRunning', None)):
-                    if thread.isRunning():
-                        if not thread.wait(2000):
-                            print("[DEBUG] Thread timeout - forcing termination")
-                            thread.terminate()
-                        thread.wait()
-                        print("[DEBUG] Thread stopped")
-            except RuntimeError:
-                print("[DEBUG] Thread already deleted")
-        
-        if relay_handler:
-            relay_handler.set_all_relays(0)
-            print("[DEBUG] All relays deactivated")
-        
-        # We do not explicitly call cleanup() here; it will be called by worker.finished.
-        print("[DEBUG] Stop sequence completed successfully")
-        return True
-    except Exception as e:
-        print(f"[ERROR] Stop sequence failed: {e}")
-        import traceback
+        return stop_sequence.execute_stop_sequence(
+            relay_handler, worker, thread, control_signals,
+            dialog_factory=_show_stopping_dialog,
+        )
+    except Exception as exc:
+        print(f"[ERROR] Stop sequence failed: {exc}")
         traceback.print_exc()
         return False
 

--- a/Project/tests/unit/test_stop_sequence.py
+++ b/Project/tests/unit/test_stop_sequence.py
@@ -1,0 +1,167 @@
+"""Tests for the safety-critical stop sequence (utils.stop_sequence).
+
+Regression coverage for the v1.8.0 incident: an operator pressed Stop
+mid-delivery, the GUI deadlocked on an unbounded ``thread.wait()`` after
+a ``terminate()`` that never took, and the hardware failsafe (which ran
+last) was never reached — leaving the master solenoid energized.
+
+These tests are deliberately Qt-free and hardware-free: the module under
+test takes all collaborators as injected mocks, so the ordering contract
+can be asserted on any machine without PyQt5 or a relay HAT.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from utils import stop_sequence
+
+
+def _make_signals():
+    signals = MagicMock()
+    signals.stop_requested = MagicMock()
+    return signals
+
+
+# ---------------------------------------------------------------------------
+# The core safety invariant
+# ---------------------------------------------------------------------------
+
+def test_hardware_safe_runs_before_any_thread_interaction():
+    """``set_all_relays(0)`` must fire before the thread is waited on.
+
+    The whole incident was caused by the failsafe running *after* a
+    blocking wait. A shared call-order recorder proves the ordering.
+    """
+    order = []
+    handler = MagicMock()
+    handler.set_all_relays.side_effect = lambda *_a: order.append("relays_off")
+
+    thread = MagicMock()
+    thread.isRunning.return_value = True
+    thread.wait.side_effect = lambda *_a: order.append("thread_wait") or True
+
+    worker = MagicMock()
+    signals = _make_signals()
+    signals.stop_requested.emit.side_effect = lambda: order.append("stop_emit")
+
+    stop_sequence.execute_stop_sequence(handler, worker, thread, signals)
+
+    assert order, "nothing happened"
+    assert order[0] == "relays_off", f"hardware not first: {order}"
+    assert order.index("relays_off") < order.index("thread_wait")
+
+
+def test_thread_wait_is_always_bounded():
+    """Every ``thread.wait`` call must carry a positive timeout.
+
+    Guards against the exact v1.8.0 bug: ``thread.wait()`` with no arg
+    blocks the GUI thread forever when ``terminate()`` doesn't take.
+    """
+    handler = MagicMock()
+    thread = MagicMock()
+    thread.isRunning.return_value = True
+    # Clean-exit wait times out -> escalate to terminate, then wait again.
+    thread.wait.return_value = False
+    worker = MagicMock()
+
+    stop_sequence.execute_stop_sequence(handler, worker, thread, _make_signals())
+
+    assert thread.wait.call_count >= 1
+    for call in thread.wait.call_args_list:
+        args = call.args
+        assert args, f"thread.wait() called with no timeout: {call}"
+        assert args[0] > 0, f"thread.wait() called with non-positive timeout: {call}"
+
+
+def test_terminate_called_when_clean_exit_times_out():
+    handler = MagicMock()
+    thread = MagicMock()
+    thread.isRunning.return_value = True
+    thread.wait.return_value = False  # never exits cleanly
+    worker = MagicMock()
+
+    stop_sequence.execute_stop_sequence(handler, worker, thread, _make_signals())
+
+    thread.terminate.assert_called_once()
+
+
+def test_clean_exit_skips_terminate():
+    handler = MagicMock()
+    thread = MagicMock()
+    thread.isRunning.return_value = True
+    thread.wait.return_value = True  # exits cleanly on first wait
+    worker = MagicMock()
+
+    stop_sequence.execute_stop_sequence(handler, worker, thread, _make_signals())
+
+    thread.terminate.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Defensive scope: hardware safe even when nothing is running
+# ---------------------------------------------------------------------------
+
+def test_hardware_safe_called_even_with_no_worker_or_thread():
+    """Pressing Stop with no active schedule still drops all relays."""
+    handler = MagicMock()
+    stop_sequence.execute_stop_sequence(handler, None, None, _make_signals())
+    handler.set_all_relays.assert_called_once_with(0)
+
+
+def test_no_handler_does_not_raise():
+    # No relay handler wired yet (early startup); must not blow up.
+    stop_sequence.execute_stop_sequence(None, None, None, _make_signals())
+
+
+# ---------------------------------------------------------------------------
+# force_hardware_safe_state isolation
+# ---------------------------------------------------------------------------
+
+def test_force_hardware_safe_state_returns_true_on_success():
+    handler = MagicMock()
+    assert stop_sequence.force_hardware_safe_state(handler) is True
+    handler.set_all_relays.assert_called_once_with(0)
+
+
+def test_force_hardware_safe_state_swallows_errors_returns_false():
+    handler = MagicMock()
+    handler.set_all_relays.side_effect = OSError("I2C bus error")
+    assert stop_sequence.force_hardware_safe_state(handler) is False
+
+
+def test_force_hardware_safe_state_none_handler_returns_false():
+    assert stop_sequence.force_hardware_safe_state(None) is False
+
+
+# ---------------------------------------------------------------------------
+# Dialog lifecycle
+# ---------------------------------------------------------------------------
+
+def test_dialog_is_closed_after_teardown():
+    handler = MagicMock()
+    dialog = MagicMock()
+    stop_sequence.execute_stop_sequence(
+        handler, None, None, _make_signals(),
+        dialog_factory=lambda: dialog,
+    )
+    dialog.close.assert_called_once()
+
+
+def test_dialog_closed_even_if_teardown_raises():
+    handler = MagicMock()
+    dialog = MagicMock()
+    thread = MagicMock()
+    thread.isRunning.side_effect = RuntimeError("boom")  # forces an error path
+    # RuntimeError is caught inside bounded_worker_teardown, but prove the
+    # dialog still closes regardless by making emit raise instead.
+    signals = _make_signals()
+    signals.stop_requested.emit.side_effect = ValueError("unexpected")
+    try:
+        stop_sequence.execute_stop_sequence(
+            handler, MagicMock(), thread, signals,
+            dialog_factory=lambda: dialog,
+        )
+    except ValueError:
+        pass
+    dialog.close.assert_called_once()

--- a/Project/utils/stop_sequence.py
+++ b/Project/utils/stop_sequence.py
@@ -1,0 +1,128 @@
+"""Safety-critical stop-sequence ordering for the Stop button.
+
+Deliberately **Qt-free** so the ordering contract can be unit-tested with
+plain mocks and no PyQt5 / hardware present. main.py supplies the real
+worker / thread / relay-handler globals and a Qt dialog factory; this
+module owns *only* the order of operations and the bounded-wait policy.
+
+Why this module exists (the v1.8.0 incident):
+
+An operator pressed Stop mid-delivery. The old ``stop_program`` emitted
+the worker-stop signal, then called ``thread.wait()`` with no timeout
+after ``terminate()``. The worker was inside an async C-extension call
+(asyncio + libserial), so ``terminate()`` never took, ``wait()`` blocked
+the GUI thread forever, and the hardware-failsafe line — which ran *last*
+— was never reached. The global master solenoid stayed energized with
+the cage valves closed: trapped line pressure, an unsafe state.
+
+The fix this module encodes:
+
+  1. **Hardware safe FIRST.** Drop every relay (master + cages) before
+     touching the worker thread at all. Even if teardown then hangs, the
+     hardware is already safe.
+  2. **Bounded waits only.** Never call ``thread.wait()`` without a
+     timeout. A thread that refuses to die is abandoned, not awaited
+     forever.
+
+See docs/MAINTENANCE.md §1 (delivery/relay bug → always release).
+"""
+
+from __future__ import annotations
+
+import traceback
+
+# How long to wait for a clean worker exit before escalating to
+# terminate(), and how long to wait for terminate() to take. Both bounded
+# — the GUI must never block indefinitely on Stop.
+CLEAN_EXIT_TIMEOUT_MS = 3000
+TERMINATE_TIMEOUT_MS = 1000
+
+
+def force_hardware_safe_state(handler) -> bool:
+    """Drop every relay (including the global master) immediately.
+
+    Runs FIRST in the stop sequence, before any thread coordination.
+    Idempotent. Logs but never raises — a failure here is the most
+    important thing the operator could see, so it must not be swallowed
+    into a generic stack unwind. Returns True on success, False on error
+    (or when there is no handler).
+    """
+    if handler is None:
+        return False
+    try:
+        handler.set_all_relays(0)
+        print("[STOP] HARDWARE SAFE: all relays off (master + cages)")
+        return True
+    except Exception as exc:
+        print(f"[STOP] CRITICAL: hardware safe-state call failed: {exc}")
+        traceback.print_exc()
+        return False
+
+
+def bounded_worker_teardown(worker_obj, thread_obj, signals) -> None:
+    """Signal the worker and wait briefly. Never block the GUI forever.
+
+    A. Emit ``stop_requested`` (delivered to the worker via QueuedConnection).
+    B. ``thread.wait(CLEAN_EXIT_TIMEOUT_MS)`` for a clean exit.
+    C. On timeout: ``terminate()`` then ``wait(TERMINATE_TIMEOUT_MS)``.
+    D. If that also times out: log and abandon. Hardware is already safe.
+
+    The bounded waits in C/D are the whole point — the v1.8.0 deadlock
+    was an unbounded ``wait()`` after a ``terminate()`` that never took.
+    """
+    if worker_obj is not None:
+        try:
+            signals.stop_requested.emit()
+            print("[DEBUG] Worker stop() requested")
+        except RuntimeError:
+            print("[DEBUG] Worker already deleted")
+
+    if thread_obj is None:
+        return
+    try:
+        is_running = getattr(thread_obj, "isRunning", None)
+        if not (callable(is_running) and is_running()):
+            return
+        if thread_obj.wait(CLEAN_EXIT_TIMEOUT_MS):
+            print("[DEBUG] Thread exited cleanly")
+            return
+        print(f"[STOP] Worker did not exit in {CLEAN_EXIT_TIMEOUT_MS}ms;"
+              " calling terminate()")
+        thread_obj.terminate()
+        if thread_obj.wait(TERMINATE_TIMEOUT_MS):
+            print("[DEBUG] Thread terminated cleanly")
+        else:
+            # NEVER wait() with no arg here — that's the v1.8.0 deadlock.
+            print("[STOP] terminate() did not take; abandoning thread"
+                  " (hardware already safe)")
+    except RuntimeError:
+        print("[DEBUG] Thread already deleted")
+
+
+def execute_stop_sequence(handler, worker_obj, thread_obj, signals,
+                          dialog_factory=None) -> bool:
+    """Run the stop sequence in the safety-critical order.
+
+    Contract (locked by tests/unit/test_stop_sequence.py):
+      1. ``handler.set_all_relays(0)`` is called BEFORE any thread wait
+         or terminate.
+      2. ``thread.wait`` is only ever called with a positive timeout.
+
+    ``dialog_factory`` (optional) returns an object with a ``close()``
+    method shown during teardown; it is always closed, even on error.
+    """
+    print("[DEBUG] Starting stop sequence")
+    force_hardware_safe_state(handler)
+
+    dialog = dialog_factory() if dialog_factory else None
+    try:
+        bounded_worker_teardown(worker_obj, thread_obj, signals)
+    finally:
+        if dialog is not None:
+            try:
+                dialog.close()
+            except Exception:
+                pass
+
+    print("[DEBUG] Stop sequence completed successfully")
+    return True

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"


### PR DESCRIPTION
CRITICAL. Fixes an unsafe-state bug found on the test Pi: an operator pressed Stop mid-delivery, the GUI froze completely, and the global master solenoid (HAT0 ch16) was left ENERGIZED while the cage valves were closed — trapped line pressure, the exact state the failsafe is meant to prevent. Confirmed via gdb: the main thread was blocked in the Stop button's clicked slot on PyThread_acquire_lock_timed.

Root cause (old stop_program in main.py):

  1. emit stop_requested (QueuedConnection)
  2. thread.wait(2000); on timeout -> thread.terminate(); thread.wait() ^ unbounded wait with NO timeout
  3. relay_handler.set_all_relays(0)   <- failsafe ran LAST

The worker was inside an async C-extension call (asyncio + pyserial), so QueuedConnection's stop slot never ran (the worker never returned to its Qt event loop) and terminate() never took. The unbounded wait() in step 2 then blocked the GUI thread forever, so step 3 was never reached.

Fix- reorder and bound:

  1. force_hardware_safe_state(handler): set_all_relays(0) FIRST, before any thread coordination. Even if teardown then hangs, hardware is already safe. Serialized with worker I2C writes by I2CCoordinator; idempotent; logs but never raises.
  2. bounded_worker_teardown(): emit stop, wait(3000) for clean exit, escalate to terminate()+wait(1000), then ABANDON. Never an unbounded wait().
  3. A modal "Stopping…" QProgressDialog (no cancel button) gives the operator feedback during the brief bounded wait.

Defensive: set_all_relays(0) runs on every Stop click regardless of worker state (idempotent ~10ms of I2C), so an operator can never leave anything energized.

Engineering: the safety-critical ORDERING lives in a new Qt-free, hardware-free module utils/stop_sequence.py so it is unit-testable with plain mocks on any machine. main.py keeps only the Qt dialog factory and a thin global-wiring wrapper. 11 new tests in test_stop_sequence.py lock the two invariants — (a) hardware-safe before any thread wait, (b) thread.wait is only ever called with a positive timeout — plus the defensive-scope and dialog-lifecycle behavior. These run in the suite everywhere (no PyQt5 needed): 21 -> 32 passing locally.

Follow-up v1.8.2 (Phase 3.4d.2) adds cooperative cancellation to the delivery strategy so the worker exits in <100ms and terminate() is essentially never needed. This PR makes Stop SAFE; the next makes it CLEAN.

PATCH 1.8.0 -> 1.8.1.