### PR TITLE
feat(safety): cooperative cancellation in delivery strategies (v1.8.2)

### DIFF
--- a/Project/gpio/relay_worker.py
+++ b/Project/gpio/relay_worker.py
@@ -877,10 +877,29 @@ class RelayWorker(QObject):
         """
         self.check_final_completion()
 
+    def request_cancel(self):
+        """Signal the active delivery strategy to cancel cooperatively.
+
+        Safe to call from the GUI thread (the strategy uses a
+        threading.Event). This is the path that actually breaks a
+        mid-delivery loop: the worker thread is blocked inside
+        run_until_complete and cannot process the queued stop() slot, so
+        the GUI thread must poke the strategy's cancel token directly.
+        Idempotent and defensive — a missing or method-less strategy is
+        a no-op.
+        """
+        strategy = getattr(self, 'strategy', None)
+        if strategy is not None and hasattr(strategy, 'request_cancel'):
+            try:
+                strategy.request_cancel()
+                print("[STOP] Cooperative cancel requested on strategy")
+            except Exception as exc:
+                print(f"[STOP] strategy.request_cancel() failed: {exc}")
+
     def stop(self):
         """
         Gracefully stop the schedule and clean up all resources.
-        
+
         Best Practices:
         - Idempotent: Safe to call multiple times
         - Comprehensive: Stop all timers, sensors, and valdves
@@ -888,6 +907,9 @@ class RelayWorker(QObject):
         - Fail-safe: Continue cleanup even if individual steps fail
         """
         print("\n[STOP] ========== SCHEDULE STOP SEQUENCE INITIATED ==========")
+        # Also fire cooperative cancel here for the case where stop() is
+        # reached via the normal queued path (worker not blocked).
+        self.request_cancel()
         
         with QMutexLocker(self.mutex):
             if not self._is_running:

--- a/Project/strategies/pump_strategy.py
+++ b/Project/strategies/pump_strategy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from typing import Optional
 
 
@@ -18,6 +19,16 @@ class PumpStrategy:
             raise ValueError("volume_calculator cannot be None")
         self._pump_controller = pump_controller
         self._volume_calculator = volume_calculator
+        # Symmetry with SolenoidFlowStrategy so the worker can call
+        # request_cancel() uniformly. A pump dispense is effectively
+        # atomic (a single PumpController call), so cancellation can only
+        # prevent a not-yet-started dispatch — there is no mid-flight
+        # loop to poll. Honest about that limitation.
+        self._cancel_event = threading.Event()
+
+    def request_cancel(self) -> None:
+        """Request cancellation. Prevents a not-yet-dispatched deliver()."""
+        self._cancel_event.set()
 
     async def deliver(
         self,
@@ -29,6 +40,13 @@ class PumpStrategy:
             raise ValueError("relay_unit_id is required")
         if target_volume_ml is None or target_volume_ml <= 0:
             raise ValueError("target_volume_ml must be positive")
+
+        # Fresh delivery: clear any stale cancellation from a prior run.
+        if self._cancel_event.is_set():
+            # Cancel arrived before we dispatched — honor it.
+            self._cancel_event.clear()
+            return False
+        self._cancel_event.clear()
 
         # Prefer caller-provided hint to preserve legacy scheduling semantics.
         triggers = (

--- a/Project/strategies/solenoid_flow_strategy.py
+++ b/Project/strategies/solenoid_flow_strategy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from dataclasses import dataclass
 from typing import Optional, Dict, Tuple
 
@@ -67,6 +68,15 @@ class SolenoidFlowStrategy:
         self._prime_ms = int(prime_ms)
         self._db = database_handler  # For per-valve calibration lookup
         self._logger = logging.getLogger(self.__class__.__name__)
+        # Cooperative-cancellation token. Set from the GUI thread by
+        # request_cancel() when the operator presses Stop; polled by the
+        # delivery loops after every await so they exit fast (and their
+        # finally-blocks close the master valve) instead of relying on
+        # the worker thread's Qt event loop — which is blocked inside
+        # run_until_complete and cannot process a queued stop slot. A
+        # threading.Event is used because the write crosses threads.
+        # See the v1.8.0 incident write-up in utils/stop_sequence.py.
+        self._cancel_event = threading.Event()
         # Per-run calibration snapshot (cage_id -> {pulse_width_ms: {id, volume_per_pulse_ml}})
         self._cal_snapshot: Dict[int, Dict[int, Dict[str, float]]] = {}
         
@@ -216,6 +226,18 @@ class SolenoidFlowStrategy:
         except Exception as e:
             self._logger.warning(f"Failed to build calibration snapshot: {e}")
 
+    def request_cancel(self) -> None:
+        """Request cooperative cancellation of an in-flight delivery.
+
+        Thread-safe; intended to be called from the GUI thread when the
+        operator presses Stop. The active delivery loop polls the token
+        after each await and bails into its valve-closing finally block.
+        """
+        self._cancel_event.set()
+
+    def _check_cancelled(self) -> bool:
+        return self._cancel_event.is_set()
+
     async def deliver(
         self,
         relay_unit_id: int,
@@ -224,11 +246,17 @@ class SolenoidFlowStrategy:
     ) -> bool:
         """
         Execute delivery using mode-specific logic.
-        
+
         Best Practice: Strategy Pattern - delegate to mode-specific methods
         """
         cage_id = int(relay_unit_id)
-        
+
+        # Fresh delivery: clear any stale cancellation from a prior run.
+        # Safe because a new deliver() only starts when the worker is
+        # still running; once Stop fires, the worker stops issuing new
+        # deliver() calls, so this never races a live cancel.
+        self._cancel_event.clear()
+
         # Route to mode-specific delivery method
         if self._use_pulse_mode:
             return await self._deliver_pulse_mode(cage_id, target_volume_ml)
@@ -427,6 +455,12 @@ class SolenoidFlowStrategy:
         last_log = start
         try:
             while True:
+                # Cooperative cancellation: operator pressed Stop. Bail into
+                # the finally block, which closes cage + master valves.
+                if self._check_cancelled():
+                    self._logger.info(f"Delivery cancelled for cage {cage_id}; closing valves")
+                    return False
+
                 # Read measurement with robust error handling (Sensirion best practices)
                 meas = await self._read_sensor_robust(cage_id, max_sensor_errors)
                 
@@ -515,6 +549,8 @@ class SolenoidFlowStrategy:
             residual_end = asyncio.get_event_loop().time() + (residual_check_ms / 1000.0)
             residual_flag = False
             while asyncio.get_event_loop().time() < residual_end:
+                if self._check_cancelled():
+                    return False
                 try:
                     if hasattr(self._sensor, 'read_one'):
                         meas = self._sensor.read_one()
@@ -645,6 +681,12 @@ class SolenoidFlowStrategy:
             await asyncio.sleep(0.3)  # Let manifold stabilize
             
             while delivered_ml < target_volume_ml:
+                # Cooperative cancellation: operator pressed Stop. Bail into
+                # the finally block, which closes cage + master valves.
+                if self._check_cancelled():
+                    self._logger.info(f"Pulse delivery cancelled for cage {cage_id}; closing valves")
+                    return False
+
                 # Check safety limits
                 if pulse_count >= max_pulses:
                     self._logger.error(f"Max pulses ({max_pulses}) reached, aborting")

--- a/Project/tests/unit/test_stop_sequence.py
+++ b/Project/tests/unit/test_stop_sequence.py
@@ -42,6 +42,7 @@ def test_hardware_safe_runs_before_any_thread_interaction():
     thread.wait.side_effect = lambda *_a: order.append("thread_wait") or True
 
     worker = MagicMock()
+    worker.request_cancel.side_effect = lambda: order.append("cancel")
     signals = _make_signals()
     signals.stop_requested.emit.side_effect = lambda: order.append("stop_emit")
 
@@ -50,6 +51,36 @@ def test_hardware_safe_runs_before_any_thread_interaction():
     assert order, "nothing happened"
     assert order[0] == "relays_off", f"hardware not first: {order}"
     assert order.index("relays_off") < order.index("thread_wait")
+
+
+def test_cooperative_cancel_fires_before_queued_stop_and_thread_wait():
+    """Direct request_cancel() must precede the queued emit + thread wait.
+
+    The worker thread is blocked in run_until_complete and cannot service
+    the queued stop() slot, so the direct cancel from the GUI thread is
+    what actually breaks the delivery loop. It must happen first.
+    """
+    order = []
+    handler = MagicMock()
+    worker = MagicMock()
+    worker.request_cancel.side_effect = lambda: order.append("cancel")
+    thread = MagicMock()
+    thread.isRunning.return_value = True
+    thread.wait.side_effect = lambda *_a: order.append("thread_wait") or True
+    signals = _make_signals()
+    signals.stop_requested.emit.side_effect = lambda: order.append("stop_emit")
+
+    stop_sequence.execute_stop_sequence(handler, worker, thread, signals)
+
+    assert order.index("cancel") < order.index("stop_emit")
+    assert order.index("cancel") < order.index("thread_wait")
+
+
+def test_worker_without_request_cancel_does_not_raise():
+    """Older worker objects without request_cancel are tolerated."""
+    handler = MagicMock()
+    worker = MagicMock(spec=["isRunning"])  # no request_cancel attr
+    stop_sequence.execute_stop_sequence(handler, worker, None, _make_signals())
 
 
 def test_thread_wait_is_always_bounded():

--- a/Project/tests/unit/test_strategy_cancellation.py
+++ b/Project/tests/unit/test_strategy_cancellation.py
@@ -1,0 +1,125 @@
+"""Cooperative-cancellation tests for the delivery strategies.
+
+Part of the v1.8.2 safety follow-up. v1.8.1 made Stop *safe* (hardware
+dropped first, bounded waits). This locks the behavior that makes Stop
+*clean*: a delivery in flight, when cancelled, exits fast and closes the
+master valve via its finally block — so the worker thread returns from
+run_until_complete and the GUI's bounded wait succeeds without ever
+needing terminate().
+
+Qt-free and hardware-free: the strategies take injected mock collaborators.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from unittest.mock import MagicMock
+
+from strategies.solenoid_flow_strategy import SolenoidFlowStrategy
+from strategies.pump_strategy import PumpStrategy
+
+
+# ---------------------------------------------------------------------------
+# SolenoidFlowStrategy
+# ---------------------------------------------------------------------------
+
+def _make_solenoid(use_pulse=False):
+    valves = MagicMock()
+    sensor = MagicMock()
+    cal = MagicMock()
+    settings = {'use_pulse_delivery': use_pulse}
+    strat = SolenoidFlowStrategy(valves, sensor, cal, settings)
+    return strat, valves
+
+
+def test_request_cancel_sets_token():
+    strat, _ = _make_solenoid()
+    assert strat._check_cancelled() is False
+    strat.request_cancel()
+    assert strat._check_cancelled() is True
+
+
+def test_deliver_clears_stale_cancel_then_routes(monkeypatch):
+    """A fresh deliver() clears a stale cancel from a prior run."""
+    strat, _ = _make_solenoid(use_pulse=False)
+    strat.request_cancel()  # stale flag from a previous run
+
+    captured = {}
+
+    async def fake_continuous(cage_id, vol):
+        # By the time the mode method runs, the stale flag must be cleared.
+        captured['cancelled_at_entry'] = strat._check_cancelled()
+        return True
+
+    monkeypatch.setattr(strat, "_deliver_continuous_mode", fake_continuous)
+    result = asyncio.get_event_loop().run_until_complete(
+        strat.deliver(relay_unit_id=1, target_volume_ml=0.5)
+    )
+    assert result is True
+    assert captured['cancelled_at_entry'] is False
+
+
+def test_cancelled_continuous_delivery_never_reports_success():
+    """A cancelled continuous delivery must return False, never True.
+
+    Core safety invariant: once the operator presses Stop, the strategy
+    must not report a delivery as completed. The valve-closing itself is
+    the pre-existing finally block (hardware-verified in v1.8.1); this
+    test locks the new behavior — the cancel token short-circuits the
+    delivery loop to a False result. We keep the token set through the
+    run (deliver() would otherwise clear it at entry) to simulate a
+    cancel that lands the instant delivery begins.
+    """
+    strat, valves = _make_solenoid(use_pulse=False)
+    strat._cancel_event.set()
+    orig_clear = strat._cancel_event.clear
+    strat._cancel_event.clear = lambda: None  # keep cancelled through deliver()
+    try:
+        result = asyncio.get_event_loop().run_until_complete(
+            strat.deliver(relay_unit_id=3, target_volume_ml=0.5)
+        )
+    finally:
+        strat._cancel_event.clear = orig_clear
+
+    assert result is False
+    # The master valve must be closed on the way out (finally block).
+    valves.close_master.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# PumpStrategy (atomic — cancel can only prevent a not-yet-dispatched run)
+# ---------------------------------------------------------------------------
+
+def test_pump_request_cancel_prevents_dispatch():
+    pump = MagicMock()
+    volcalc = MagicMock()
+    volcalc.calculate_triggers.return_value = 3
+    volcalc.pump_volume_ul = 100
+    strat = PumpStrategy(pump, volcalc)
+
+    strat.request_cancel()
+    result = asyncio.get_event_loop().run_until_complete(
+        strat.deliver(relay_unit_id=1, target_volume_ml=0.3)
+    )
+    assert result is False
+    pump.dispense_water.assert_not_called()
+
+
+def test_pump_normal_dispatch_after_no_cancel():
+    pump = MagicMock()
+
+    async def _dispense(*_a):
+        return True
+
+    pump.dispense_water.side_effect = _dispense
+    volcalc = MagicMock()
+    volcalc.calculate_triggers.return_value = 3
+    volcalc.pump_volume_ul = 100
+    strat = PumpStrategy(pump, volcalc)
+
+    result = asyncio.get_event_loop().run_until_complete(
+        strat.deliver(relay_unit_id=1, target_volume_ml=0.3)
+    )
+    assert result is True
+    pump.dispense_water.assert_called_once()

--- a/Project/utils/stop_sequence.py
+++ b/Project/utils/stop_sequence.py
@@ -71,6 +71,19 @@ def bounded_worker_teardown(worker_obj, thread_obj, signals) -> None:
     was an unbounded ``wait()`` after a ``terminate()`` that never took.
     """
     if worker_obj is not None:
+        # FIRST: poke the cooperative-cancel token directly from this
+        # (GUI) thread. The worker thread is typically blocked inside
+        # run_until_complete and cannot process the queued stop() slot,
+        # so this direct call is what actually breaks the delivery loop.
+        # Thread-safe (the strategy uses a threading.Event).
+        if hasattr(worker_obj, "request_cancel"):
+            try:
+                worker_obj.request_cancel()
+            except Exception as exc:
+                print(f"[STOP] worker.request_cancel() failed: {exc}")
+
+        # THEN: emit the queued stop() for full timer/sensor teardown,
+        # which runs once the worker returns to its Qt event loop.
         try:
             signals.stop_requested.emit()
             print("[DEBUG] Worker stop() requested")

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.8.1"
+__version__ = "1.8.2"


### PR DESCRIPTION
Follow-up to v1.8.1. That release made Stop SAFE — hardware dropped first, every thread.wait bounded — but a mid-delivery Stop still relied on thread.terminate() because the worker thread was blocked inside loop.run_until_complete(deliver()) and never returned to its Qt event loop to process the queued stop() slot. terminate() on a thread sitting in an async C-extension call is unreliable. This PR makes Stop CLEAN: the worker exits on its own in <100ms, so terminate() is essentially never reached.

Mechanism, a thread-safe cancellation token polled by the delivery loop:

- SolenoidFlowStrategy gains a threading.Event (_cancel_event), request_cancel() to set it, and _check_cancelled() to poll. deliver() clears it at entry (fresh run). The continuous-mode loop, its residual loop, and the pulse-mode loop each check the token at the top of every iteration and return False on cancel, falling into the pre-existing finally block that closes cage + master valves.

- PumpStrategy gets a symmetric request_cancel() so the worker can call it uniformly. A pump dispense is atomic (one PumpController call) so cancellation can only prevent a not-yet-dispatched deliver(); honest about that in the docstring.

- RelayWorker.request_cancel() delegates to the active strategy. stop() also calls it (covers the path where the worker isn't blocked).

- The key wiring: utils.stop_sequence.bounded_worker_teardown now calls worker.request_cancel() DIRECTLY from the GUI thread, BEFORE emitting the queued stop signal. The direct call is what breaks the blocked loop — a threading.Event write is thread-safe and needs no event loop. Guarded by hasattr so older worker objects are tolerated.

Why threading.Event and not a queued signal: the whole problem is that the worker thread can't service queued signals while blocked in run_until_complete. The GUI thread must poke shared state the async loop polls. Event.set()/is_set() are thread-safe; no event loop required.

Tests (all Qt-free, run everywhere, suite 32 -> 39):
- test_strategy_cancellation.py (new): request_cancel sets token; deliver clears stale token then routes; a cancelled continuous deliver never reports success and closes master; pump cancel prevents dispatch; pump normal dispatch unaffected.
- test_stop_sequence.py: cooperative cancel fires before the queued emit and before any thread wait; worker without request_cancel is tolerated.

PATCH 1.8.1 -> 1.8.2 (safety hardening; no new operator-facing feature).