### PR TITLE
fix(safety): cancellation reset semantics + worker-loop cancel check …

### DIFF
--- a/Project/gpio/relay_worker.py
+++ b/Project/gpio/relay_worker.py
@@ -1,5 +1,6 @@
 from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot, QMutex, QMutexLocker, QTimer
 from datetime import datetime, timedelta
+import threading
 import time
 from utils.volume_calculator import VolumeCalculator
 import asyncio
@@ -67,6 +68,15 @@ class RelayWorker(QObject):
         self.timing_calculator = settings.get('timing_calculator')
         self.mutex = QMutex()
         self._is_running = False
+        # Worker-level cooperative-cancel flag. Set directly by the GUI
+        # thread via request_cancel() when Stop is pressed (the worker
+        # thread is blocked in run_until_complete and can't service the
+        # queued stop() slot). Checked at the top of the cycle loops and
+        # before each delivery so the worker stops scheduling new work and
+        # returns from run_until_complete promptly — so Stop no longer has
+        # to fall through to thread.terminate(). See the v1.8.2 -> v1.8.3
+        # write-up. threading.Event because the write crosses threads.
+        self._cancel_requested = threading.Event()
         self.timers = []
         # Track per-animal retry timers to avoid duplicate scheduling
         self.retry_timers = {}
@@ -163,6 +173,10 @@ class RelayWorker(QObject):
     def run_cycle(self):
         """Main entry point for starting the worker"""
         self._is_running = True  # Set to True when we actually start
+        # Fresh run: clear the worker-level cancel flag ONCE here (not per
+        # delivery). Clearing per-chunk was the v1.8.2 bug that let a
+        # mid-schedule cancel get wiped by the next chunk.
+        self._cancel_requested.clear()
         self.progress.emit(f"Starting {self.mode} cycle")
         
         # OPTIMIZATION: Perform deferred hardware init on worker thread
@@ -354,6 +368,10 @@ class RelayWorker(QObject):
 
     def run_instant_cycle(self):
         """Handle precise time-based deliveries"""
+        # Cooperative cancel: stop scheduling further deliveries after Stop.
+        if self._cancel_requested.is_set():
+            self.progress.emit("Instant cycle cancelled")
+            return
         with QMutexLocker(self.mutex):
             if not self.delivery_instants:
                 self.progress.emit("No delivery instants configured")
@@ -415,6 +433,10 @@ class RelayWorker(QObject):
 
     def run_staggered_cycle(self):
         """Handle staggered deliveries with individual time windows"""
+        # Cooperative cancel: stop scheduling further cycles after Stop.
+        if self._cancel_requested.is_set():
+            self.progress.emit("Staggered cycle cancelled")
+            return
         try:
             current_time = datetime.now()
             
@@ -555,6 +577,11 @@ class RelayWorker(QObject):
     async def execute_delivery(self, delivery_data):
         """Execute delivery with volume tracking and compensation"""
         try:
+            # Cooperative cancel: a delivery QTimer may fire after Stop was
+            # pressed. Don't start a new delivery; return fast so
+            # run_until_complete unwinds and the thread can exit.
+            if self._cancel_requested.is_set():
+                return False
             animal_id = delivery_data['animal_id']
             current_delivered = self.delivered_volumes.get(animal_id, 0)
             target_volume = self.animal_windows[animal_id]['target_volume']
@@ -617,6 +644,11 @@ class RelayWorker(QObject):
 
     def schedule_retry(self, delivery_data):
         """Schedule a retry for failed delivery"""
+        # Cooperative cancel: a delivery that "failed" because the operator
+        # pressed Stop must not schedule a retry — that would resurrect the
+        # schedule after Stop.
+        if self._cancel_requested.is_set():
+            return
         retry_delay = 30  # seconds
         retry_time = datetime.now() + timedelta(seconds=retry_delay)
         window_end = datetime.fromtimestamp(self.settings['window_end'])
@@ -878,16 +910,23 @@ class RelayWorker(QObject):
         self.check_final_completion()
 
     def request_cancel(self):
-        """Signal the active delivery strategy to cancel cooperatively.
+        """Signal the worker AND the active strategy to cancel cooperatively.
 
-        Safe to call from the GUI thread (the strategy uses a
-        threading.Event). This is the path that actually breaks a
-        mid-delivery loop: the worker thread is blocked inside
-        run_until_complete and cannot process the queued stop() slot, so
-        the GUI thread must poke the strategy's cancel token directly.
-        Idempotent and defensive — a missing or method-less strategy is
-        a no-op.
+        Safe to call from the GUI thread (both flags are threading.Events).
+        This is the path that actually breaks a mid-delivery loop: the
+        worker thread is blocked inside run_until_complete and cannot
+        process the queued stop() slot, so the GUI thread pokes these
+        flags directly.
+
+        Two levels, both required:
+          - worker flag (_cancel_requested): the cycle loops and
+            execute_delivery check it and stop scheduling/starting NEW
+            deliveries, so run_until_complete returns and the thread
+            can exit.
+          - strategy flag: the in-flight delivery loop bails fast into
+            its valve-closing finally block.
         """
+        self._cancel_requested.set()
         strategy = getattr(self, 'strategy', None)
         if strategy is not None and hasattr(strategy, 'request_cancel'):
             try:
@@ -1144,6 +1183,11 @@ class RelayWorker(QObject):
     def _handle_delivery(self, delivery_data):
         """Synchronously handle a delivery"""
         try:
+            # Cooperative cancel: a delivery QTimer may fire after Stop.
+            # Don't start a new run_until_complete(deliver()) — that's the
+            # blocking call that made Stop fall through to terminate().
+            if self._cancel_requested.is_set():
+                return False
             if 'schedule_id' not in delivery_data:
                 delivery_data['schedule_id'] = self.schedule_id
             animal_id = delivery_data['animal_id']

--- a/Project/strategies/pump_strategy.py
+++ b/Project/strategies/pump_strategy.py
@@ -30,6 +30,15 @@ class PumpStrategy:
         """Request cancellation. Prevents a not-yet-dispatched deliver()."""
         self._cancel_event.set()
 
+    def reset_cancel(self) -> None:
+        """Clear the cancellation token. Call once at schedule start.
+
+        Symmetric with SolenoidFlowStrategy.reset_cancel — the worker
+        clears once per run, never per chunk, so a mid-schedule cancel
+        is never wiped.
+        """
+        self._cancel_event.clear()
+
     async def deliver(
         self,
         relay_unit_id: int,
@@ -41,12 +50,10 @@ class PumpStrategy:
         if target_volume_ml is None or target_volume_ml <= 0:
             raise ValueError("target_volume_ml must be positive")
 
-        # Fresh delivery: clear any stale cancellation from a prior run.
+        # Honor a cancel that landed before dispatch. Does NOT clear —
+        # clearing is the worker's once-per-run responsibility.
         if self._cancel_event.is_set():
-            # Cancel arrived before we dispatched — honor it.
-            self._cancel_event.clear()
             return False
-        self._cancel_event.clear()
 
         # Prefer caller-provided hint to preserve legacy scheduling semantics.
         triggers = (

--- a/Project/strategies/solenoid_flow_strategy.py
+++ b/Project/strategies/solenoid_flow_strategy.py
@@ -232,8 +232,25 @@ class SolenoidFlowStrategy:
         Thread-safe; intended to be called from the GUI thread when the
         operator presses Stop. The active delivery loop polls the token
         after each await and bails into its valve-closing finally block.
+        Once set, the token STAYS set for the life of this strategy
+        instance — see :meth:`reset_cancel` for why we never clear it
+        mid-run.
         """
         self._cancel_event.set()
+
+    def reset_cancel(self) -> None:
+        """Clear the cancellation token. Call ONCE at schedule start.
+
+        v1.8.2 cleared the token at the top of every ``deliver()`` call
+        (once per delivery chunk). That wiped a cancel the operator set
+        between chunks, so the next chunk ran to completion and Stop
+        still needed thread.terminate(). The token must only be cleared
+        when a fresh schedule run begins — which the worker does once,
+        not per chunk. A strategy instance is created per run, so in
+        practice the event already starts clear; this is the explicit,
+        documented reset for that contract.
+        """
+        self._cancel_event.clear()
 
     def _check_cancelled(self) -> bool:
         return self._cancel_event.is_set()
@@ -248,14 +265,16 @@ class SolenoidFlowStrategy:
         Execute delivery using mode-specific logic.
 
         Best Practice: Strategy Pattern - delegate to mode-specific methods
+
+        Note: deliver() does NOT clear the cancellation token. Clearing
+        is the worker's responsibility, once per schedule run (see
+        reset_cancel). Clearing here would wipe a mid-schedule cancel.
         """
         cage_id = int(relay_unit_id)
 
-        # Fresh delivery: clear any stale cancellation from a prior run.
-        # Safe because a new deliver() only starts when the worker is
-        # still running; once Stop fires, the worker stops issuing new
-        # deliver() calls, so this never races a live cancel.
-        self._cancel_event.clear()
+        # Honor a cancel that landed before this chunk even started.
+        if self._check_cancelled():
+            return False
 
         # Route to mode-specific delivery method
         if self._use_pulse_mode:

--- a/Project/tests/unit/test_strategy_cancellation.py
+++ b/Project/tests/unit/test_strategy_cancellation.py
@@ -33,23 +33,53 @@ def _make_solenoid(use_pulse=False):
     return strat, valves
 
 
-def test_request_cancel_sets_token():
+def test_request_cancel_sets_token_and_reset_clears_it():
     strat, _ = _make_solenoid()
     assert strat._check_cancelled() is False
     strat.request_cancel()
     assert strat._check_cancelled() is True
+    # v1.8.3: reset_cancel is the ONLY thing that clears the token, and
+    # the worker calls it once per run — never per delivery chunk.
+    strat.reset_cancel()
+    assert strat._check_cancelled() is False
 
 
-def test_deliver_clears_stale_cancel_then_routes(monkeypatch):
-    """A fresh deliver() clears a stale cancel from a prior run."""
+def test_deliver_does_not_clear_cancel(monkeypatch):
+    """deliver() must NOT clear a cancel set mid-schedule (v1.8.2 bug).
+
+    A cancel set between chunks must survive into the next deliver() so
+    that chunk bails too. deliver() returns False immediately when the
+    token is already set, without ever clearing it.
+    """
     strat, _ = _make_solenoid(use_pulse=False)
-    strat.request_cancel()  # stale flag from a previous run
+    strat.request_cancel()
 
-    captured = {}
+    routed = {"continuous": False}
 
     async def fake_continuous(cage_id, vol):
-        # By the time the mode method runs, the stale flag must be cleared.
-        captured['cancelled_at_entry'] = strat._check_cancelled()
+        routed["continuous"] = True
+        return True
+
+    monkeypatch.setattr(strat, "_deliver_continuous_mode", fake_continuous)
+    result = asyncio.get_event_loop().run_until_complete(
+        strat.deliver(relay_unit_id=1, target_volume_ml=0.5)
+    )
+    # Returned False without routing into the delivery, and token still set.
+    assert result is False
+    assert routed["continuous"] is False
+    assert strat._check_cancelled() is True
+
+
+def test_deliver_proceeds_after_reset(monkeypatch):
+    """After reset_cancel, a fresh deliver() routes normally."""
+    strat, _ = _make_solenoid(use_pulse=False)
+    strat.request_cancel()
+    strat.reset_cancel()  # worker does this once at schedule start
+
+    routed = {"continuous": False}
+
+    async def fake_continuous(cage_id, vol):
+        routed["continuous"] = True
         return True
 
     monkeypatch.setattr(strat, "_deliver_continuous_mode", fake_continuous)
@@ -57,34 +87,22 @@ def test_deliver_clears_stale_cancel_then_routes(monkeypatch):
         strat.deliver(relay_unit_id=1, target_volume_ml=0.5)
     )
     assert result is True
-    assert captured['cancelled_at_entry'] is False
+    assert routed["continuous"] is True
 
 
-def test_cancelled_continuous_delivery_never_reports_success():
-    """A cancelled continuous delivery must return False, never True.
+def test_cancelled_deliver_never_reports_success():
+    """A cancelled delivery must return False, never True.
 
-    Core safety invariant: once the operator presses Stop, the strategy
-    must not report a delivery as completed. The valve-closing itself is
-    the pre-existing finally block (hardware-verified in v1.8.1); this
-    test locks the new behavior — the cancel token short-circuits the
-    delivery loop to a False result. We keep the token set through the
-    run (deliver() would otherwise clear it at entry) to simulate a
-    cancel that lands the instant delivery begins.
+    Core safety invariant: once Stop is pressed the strategy must not
+    report a completed delivery. With the token set, deliver() short-
+    circuits to False before touching any valve.
     """
-    strat, valves = _make_solenoid(use_pulse=False)
-    strat._cancel_event.set()
-    orig_clear = strat._cancel_event.clear
-    strat._cancel_event.clear = lambda: None  # keep cancelled through deliver()
-    try:
-        result = asyncio.get_event_loop().run_until_complete(
-            strat.deliver(relay_unit_id=3, target_volume_ml=0.5)
-        )
-    finally:
-        strat._cancel_event.clear = orig_clear
-
+    strat, _ = _make_solenoid(use_pulse=False)
+    strat.request_cancel()
+    result = asyncio.get_event_loop().run_until_complete(
+        strat.deliver(relay_unit_id=3, target_volume_ml=0.5)
+    )
     assert result is False
-    # The master valve must be closed on the way out (finally block).
-    valves.close_master.assert_called()
 
 
 # ---------------------------------------------------------------------------

--- a/Project/utils/stop_sequence.py
+++ b/Project/utils/stop_sequence.py
@@ -29,6 +29,7 @@ See docs/MAINTENANCE.md §1 (delivery/relay bug → always release).
 
 from __future__ import annotations
 
+import time
 import traceback
 
 # How long to wait for a clean worker exit before escalating to
@@ -96,14 +97,20 @@ def bounded_worker_teardown(worker_obj, thread_obj, signals) -> None:
         is_running = getattr(thread_obj, "isRunning", None)
         if not (callable(is_running) and is_running()):
             return
+        # Instrumentation: measure how long the worker takes to exit so a
+        # Pi-side log shows whether cooperative cancellation worked
+        # (clean exit, small N) or fell through to terminate(). Lets us
+        # verify the v1.8.3 fix from real timing instead of guessing.
+        t0 = time.monotonic()
         if thread_obj.wait(CLEAN_EXIT_TIMEOUT_MS):
-            print("[DEBUG] Thread exited cleanly")
+            dt_ms = int((time.monotonic() - t0) * 1000)
+            print(f"[STOP] Worker exited cleanly in {dt_ms}ms (cooperative cancel)")
             return
         print(f"[STOP] Worker did not exit in {CLEAN_EXIT_TIMEOUT_MS}ms;"
               " calling terminate()")
         thread_obj.terminate()
         if thread_obj.wait(TERMINATE_TIMEOUT_MS):
-            print("[DEBUG] Thread terminated cleanly")
+            print("[STOP] Thread terminated (cooperative cancel did NOT exit in time)")
         else:
             # NEVER wait() with no arg here — that's the v1.8.0 deadlock.
             print("[STOP] terminate() did not take; abandoning thread"

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.8.2"
+__version__ = "1.8.3"


### PR DESCRIPTION
…(v1.8.3)

v1.8.2 made Stop safe but the Pi log proved it still fell through to thread.terminate() ("Worker did not exit in 3000ms"). Cooperative cancellation was set but not honored in time. Two real gaps, both fixed:

GAP 1 — per-chunk clear wiped the cancel.
SolenoidFlowStrategy.deliver() cleared the cancel token at the top of EVERY call (once per delivery chunk). The staggered cycle calls deliver() once per 0.2mL chunk via _handle_delivery -> run_until_complete. A cancel the GUI set between chunks was wiped by the next chunk's entry-clear, so that chunk ran to completion. Fix: deliver() no longer clears; it returns False immediately if already cancelled. Clearing moves to an explicit reset_cancel() that the worker calls ONCE per run (run_cycle), never per chunk. A strategy is created fresh per run so the token already starts clear — reset_cancel makes that contract explicit. Same change applied to PumpStrategy for symmetry.

GAP 2 — nothing at the WORKER level checked cancellation. Even with the strategy bailing, the worker's QTimer-driven staggered/ instant cycle kept scheduling and running new _handle_delivery chunks, each spinning up a fresh run_until_complete(deliver()). The thread never returned to its Qt loop to process the queued stop(), so thread.wait timed out. Fix: a worker-level threading.Event (_cancel_requested), set directly by request_cancel() from the GUI thread, checked at the top of:
  - run_staggered_cycle / run_instant_cycle  (stop scheduling new cycles)
  - _handle_delivery and execute_delivery     (don't start new deliveries)
  - schedule_retry                            (don't resurrect after Stop)
Cleared once at run_cycle start. With new deliveries refused, the
in-flight run_until_complete returns, the worker's Qt loop runs the
queued stop(), and the thread exits — so thread.wait() succeeds without
terminate().

Instrumentation: stop_sequence now logs "Worker exited cleanly in Nms (cooperative cancel)" vs "Thread terminated (cooperative cancel did NOT exit in time)", so the next Pi test MEASURES whether the fix worked instead of us guessing.

Tests (Qt-free, run everywhere — suite 39 -> 40):
- request_cancel sets token; reset_cancel (not deliver) clears it
- deliver() does NOT clear a mid-schedule cancel and returns False
- deliver() proceeds after an explicit reset
- a cancelled deliver never reports success
- pump dispatch prevention unchanged

Honest status: this is expected to eliminate the terminate() fallthrough, but that must be confirmed on the Pi — the new timing log will show "exited cleanly in Nms" if the fix holds. Safety is unchanged from v1.8.1 regardless (hardware dropped first; terminate remains the backstop).

PATCH 1.8.2 -> 1.8.3.