### PR TITLE
chore(diag): [TIMING] phase markers for the Stop sequence (v1.8.4)

### DIFF
--- a/Project/gpio/relay_worker.py
+++ b/Project/gpio/relay_worker.py
@@ -926,6 +926,7 @@ class RelayWorker(QObject):
           - strategy flag: the in-flight delivery loop bails fast into
             its valve-closing finally block.
         """
+        print(f"[TIMING] worker.request_cancel at {time.monotonic():.3f}")
         self._cancel_requested.set()
         strategy = getattr(self, 'strategy', None)
         if strategy is not None and hasattr(strategy, 'request_cancel'):
@@ -945,6 +946,7 @@ class RelayWorker(QObject):
         - Observable: Log each cleanup step
         - Fail-safe: Continue cleanup even if individual steps fail
         """
+        print(f"[TIMING] worker.stop() slot entry at {time.monotonic():.3f}")
         print("\n[STOP] ========== SCHEDULE STOP SEQUENCE INITIATED ==========")
         # Also fire cooperative cancel here for the case where stop() is
         # reached via the normal queued path (worker not blocked).
@@ -1183,10 +1185,12 @@ class RelayWorker(QObject):
     def _handle_delivery(self, delivery_data):
         """Synchronously handle a delivery"""
         try:
+            print(f"[TIMING] _handle_delivery entry at {time.monotonic():.3f}")
             # Cooperative cancel: a delivery QTimer may fire after Stop.
             # Don't start a new run_until_complete(deliver()) — that's the
             # blocking call that made Stop fall through to terminate().
             if self._cancel_requested.is_set():
+                print(f"[TIMING] _handle_delivery cancel-guard return at {time.monotonic():.3f}")
                 return False
             if 'schedule_id' not in delivery_data:
                 delivery_data['schedule_id'] = self.schedule_id
@@ -1220,6 +1224,7 @@ class RelayWorker(QObject):
                         f"volume={delivery_data['water_volume']:.3f}mL"
                     )
                     
+                    print(f"[TIMING] run_until_complete(deliver) start at {time.monotonic():.3f}")
                     loop = asyncio.new_event_loop()
                     try:
                         asyncio.set_event_loop(loop)
@@ -1230,7 +1235,8 @@ class RelayWorker(QObject):
                                 triggers_hint=delivery_data.get('triggers'),
                             )
                         )
-                        
+                        print(f"[TIMING] run_until_complete(deliver) returned at {time.monotonic():.3f} success={success}")
+
                         # CRITICAL DEBUG: Log delivery result
                         self.progress.emit(
                             f"[DEBUG] Delivery completed: animal={animal_id}, success={success}"

--- a/Project/strategies/solenoid_flow_strategy.py
+++ b/Project/strategies/solenoid_flow_strategy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+import time
 from dataclasses import dataclass
 from typing import Optional, Dict, Tuple
 
@@ -477,6 +478,7 @@ class SolenoidFlowStrategy:
                 # Cooperative cancellation: operator pressed Stop. Bail into
                 # the finally block, which closes cage + master valves.
                 if self._check_cancelled():
+                    print(f"[TIMING] continuous loop SAW CANCEL at {time.monotonic():.3f}")
                     self._logger.info(f"Delivery cancelled for cage {cage_id}; closing valves")
                     return False
 
@@ -700,9 +702,11 @@ class SolenoidFlowStrategy:
             await asyncio.sleep(0.3)  # Let manifold stabilize
             
             while delivered_ml < target_volume_ml:
+                print(f"[TIMING] pulse loop top (pulse {pulse_count}) at {time.monotonic():.3f}")
                 # Cooperative cancellation: operator pressed Stop. Bail into
                 # the finally block, which closes cage + master valves.
                 if self._check_cancelled():
+                    print(f"[TIMING] pulse loop SAW CANCEL at {time.monotonic():.3f}")
                     self._logger.info(f"Pulse delivery cancelled for cage {cage_id}; closing valves")
                     return False
 

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.8.3"
+__version__ = "1.8.4"


### PR DESCRIPTION
Diagnostic-only. v1.8.2 and v1.8.3 both failed to make Stop exit cleanly — terminate() still fired after the 3s wait — and I've been diagnosing from logs without hard timing. This adds monotonic-clock [TIMING] markers at every phase boundary so ONE Pi Stop-test reveals exactly where the time goes, instead of another speculative fix.

Markers (all share one process monotonic clock, directly comparable across the GUI and worker threads):
  GUI thread:
    - worker.request_cancel        (T0: operator pressed Stop)
    - stop_sequence already logs "exited cleanly in Nms" / "did not
      exit in 3000ms" (the wait outcome)
  worker thread:
    - _handle_delivery entry
    - _handle_delivery cancel-guard return
    - run_until_complete(deliver) start / returned
    - worker.stop() slot entry
  strategy (worker thread):
    - pulse loop top (per pulse) / pulse loop SAW CANCEL
    - continuous loop SAW CANCEL

Reading the deltas:
  T0 -> "SAW CANCEL"        = how long until the delivery loop noticed
  "deliver returned" -> "stop() slot entry" = queued-slot latency
  "stop() slot entry" -> wait success      = thread teardown time
Whichever gap is ~3s is the real bottleneck.

No behavior change (print statements only); suite stays at 40 passed. After the Pi re-test, v1.8.5 will carry the targeted fix and these markers will be removed.

PATCH 1.8.3 -> 1.8.4.