### PR TITLE
fix(db): tolerate ISO datetimes without microseconds in staggered sch…

### DIFF
--- a/Project/models/database_handler.py
+++ b/Project/models/database_handler.py
@@ -1161,9 +1161,16 @@ class DatabaseHandler:
                         VALUES (?, ?, ?)
                     ''', (schedule_id, animal_id, desired_output))
                     
-                    # Parse datetime strings using strptime
-                    start_time = datetime.strptime(schedule.start_time, "%Y-%m-%dT%H:%M:%S.%f")
-                    end_time = datetime.strptime(schedule.end_time, "%Y-%m-%dT%H:%M:%S.%f")
+                    # Parse ISO datetime strings. Use fromisoformat (the exact
+                    # inverse of the .isoformat() that produced these strings)
+                    # instead of strptime with a fixed "...%S.%f" format. The
+                    # %f token REQUIRES fractional seconds, but isoformat()
+                    # OMITS them when microseconds == 0 (e.g. a start time on a
+                    # whole second like '2026-05-28T18:00:14'), which made
+                    # schedule creation fail intermittently depending on the
+                    # exact second the operator picked.
+                    start_time = datetime.fromisoformat(schedule.start_time)
+                    end_time = datetime.fromisoformat(schedule.end_time)
                     
                     cursor.execute('''
                         INSERT INTO schedule_staggered_windows

--- a/Project/tests/unit/test_schedule_datetime.py
+++ b/Project/tests/unit/test_schedule_datetime.py
@@ -1,0 +1,67 @@
+"""Regression test for staggered-schedule datetime parsing.
+
+Bug (found on the Pi, v1.8.4): add_staggered_schedule parsed
+schedule.start_time / end_time with
+    datetime.strptime(s, "%Y-%m-%dT%H:%M:%S.%f")
+The %f token REQUIRES fractional seconds, but datetime.isoformat()
+OMITS them when microseconds == 0. So a start time that happened to
+land on a whole second (e.g. '2026-05-28T18:00:14') made schedule
+creation raise ValueError and silently return None — the wizard's
+Finish "did nothing". Times with nonzero microseconds worked, which
+is why it looked intermittent.
+
+Fix: parse with datetime.fromisoformat (the inverse of isoformat),
+which accepts both with- and without-microsecond ISO strings.
+
+Qt-free: DatabaseHandler imports no PyQt5, so this runs everywhere.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from models.database_handler import DatabaseHandler
+from models.Schedule import Schedule
+
+
+def _staggered_schedule(start_iso: str, end_iso: str) -> Schedule:
+    sched = Schedule(
+        schedule_id=None,
+        name="regression",
+        water_volume=1.0,
+        start_time=start_iso,
+        end_time=end_iso,
+        created_by=1,
+        is_super_user=0,
+        delivery_mode="staggered",
+    )
+    sched.add_animal(animal_id=1, relay_unit_id=1, desired_volume=1.0)
+    return sched
+
+
+def test_whole_second_start_time_creates_schedule(database_handler):
+    """A start time on a whole second (no microseconds) must succeed.
+
+    This is the exact shape that failed: isoformat() of a datetime whose
+    microsecond is 0 yields 'YYYY-MM-DDTHH:MM:SS' with no '.ffffff'.
+    """
+    start = datetime(2026, 5, 28, 18, 0, 14)         # microsecond == 0
+    end = datetime(2026, 5, 28, 18, 3, 14)
+    assert start.isoformat() == "2026-05-28T18:00:14"  # no fractional part
+
+    schedule_id = database_handler.add_staggered_schedule(
+        _staggered_schedule(start.isoformat(), end.isoformat())
+    )
+    assert schedule_id is not None
+
+
+def test_microsecond_start_time_still_works(database_handler):
+    """The previously-working case (nonzero microseconds) must still work."""
+    start = datetime(2026, 5, 28, 18, 0, 14, 549000)   # has microseconds
+    end = datetime(2026, 5, 28, 18, 3, 14, 549000)
+    assert "." in start.isoformat()                    # fractional part present
+
+    schedule_id = database_handler.add_staggered_schedule(
+        _staggered_schedule(start.isoformat(), end.isoformat())
+    )
+    assert schedule_id is not None

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.8.4"
+__version__ = "1.8.5"


### PR DESCRIPTION
…edules (v1.8.5)

Creating a staggered schedule failed (Finish "did nothing", schedule_id returned None) whenever the chosen start OR end time landed on a whole second. add_staggered_schedule parsed the times with:

    datetime.strptime(s, "%Y-%m-%dT%H:%M:%S.%f")

The %f token REQUIRES fractional seconds, but datetime.isoformat() OMITS them when microseconds == 0. So '2026-05-28T18:00:14' (a clean 18:00 start whose seconds rolled to a whole number) raised ValueError: time data ... does not match format '...%S.%f'. Times with nonzero microseconds (e.g. '...:55.549000') parsed fine — which is why the wizard "always worked before" and broke seemingly at random.

NOT introduced by the recent stop-sequence / timing work — this is a pre-existing latent bug in the schedule-creation path that only surfaces on a whole-second timestamp.

Fix: parse with datetime.fromisoformat() — the exact inverse of the isoformat() that produced these strings. It accepts both with- and without-microsecond ISO 8601 strings (Python 3.7+; 3.11 on the Pi). Applied to both start_time and end_time.

Regression test (Qt-free, runs everywhere — suite 40 -> 42):
- whole-second start time (microsecond == 0) now creates the schedule
- nonzero-microsecond start time still works

PATCH 1.8.4 -> 1.8.5.