### PR TITLE
fix(safety): stop() UnboundLocalError that forced terminate() (v1.8.6)

### DIFF
--- a/Project/gpio/relay_worker.py
+++ b/Project/gpio/relay_worker.py
@@ -926,7 +926,6 @@ class RelayWorker(QObject):
           - strategy flag: the in-flight delivery loop bails fast into
             its valve-closing finally block.
         """
-        print(f"[TIMING] worker.request_cancel at {time.monotonic():.3f}")
         self._cancel_requested.set()
         strategy = getattr(self, 'strategy', None)
         if strategy is not None and hasattr(strategy, 'request_cancel'):
@@ -946,7 +945,6 @@ class RelayWorker(QObject):
         - Observable: Log each cleanup step
         - Fail-safe: Continue cleanup even if individual steps fail
         """
-        print(f"[TIMING] worker.stop() slot entry at {time.monotonic():.3f}")
         print("\n[STOP] ========== SCHEDULE STOP SEQUENCE INITIATED ==========")
         # Also fire cooperative cancel here for the case where stop() is
         # reached via the normal queued path (worker not blocked).
@@ -1014,8 +1012,12 @@ class RelayWorker(QObject):
                     self.strategy._sensor.stop()
                     print("[STOP]    Flow sensor stop() completed")
                     
-                    # Wait briefly to ensure sensor stops cleanly
-                    import time
+                    # Wait briefly to ensure sensor stops cleanly.
+                    # (time is imported at module scope; a local re-import
+                    # here shadowed it for the whole method and crashed the
+                    # v1.8.4 timing print at the top of stop() with an
+                    # UnboundLocalError, which prevented finished/quit and
+                    # forced thread.terminate() on every Stop.)
                     time.sleep(0.5)
                     
                     # Verify sensor stopped
@@ -1185,12 +1187,10 @@ class RelayWorker(QObject):
     def _handle_delivery(self, delivery_data):
         """Synchronously handle a delivery"""
         try:
-            print(f"[TIMING] _handle_delivery entry at {time.monotonic():.3f}")
             # Cooperative cancel: a delivery QTimer may fire after Stop.
             # Don't start a new run_until_complete(deliver()) — that's the
             # blocking call that made Stop fall through to terminate().
             if self._cancel_requested.is_set():
-                print(f"[TIMING] _handle_delivery cancel-guard return at {time.monotonic():.3f}")
                 return False
             if 'schedule_id' not in delivery_data:
                 delivery_data['schedule_id'] = self.schedule_id
@@ -1224,7 +1224,6 @@ class RelayWorker(QObject):
                         f"volume={delivery_data['water_volume']:.3f}mL"
                     )
                     
-                    print(f"[TIMING] run_until_complete(deliver) start at {time.monotonic():.3f}")
                     loop = asyncio.new_event_loop()
                     try:
                         asyncio.set_event_loop(loop)
@@ -1235,7 +1234,6 @@ class RelayWorker(QObject):
                                 triggers_hint=delivery_data.get('triggers'),
                             )
                         )
-                        print(f"[TIMING] run_until_complete(deliver) returned at {time.monotonic():.3f} success={success}")
 
                         # CRITICAL DEBUG: Log delivery result
                         self.progress.emit(

--- a/Project/strategies/solenoid_flow_strategy.py
+++ b/Project/strategies/solenoid_flow_strategy.py
@@ -478,7 +478,6 @@ class SolenoidFlowStrategy:
                 # Cooperative cancellation: operator pressed Stop. Bail into
                 # the finally block, which closes cage + master valves.
                 if self._check_cancelled():
-                    print(f"[TIMING] continuous loop SAW CANCEL at {time.monotonic():.3f}")
                     self._logger.info(f"Delivery cancelled for cage {cage_id}; closing valves")
                     return False
 
@@ -702,11 +701,9 @@ class SolenoidFlowStrategy:
             await asyncio.sleep(0.3)  # Let manifold stabilize
             
             while delivered_ml < target_volume_ml:
-                print(f"[TIMING] pulse loop top (pulse {pulse_count}) at {time.monotonic():.3f}")
                 # Cooperative cancellation: operator pressed Stop. Bail into
                 # the finally block, which closes cage + master valves.
                 if self._check_cancelled():
-                    print(f"[TIMING] pulse loop SAW CANCEL at {time.monotonic():.3f}")
                     self._logger.info(f"Pulse delivery cancelled for cage {cage_id}; closing valves")
                     return False
 

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.8.5"
+__version__ = "1.8.6"


### PR DESCRIPTION
The v1.8.4 [TIMING] instrumentation revealed the truth AND introduced a crash. Reading the monotonic timestamps from the Pi:

  worker.request_cancel        24608.460
  pulse loop SAW CANCEL        24608.596   (+136 ms)
  deliver() returned False     24608.618   (+158 ms)

Cooperative cancellation WORKS — the delivery loop bailed in 136 ms. That was never the problem. The problem was at the end:

  UnboundLocalError: cannot access local variable 'time'
    at relay_worker.py stop(): print(f"... {time.monotonic()} ...")

RelayWorker.stop() contains an inner `import time` (for time.sleep(0.5) in the flow-sensor stop section). Python treats `time` as local to the WHOLE function, so the v1.8.4 timing print I added at the TOP of stop() referenced it before assignment -> UnboundLocalError -> stop() crashed -> finished never emitted -> thread.quit() never called -> the GUI's wait() timed out -> terminate(). So my own diagnostic was forcing the exact terminate() it was meant to diagnose.

Fix:
  - Remove the redundant inner `import time` in stop(); the module already imports time at top scope. No more shadowing.
  - Strip all [TIMING] prints from relay_worker.py and solenoid_flow_strategy.py — they served their purpose (we now know cancel fires in 136 ms). The low-noise stop_sequence "Worker exited cleanly in Nms" / "Thread terminated" line stays as permanent operational logging and will confirm clean exit on the next test.

Expected on the Pi after this: Stop now exits cleanly (the worker's stop() runs to completion, emits finished, the thread quits) and the log shows "Worker exited cleanly in Nms" instead of the terminate path. Safety is unchanged regardless (hardware dropped first; terminate remains the backstop).

Suite stays 42 passed.

PATCH 1.8.5 -> 1.8.6.