### PR TITLE
fix(safety): quit worker thread via DirectConnection so Stop exits cl…

### DIFF
--- a/Project/main.py
+++ b/Project/main.py
@@ -310,7 +310,18 @@ def run_program(schedule, mode, window_start, window_end):
         #   • thread.quit() – so the thread stops,
         #   • worker.deleteLater() – so the worker cleans itself up,
         #   • cleanup() – our centralized cleanup function (only once).
-        worker.finished.connect(thread.quit)
+        #
+        # thread.quit() MUST use DirectConnection. finished is emitted from
+        # the worker thread, but the QThread object's affinity is THIS (GUI)
+        # thread, so an AutoConnection would queue thread.quit() into the GUI
+        # event loop. stop_program() blocks the GUI thread in
+        # thread.wait(3000), so that queued quit() could never run — the
+        # worker's event loop was never told to exit and the wait always
+        # timed out into thread.terminate(). DirectConnection runs quit() in
+        # the worker thread (QThread.quit is thread-safe), exiting the
+        # worker's own event loop right after stop() returns — so Stop now
+        # exits cleanly instead of being force-terminated.
+        worker.finished.connect(thread.quit, Qt.DirectConnection)
         worker.finished.connect(worker.deleteLater)
         worker.finished.connect(cleanup)
         thread.finished.connect(thread.deleteLater)

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.8.6"
+__version__ = "1.8.7"


### PR DESCRIPTION
…eanly (v1.8.7)

THE actual cause of terminate() firing on every Stop — traced from code
+ Qt connection semantics, not guessed.

v1.8.6 fixed the stop() UnboundLocalError, so stop() now runs to completion and emits `finished` — yet thread.wait(3000) STILL timed out into terminate(). Why:

  main.py:
    thread = QThread()                      # affinity: GUI thread
    worker.moveToThread(thread)             # affinity: worker thread
    worker.finished.connect(thread.quit)    # AutoConnection

  stop_sequence.bounded_worker_teardown:
    thread.wait(3000)                       # blocks the GUI thread

`finished` is emitted from the WORKER thread; the QThread object's affinity is the GUI thread. Qt's AutoConnection therefore routes thread.quit() as a QUEUED call into the GUI thread's event loop. But the GUI thread is blocked in thread.wait(3000) and never services its event queue, so thread.quit() can't run — the worker's event loop is never told to exit, the thread never finishes, and wait() times out into terminate(). Every single time.

This matches all prior evidence: the v1.8.4 timing data showed the worker did its work in ~160ms (cancel seen +136ms, deliver returned +158ms); the missing ~2.8s was purely waiting on a quit() that could never execute. stop() completing and emitting finished (v1.8.6) didn't help because the quit was queued behind the blocked GUI thread.

Fix: connect finished -> thread.quit with Qt.DirectConnection. QThread.quit is thread-safe; DirectConnection runs it in the worker thread the instant finished is emitted, exiting the worker's OWN event loop as soon as stop() returns — no dependency on the blocked GUI event loop. The other two finished connections (deleteLater, cleanup) are unchanged.

Confirmation: derived rigorously from the connection wiring + Qt's documented AutoConnection rule (queued when emitter thread != receiver affinity). The stop_sequence "Worker exited cleanly in Nms" log line (already present) will show the result on the next Pi Stop test — expect "exited cleanly in <a few hundred>ms" and NO terminate line. Safety is unchanged regardless (hardware dropped first; terminate remains backstop).

Suite stays 42 passed (the Qt thread-affinity behavior is integration- level; the stop_sequence ordering tests already cover the GUI-side logic).

PATCH 1.8.6 -> 1.8.7.