### PR TITLE
chore(lint): adopt ruff config + dev dependency (no source changes)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,6 @@
 pytest>=7.0
 # Phase-0 dead-code audit baseline; not used at runtime.
 vulture>=2.11
+# Linter/formatter; config in ruff.toml. Run: ruff check / ruff format
+# Pinned major to keep formatting output stable across contributors.
+ruff>=0.6,<0.7

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,37 @@
+# Ruff configuration for RRR.
+#
+# Adopted in two steps on purpose (see CONTRIBUTING.md / the cleanup plan):
+#   3.7a (this commit): add the config + dev dependency only. No source
+#                       changes, no CI gate yet — so existing CI stays green
+#                       and developers can run `ruff` locally.
+#   3.7b (next):        apply `ruff check --fix` + `ruff format` as a single
+#                       mechanical reformat, AND add the CI gate in the same
+#                       PR so the gate lands on already-formatted code.
+#
+# Intentionally MINIMAL to start: formatting + import sorting + dead-import
+# removal only. Heavier lint families (pyflakes-undefined, bugbear, naming,
+# complexity) are deferred to later opt-in PRs to avoid a giant risky churn
+# on this large, working codebase.
+
+# py39 is the floor a contributor's machine might run (CI/devs); the device
+# ships 3.11. Keeping the floor low avoids ruff suggesting newer-only syntax.
+target-version = "py39"
+line-length = 99
+
+# The app code lives under Project/; the venv is never linted.
+extend-exclude = [
+    "Project/venv",
+    "Project/tests",   # hardware-diagnostic CLIs + fixtures; lint unit/ only via opt-in later
+    "dist",
+    "build",
+]
+
+[lint]
+# F401 unused imports, F811 redefinition, F841 unused local variable, I import sorting.
+select = ["F401", "F811", "F841", "I"]
+
+[format]
+# Preserve existing quote style on the first adoption pass so the 3.7b
+# reformat diff stays focused on whitespace / line-wrapping / imports
+# rather than flipping every quote in the repo. Can be tightened later.
+quote-style = "preserve"


### PR DESCRIPTION
Phase 3.7a of the cleanup plan. Adds ruff.toml and pins ruff in requirements-dev.txt so developers can lint/format locally. Deliberately NO source reformatting and NO CI gate in this PR — adding a gate now would turn CI red on the (not-yet-formatted) tree. The mechanical reformat AND the CI gate land together in 3.7b, so the gate arrives on already-formatted code and passes.

Config is intentionally minimal for a first adoption on a large working codebase:
  - line-length 99, target py39 (lowest contributor floor; device is 3.11)
  - lint select: F401 (unused imports), F811 (redefinition), F841 (unused vars), I (import sorting)
  - format: quote-style = preserve, to keep the 3.7b diff focused on whitespace/wrapping/imports rather than flipping every quote
  - excludes: Project/venv, Project/tests (hardware CLIs), dist, build Heavier families (bugbear, naming, complexity) deferred to later opt-in.

Dry-run baseline for 3.7b (ruff check --statistics, no fixes applied):
  118 F401 unused-import, 77 I001 unsorted-imports,
  15 F841 unused-variable, 6 F811 redefined-while-unused.
Note for 3.7b: F401 in re-export __init__.py files and the 6 F811s need manual review, not blind --fix.

No version bump (dev tooling per MAINTENANCE.md §1 / §3c).