### PR TITLE
refactor(lint): remove unused imports (F401) + widen CI gate (3.7b-2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,10 +35,10 @@ jobs:
           # Enforce only the rules cleaned so far. ruff.toml's `select`
           # lists the full target set (F401/F811/F841/I); CI gates it
           # incrementally as each family is fixed in its own PR:
-          #   now: formatting + import-sort (I)
-          #   next: F401 unused-imports, then F841 unused-vars, then F811.
+          #   now: formatting + import-sort (I) + unused-imports (F401)
+          #   next: F841 unused-vars, then F811 redefinitions.
           ruff format --check .
-          ruff check --select I .
+          ruff check --select I,F401 .
 
       - name: Run pytest
         run: python3 -m pytest

--- a/Project/controllers/projects_controller.py
+++ b/Project/controllers/projects_controller.py
@@ -1,6 +1,5 @@
 from models.animal import Animal
 from models.database_handler import DatabaseHandler
-from models.Schedule import Schedule
 
 
 class ProjectsController:

--- a/Project/controllers/pump_controller.py
+++ b/Project/controllers/pump_controller.py
@@ -1,7 +1,3 @@
-import asyncio
-import datetime
-
-
 class PumpController:
     def __init__(self, relay_handler, database_handler):
         if not relay_handler:

--- a/Project/controllers/schedule_controller.py
+++ b/Project/controllers/schedule_controller.py
@@ -1,8 +1,7 @@
 import asyncio
 from datetime import datetime
 
-from gpio.relay_worker import RelayWorker
-from PyQt5.QtCore import QObject, QThread, pyqtSignal
+from PyQt5.QtCore import QObject, pyqtSignal
 from utils.timing_calculator import TimingCalculator
 from utils.volume_calculator import VolumeCalculator
 

--- a/Project/controllers/system_controller.py
+++ b/Project/controllers/system_controller.py
@@ -1,6 +1,5 @@
 import json
 import os
-from datetime import datetime
 
 from PyQt5.QtCore import QObject, pyqtSignal
 from utils import paths

--- a/Project/drivers/flow_sensor_factory.py
+++ b/Project/drivers/flow_sensor_factory.py
@@ -83,14 +83,16 @@ def get_available_sensor_types() -> list:
     available = []
 
     try:
-        from .flow_sensor import SLF3S0600FDriver
+        from .flow_sensor import SLF3S0600FDriver  # noqa: F401  (import IS the availability probe)
 
         available.append('i2c')
     except ImportError:
         pass
 
     try:
-        from .uart_flow_sensor import UARTFlowSensor
+        from .uart_flow_sensor import (
+            UARTFlowSensor,  # noqa: F401  (import IS the availability probe)
+        )
 
         available.append('uart')
     except ImportError:

--- a/Project/drivers/i2c_coordinator.py
+++ b/Project/drivers/i2c_coordinator.py
@@ -19,7 +19,7 @@ import logging
 import threading
 import time
 from contextlib import asynccontextmanager
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 
 class I2CCoordinator:

--- a/Project/drivers/solenoid_controller.py
+++ b/Project/drivers/solenoid_controller.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Iterable, Optional
+from typing import Dict
 
 
 class SolenoidController:

--- a/Project/gpio/custom_SM16relind.py
+++ b/Project/gpio/custom_SM16relind.py
@@ -5,7 +5,6 @@ This is a wrapper around the original SM16relind module that adds the ability
 to specify a custom I2C bus.
 """
 
-import importlib.util
 import logging
 import os
 import time

--- a/Project/gpio/gpio_handler.py
+++ b/Project/gpio/gpio_handler.py
@@ -1,6 +1,5 @@
 # gpio_handler.py
 
-import datetime
 import logging
 import os
 import time

--- a/Project/gpio/relay_worker.py
+++ b/Project/gpio/relay_worker.py
@@ -5,7 +5,6 @@ import time
 from datetime import datetime, timedelta
 from functools import partial
 
-from drivers.flow_sensor import SLF3S0600FDriver
 from drivers.solenoid_controller import SolenoidController
 from PyQt5.QtCore import QMutex, QMutexLocker, QObject, QTimer, pyqtSignal, pyqtSlot
 from strategies.factory import StrategyFactory

--- a/Project/main.py
+++ b/Project/main.py
@@ -2,9 +2,7 @@
 # =============================================================================
 # Global exception hook and stream redirection (unchanged)
 # =============================================================================
-import os
 import sys
-import time
 import traceback
 from datetime import datetime
 
@@ -17,7 +15,7 @@ from models.database_handler import DatabaseHandler
 from models.login_system import LoginSystem
 from models.relay_unit_manager import RelayUnitManager
 from notifications.notifications import NotificationHandler
-from PyQt5.QtCore import QMutex, QMutexLocker, QObject, Qt, QThread, QTimer, pyqtSignal
+from PyQt5.QtCore import QObject, Qt, QThread, pyqtSignal
 from PyQt5.QtGui import QGuiApplication
 from PyQt5.QtNetwork import QLocalServer, QLocalSocket
 from PyQt5.QtWidgets import QApplication, QInputDialog
@@ -25,7 +23,6 @@ from ui.gui import RodentRefreshmentGUI
 from ui.SettingsTab import SettingsTab
 from ui.style.theme import StyleManager
 from utils import paths, stop_sequence, updater
-from utils.volume_calculator import VolumeCalculator
 from version import __version__
 
 _DEBUG_LOG_PATH = paths.debug_log_path()

--- a/Project/models/Schedule.py
+++ b/Project/models/Schedule.py
@@ -1,6 +1,6 @@
 # models/schedule.py
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 
 class Schedule:

--- a/Project/strategies/solenoid_flow_strategy.py
+++ b/Project/strategies/solenoid_flow_strategy.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
-import time
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple
 

--- a/Project/tools/valve_calibration_tool.py
+++ b/Project/tools/valve_calibration_tool.py
@@ -41,7 +41,6 @@ import asyncio
 import logging
 import sys
 import time
-from datetime import datetime
 from pathlib import Path
 from typing import Dict, Optional
 

--- a/Project/ui/CalibrationWizard.py
+++ b/Project/ui/CalibrationWizard.py
@@ -10,11 +10,9 @@ Best Practices:
 - Persistent storage of results
 """
 
-import asyncio
 from datetime import datetime
 
-from PyQt5.QtCore import QEvent, Qt, QTimer, pyqtSignal
-from PyQt5.QtGui import QFont
+from PyQt5.QtCore import Qt, QTimer, pyqtSignal
 from PyQt5.QtWidgets import (
     QDialog,
     QDoubleSpinBox,
@@ -28,8 +26,6 @@ from PyQt5.QtWidgets import (
     QSpinBox,
     QTextEdit,
     QVBoxLayout,
-    QWizard,
-    QWizardPage,
 )
 
 

--- a/Project/ui/PrimingControlWidget.py
+++ b/Project/ui/PrimingControlWidget.py
@@ -18,7 +18,7 @@ Date: 2025-10-16
 from datetime import datetime
 from typing import Dict, Optional, Set
 
-from PyQt5.QtCore import QObject, Qt, pyqtSignal
+from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtWidgets import (
     QComboBox,
     QGroupBox,

--- a/Project/ui/ScheduleProgressTracker.py
+++ b/Project/ui/ScheduleProgressTracker.py
@@ -14,15 +14,13 @@ Best Practices:
 
 from datetime import datetime
 
-from PyQt5.QtCore import QEasingCurve, QPropertyAnimation, Qt, QTimer, pyqtSignal, pyqtSlot
-from PyQt5.QtGui import QColor, QFont, QPalette
+from PyQt5.QtCore import QTimer
 from PyQt5.QtWidgets import (
     QFrame,
     QGridLayout,
     QHBoxLayout,
     QLabel,
     QProgressBar,
-    QPushButton,
     QScrollArea,
     QVBoxLayout,
     QWidget,

--- a/Project/ui/SettingsTab.py
+++ b/Project/ui/SettingsTab.py
@@ -12,7 +12,6 @@ from PyQt5.QtWidgets import (
     QCheckBox,
     QComboBox,
     QDialog,
-    QDoubleSpinBox,
     QFileDialog,
     QFormLayout,
     QGridLayout,
@@ -22,11 +21,8 @@ from PyQt5.QtWidgets import (
     QLineEdit,
     QMessageBox,
     QPushButton,
-    QSpinBox,
-    QTableWidget,
     QTableWidgetItem,
     QTabWidget,
-    QTextEdit,
     QVBoxLayout,
     QWidget,
 )
@@ -583,18 +579,13 @@ class SettingsTab(QWidget):
         - Visual indicators for calibration quality
         """
         from PyQt5.QtCore import Qt
-        from PyQt5.QtGui import QColor
         from PyQt5.QtWidgets import (
             QAbstractItemView,
-            QDialog,
-            QDialogButtonBox,
             QFrame,
             QHeaderView,
-            QProgressBar,
             QPushButton,
             QScrollArea,
             QTableWidget,
-            QTableWidgetItem,
         )
 
         widget = QWidget()

--- a/Project/ui/SlackCredentialsTab.py
+++ b/Project/ui/SlackCredentialsTab.py
@@ -1,12 +1,10 @@
 import json
-import os
 
 from PyQt5.QtWidgets import (
     QLabel,
     QLineEdit,
     QMessageBox,
     QPushButton,
-    QSizePolicy,
     QVBoxLayout,
     QWidget,
 )

--- a/Project/ui/SuggestSettingsTab.py
+++ b/Project/ui/SuggestSettingsTab.py
@@ -1,12 +1,10 @@
-from PyQt5.QtCore import QDateTime, Qt
+from PyQt5.QtCore import QDateTime
 from PyQt5.QtWidgets import (
-    QComboBox,
     QDateTimeEdit,
     QFormLayout,
     QHBoxLayout,
     QLabel,
     QLineEdit,
-    QMessageBox,
     QPushButton,
     QVBoxLayout,
     QWidget,

--- a/Project/ui/UserTab.py
+++ b/Project/ui/UserTab.py
@@ -3,20 +3,16 @@
 import traceback
 
 from PyQt5.QtCore import QDateTime, Qt, pyqtSignal
-from PyQt5.QtGui import QFont, QIcon
 from PyQt5.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QFormLayout,
-    QFrame,
     QGridLayout,
     QHBoxLayout,
-    QInputDialog,
     QLabel,
     QLineEdit,
     QMessageBox,
     QPushButton,
-    QSizePolicy,
     QVBoxLayout,
     QWidget,
 )

--- a/Project/ui/__init__.py
+++ b/Project/ui/__init__.py
@@ -1,12 +1,8 @@
 # ui/__init__.py
 
-from .animal_entry_widget import AnimalEntryWidget
 from .animals_tab import AnimalsTab
 from .gui import RodentRefreshmentGUI
 from .HelpTab import HelpTab
-from .projects_section import ProjectsSection
-from .relay_unit_widget import RelayUnitWidget
-from .run_stop_section import RunStopSection
 from .schedules_hub import SchedulesHub
 from .SettingsTab import SettingsTab
 from .SlackCredentialsTab import SlackCredentialsTab

--- a/Project/ui/animal_entry_widget.py
+++ b/Project/ui/animal_entry_widget.py
@@ -1,6 +1,5 @@
 # ui/animal_entry_widget.py
 
-from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QHBoxLayout, QLabel, QLineEdit, QWidget
 
 

--- a/Project/ui/available_animals_list.py
+++ b/Project/ui/available_animals_list.py
@@ -1,8 +1,8 @@
 # ui/available_animals_list.py
 
-from PyQt5.QtCore import QByteArray, QDataStream, QIODevice, QMimeData, QPoint, QRect, QSize, Qt
+from PyQt5.QtCore import QByteArray, QDataStream, QIODevice, QMimeData, QPoint, QRect, Qt
 from PyQt5.QtGui import QColor, QDrag, QFont, QLinearGradient, QPainter, QPen, QPixmap
-from PyQt5.QtWidgets import QLabel, QListWidget, QListWidgetItem
+from PyQt5.QtWidgets import QListWidget, QListWidgetItem
 
 
 class AvailableAnimalsList(QListWidget):

--- a/Project/ui/cages_visualization_tab.py
+++ b/Project/ui/cages_visualization_tab.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, Optional
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import (
-    QApplication,
     QFrame,
     QHBoxLayout,
     QLabel,

--- a/Project/ui/components/wizard.py
+++ b/Project/ui/components/wizard.py
@@ -22,7 +22,6 @@ from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional
 
 from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QFont
 from PyQt5.QtWidgets import (
     QFrame,
     QHBoxLayout,

--- a/Project/ui/gui.py
+++ b/Project/ui/gui.py
@@ -3,7 +3,7 @@
 import traceback
 
 from notifications.notifications import NotificationHandler
-from PyQt5.QtCore import Qt, QTimer, QUrl, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import QTimer, QUrl, pyqtSignal, pyqtSlot
 from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtWidgets import (
     QFrame,
@@ -12,13 +12,11 @@ from PyQt5.QtWidgets import (
     QMessageBox,
     QPlainTextEdit,
     QPushButton,
-    QScrollArea,
     QSizePolicy,
     QTabWidget,
     QVBoxLayout,
     QWidget,
 )
-from utils.volume_calculator import VolumeCalculator
 from version import __version__
 
 from .HelpTab import HelpTab

--- a/Project/ui/login_gate_widget.py
+++ b/Project/ui/login_gate_widget.py
@@ -1,6 +1,6 @@
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QColor, QFont, QPalette
-from PyQt5.QtWidgets import QHBoxLayout, QLabel, QPushButton, QStackedWidget, QVBoxLayout, QWidget
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QFont
+from PyQt5.QtWidgets import QLabel, QPushButton, QStackedWidget, QVBoxLayout, QWidget
 
 
 class LoginGateWidget(QStackedWidget):

--- a/Project/ui/projects_section.py
+++ b/Project/ui/projects_section.py
@@ -14,7 +14,7 @@ Architecture:
 - Wizard tab creates schedules, Schedules tab displays/manages them
 """
 
-from PyQt5.QtWidgets import QMessageBox, QPushButton, QTabWidget, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QTabWidget, QVBoxLayout, QWidget
 
 from .animals_tab import AnimalsTab
 from .cages_visualization_tab import CagesVisualizationTab

--- a/Project/ui/relay_unit_widget.py
+++ b/Project/ui/relay_unit_widget.py
@@ -2,18 +2,14 @@
 
 from datetime import datetime
 
-from models.animal import Animal
 from PyQt5.QtCore import QDataStream, QDateTime, QIODevice, Qt, pyqtSignal
 from PyQt5.QtWidgets import (
-    QComboBox,
     QDateTimeEdit,
     QHBoxLayout,
-    QHeaderView,
     QLabel,
     QLineEdit,
     QMessageBox,
     QPushButton,
-    QScrollArea,
     QSizePolicy,
     QTableWidget,
     QTableWidgetItem,

--- a/Project/ui/run_stop_section.py
+++ b/Project/ui/run_stop_section.py
@@ -1,23 +1,12 @@
 from datetime import datetime
 
-from gpio.relay_worker import RelayWorker
-from PyQt5.QtCore import QDateTime, Qt, QTimer, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import QTimer, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import (
-    QApplication,
-    QComboBox,
-    QDateTimeEdit,
-    QDialog,
-    QFormLayout,
     QGroupBox,
     QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QListWidget,
     QMessageBox,
     QPushButton,
     QSizePolicy,
-    QStackedWidget,
-    QTabWidget,
     QVBoxLayout,
     QWidget,
 )

--- a/Project/ui/schedule_drop_area.py
+++ b/Project/ui/schedule_drop_area.py
@@ -3,12 +3,9 @@ import traceback
 
 from models.database_handler import DatabaseHandler
 from models.Schedule import Schedule
-from PyQt5.QtCore import QDateTime, Qt, pyqtSignal
+from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
-    QComboBox,
-    QHBoxLayout,
     QLabel,
-    QPushButton,
     QSizePolicy,
     QTableWidget,
     QTableWidgetItem,

--- a/Project/ui/schedule_table.py
+++ b/Project/ui/schedule_table.py
@@ -1,5 +1,5 @@
 from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QHeaderView, QMessageBox, QTableWidget, QTableWidgetItem
+from PyQt5.QtWidgets import QHeaderView, QTableWidget, QTableWidgetItem
 
 
 class ScheduleTable(QTableWidget):

--- a/Project/ui/schedule_wizard.py
+++ b/Project/ui/schedule_wizard.py
@@ -26,11 +26,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from PyQt5.QtCore import QDateTime, Qt, QTime, pyqtSignal
+from PyQt5.QtCore import QDateTime, Qt, pyqtSignal
 from PyQt5.QtWidgets import (
-    QCheckBox,
     QComboBox,
-    QCompleter,
     QDateTimeEdit,
     QDoubleSpinBox,
     QFormLayout,
@@ -44,9 +42,6 @@ from PyQt5.QtWidgets import (
     QListWidgetItem,
     QMessageBox,
     QScrollArea,
-    QSizePolicy,
-    QSpinBox,
-    QTimeEdit,
     QVBoxLayout,
     QWidget,
 )
@@ -740,7 +735,6 @@ class Step3ConfigureParameters(QWidget):
 
         Reference: Qt Documentation - QComboBox with QCompleter
         """
-        from PyQt5.QtCore import QStringListModel
         from PyQt5.QtWidgets import QCompleter
 
         animal_id = animal["id"]
@@ -962,7 +956,6 @@ class Step3ConfigureParameters(QWidget):
 
         Reference: Qt Documentation - QComboBox with QCompleter
         """
-        from PyQt5.QtCore import QStringListModel
         from PyQt5.QtWidgets import QCompleter
 
         animal_id = animal["id"]

--- a/Project/ui/schedules_hub.py
+++ b/Project/ui/schedules_hub.py
@@ -15,7 +15,7 @@ Features:
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Dict, List
 
 from models.Schedule import Schedule
 from PyQt5.QtCore import QDateTime, QMimeData, QPoint, Qt, QTimer, pyqtSignal
@@ -26,12 +26,9 @@ from PyQt5.QtWidgets import (
     QCompleter,
     QDateTimeEdit,
     QDialog,
-    QDialogButtonBox,
     QDoubleSpinBox,
-    QFormLayout,
     QFrame,
     QGridLayout,
-    QGroupBox,
     QHBoxLayout,
     QLabel,
     QLineEdit,
@@ -40,7 +37,6 @@ from PyQt5.QtWidgets import (
     QPushButton,
     QScrollArea,
     QSizePolicy,
-    QSpinBox,
     QVBoxLayout,
     QWidget,
 )

--- a/Project/ui/staggered_delivery_slot.py
+++ b/Project/ui/staggered_delivery_slot.py
@@ -1,6 +1,4 @@
-from datetime import datetime
-
-from PyQt5.QtCore import QDateTime, Qt, QTimer, pyqtSignal
+from PyQt5.QtCore import QDateTime, pyqtSignal
 from PyQt5.QtWidgets import (
     QDateTimeEdit,
     QHBoxLayout,

--- a/Project/ui/wizard_tab.py
+++ b/Project/ui/wizard_tab.py
@@ -6,7 +6,7 @@ This tab provides the new step-by-step wizard interface for creating schedules,
 allowing side-by-side comparison with the traditional Schedules tab method.
 """
 
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QHBoxLayout, QLabel, QMessageBox, QPushButton, QVBoxLayout, QWidget
 
 from .schedule_wizard import ScheduleCreationWizard

--- a/Project/utils/calibration.py
+++ b/Project/utils/calibration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import Dict, Optional
+from typing import Dict
 
 
 class CalibrationStore:

--- a/Project/utils/help_content_manager.py
+++ b/Project/utils/help_content_manager.py
@@ -2,7 +2,7 @@
 import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
-from urllib.parse import quote, unquote
+from urllib.parse import quote
 
 # ---------------------------------------------------------------------------
 # Palette — used by _format_content and get_landing_page / get_topic_not_found

--- a/Project/utils/timing_calculator.py
+++ b/Project/utils/timing_calculator.py
@@ -1,5 +1,5 @@
 import math
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 
 class TimingCalculator:


### PR DESCRIPTION
Phase 3.7b-2. Removes 118 unused imports flagged by F401. 112 were auto-removed by `ruff check --fix --select F401`; the 6 non-auto-fixable were each reviewed by hand:

  - ui/__init__.py (4): AnimalEntryWidget, ProjectsSection, RelayUnitWidget, RunStopSection were re-exported from the package but are NOT in __all__ and nothing imports them via `ui` (callers import straight from the submodules). Dead re-exports -> removed. The 10 __all__ names keep their imports, so test_ui_package_imports_cleanly still passes.
  - flow_sensor_factory.py (2): the `from .flow_sensor import ...` / `from .uart_flow_sensor import ...` inside try/except ImportError ARE the availability probe for get_available_sensor_types() — the import itself is the test, the name is intentionally unused. Kept, with `# noqa: F401  (import IS the availability probe)` + comment so it's obvious to the next reader and ruff stays quiet.

Incidental dead-code cleanups that fell out of this:
  - solenoid_flow_strategy.py: leftover `import time` (residue from the v1.8.4->1.8.6 stop-timing instrumentation churn).
  - relay_worker.py: unused top-level `SLF3S0600FDriver` import (the driver is lazy-imported where actually needed; helps future 5.3).

CI gate widened: tests.yml now enforces format + I + F401.

Safety: full suite 42 passed / 7 skipped; Qt-free import smoke of the model/strategy/driver/util modules clean (no NameError from a removed import, no import-order/circular breakage). The remaining F841 (10) and F811 (5) are the next PR (3.7b-3).

No version bump (lint/style, no runtime effect — MAINTENANCE.md §1).