### PR TITLE
refactor(lint): resolve F841 unused-vars + F811 redefinitions; full C…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,15 +30,13 @@ jobs:
           python3 -m pip install -r requirements.txt
           python3 -m pip install -r requirements-dev.txt
 
-      - name: Lint (ruff) — format + import-sort
+      - name: Lint (ruff) — format + full configured ruleset
         run: |
-          # Enforce only the rules cleaned so far. ruff.toml's `select`
-          # lists the full target set (F401/F811/F841/I); CI gates it
-          # incrementally as each family is fixed in its own PR:
-          #   now: formatting + import-sort (I) + unused-imports (F401)
-          #   next: F841 unused-vars, then F811 redefinitions.
+          # The incremental adoption is complete: every family in
+          # ruff.toml's `select` (I, F401, F811, F841) is now clean, so CI
+          # enforces the full configured ruleset via a bare `ruff check`.
           ruff format --check .
-          ruff check --select I,F401 .
+          ruff check .
 
       - name: Run pytest
         run: python3 -m pytest

--- a/Project/controllers/system_controller.py
+++ b/Project/controllers/system_controller.py
@@ -155,8 +155,10 @@ class SystemController(QObject):
 
             temp_settings = self.settings.copy()
             # Probe hats by optimistic init. RelayHandler internally logs errors.
+            # The construction IS the probe (side effect); the instance is
+            # intentionally unused, so we don't bind it.
             manager = RelayUnitManager(temp_settings)
-            handler = RelayHandler(manager, temp_settings.get('num_hats', 1))
+            RelayHandler(manager, temp_settings.get('num_hats', 1))
             hats = max(1, temp_settings.get('num_hats', 1))
             return hats
         except Exception:

--- a/Project/gpio/relay_worker.py
+++ b/Project/gpio/relay_worker.py
@@ -856,7 +856,6 @@ class RelayWorker(QObject):
         - **Circuit Breaker**: Prevent infinite retry loops on sensor failure
         """
         try:
-            current_time = datetime.now()
             target_volumes = self.settings.get(
                 'target_volumes', self.settings.get('desired_water_outputs', {})
             )

--- a/Project/models/database_handler.py
+++ b/Project/models/database_handler.py
@@ -1,6 +1,5 @@
 # models/database_handler.py
 
-import datetime
 import hashlib
 import json
 import os

--- a/Project/models/login_system.py
+++ b/Project/models/login_system.py
@@ -39,10 +39,6 @@ class LoginSystem(QObject):
         self.login_status_changed.emit()  # Emit signal
         print("Trainer logged out. Switched to Guest mode.")
 
-    def get_current_trainer(self):
-        """Return the current trainer or None if not logged in."""
-        return self.current_trainer
-
     def is_logged_in(self):
         """Check if a trainer is currently logged in."""
         return self.current_trainer is not None

--- a/Project/strategies/solenoid_flow_strategy.py
+++ b/Project/strategies/solenoid_flow_strategy.py
@@ -216,7 +216,6 @@ class SolenoidFlowStrategy:
             for cage_id, cal in all_cals.items():
                 pw = int(cal.get('pulse_width_ms') or 0)
                 vol = float(cal.get('volume_per_pulse_ml') or 0.0)
-                cid = float(cal.get('cage_id') or cage_id)
                 if not self._cal_snapshot.get(cage_id):
                     self._cal_snapshot[cage_id] = {}
                 self._cal_snapshot[cage_id][pw] = {
@@ -954,7 +953,6 @@ class SolenoidFlowStrategy:
                 await close_task
             except Exception:
                 pass
-            valve_close_time = asyncio.get_event_loop().time()
 
             # Step 6: Continue collecting during settling
             while (asyncio.get_event_loop().time() - start_time) < total_measurement_s:

--- a/Project/ui/CalibrationWizard.py
+++ b/Project/ui/CalibrationWizard.py
@@ -467,19 +467,17 @@ class CalibrationWizard(QDialog):
         results_group.setLayout(results_layout)
         self.content_layout.addWidget(results_group)
 
-        # Quality assessment
+        # Quality assessment. NOTE: a per-quality color was previously
+        # computed here but never applied to any widget — removed as dead
+        # code. If quality coloring is wanted, wire it into quality_label.
         if cv_pct < 1.0:
             quality = "EXCELLENT"
-            color = "#4CAF50"
         elif cv_pct < 3.0:
             quality = "GOOD"
-            color = "#8BC34A"
         elif cv_pct < 5.0:
             quality = "ACCEPTABLE"
-            color = "#FFC107"
         else:
             quality = "POOR"
-            color = "#F44336"
 
         quality_label = QLabel(f"Quality: {quality}")
         quality_label.setAlignment(Qt.AlignCenter)

--- a/Project/ui/HelpTab.py
+++ b/Project/ui/HelpTab.py
@@ -258,7 +258,6 @@ class HelpTab(QWidget):
         matching_keys = {key for key, _snippet in results}
 
         # Update tree visibility
-        has_any = False
         for i in range(self.topic_tree.topLevelItemCount()):
             cat_item = self.topic_tree.topLevelItem(i)
             cat_has_match = False
@@ -269,7 +268,6 @@ class HelpTab(QWidget):
                 child.setHidden(not visible)
                 if visible:
                     cat_has_match = True
-                    has_any = True
             cat_item.setHidden(not cat_has_match)
 
         self.topic_tree.expandAll()

--- a/Project/ui/SettingsTab.py
+++ b/Project/ui/SettingsTab.py
@@ -1574,8 +1574,11 @@ class SettingsTab(QWidget):
                             else None
                         )
 
-                        # Convert birthdate to our datetime format
-                        birthdate = datetime.strptime(str(row['Birthdate']), '%y%m%d')
+                        # Validate the birthdate format (raises on bad data,
+                        # skipping the row). NOTE: the parsed value is not
+                        # stored — Animal has no birthdate field yet; this is
+                        # known debt, kept as a validation gate only.
+                        datetime.strptime(str(row['Birthdate']), '%y%m%d')
 
                         animal = Animal(
                             animal_id=None,

--- a/Project/ui/schedule_wizard.py
+++ b/Project/ui/schedule_wizard.py
@@ -706,7 +706,6 @@ class Step3ConfigureParameters(QWidget):
         animals_layout = QVBoxLayout(animals_group)
 
         for animal in self._selected_animals:
-            animal_id = animal["id"]
             animal_widget = self._create_staggered_animal_row(animal)
             animals_layout.addWidget(animal_widget)
 
@@ -1485,8 +1484,6 @@ class ScheduleCreationWizard(QWidget):
         Reference: Material Design Steppers - "Users can return to a previous step
         to edit their response."
         """
-        # Determine navigation direction
-        is_going_forward = step_index > self._last_step_index
         first_visit = step_index not in self._visited_steps
 
         # Mark step as visited

--- a/Project/utils/help_content_manager.py
+++ b/Project/utils/help_content_manager.py
@@ -1398,7 +1398,6 @@ class HelpContentManager:
         related = self.get_related(topic_key)
         if not related:
             return ""
-        p = _PALETTE.get(theme, _PALETTE['light'])
         links = "".join(f"<a href='topic:{quote(k)}'>{k}</a>" for k in related)
         return f"<div class='related-topics'><strong>Related topics:</strong> {links}</div>"
 


### PR DESCRIPTION
…I gate (3.7b-3)

Phase 3.7b-3 — closes the ruff adoption. Each item reviewed, not blanket-fixed.

F841 unused-variable (10), handled by intent:
  - Pure dead assignments removed (RHS side-effect-free): relay_worker current_time, solenoid_flow_strategy cid + valve_close_time, schedule_wizard animal_id + is_going_forward, help_content_manager p, HelpTab has_any (both the init and the set).
  - CalibrationWizard: a per-quality `color` was computed in all 4 branches but never applied to any widget — removed as dead code; comment left so quality-coloring can be wired up intentionally later.
  - system_controller: `handler = RelayHandler(...)` is a hardware PROBE — the construction's side effect (and error logging) is the point. Kept the call, dropped the unused binding.
  - SettingsTab lab-import: `birthdate = datetime.strptime(...)` is parsed but never passed to Animal() — kept as a bare validation-by-exception call (preserves the existing "bad date -> skip row" behavior) and documented the latent gap (Animal has no birthdate field). Behavior intentionally unchanged here.

F811 redefined-while-unused (5):
  - 3 redundant LOCAL re-imports of already-top-imported Qt classes (SettingsTab QTableWidget, schedule_wizard QCompleter x2) — auto-fixed.
  - database_handler: dead `import datetime` shadowed by `from datetime import datetime`. Verified the file uses no module-only attrs (no timedelta/date/timezone) before removing — import-smoke confirms it still loads.
  - login_system: duplicate `get_current_trainer` (two defs, byte-identical bodies). Removed the dead first one — provably behavior-neutral.

CI gate: now a bare `ruff check .` enforcing the full ruff.toml select (I, F401, F811, F841) + `ruff format --check`. The adoption gap is closed — a new unused import/var/redefinition or unsorted import now fails CI.

Safety: full suite 42 passed / 7 skipped; Qt-free import smoke of the edited model/strategy/util modules clean. Tests untouched.

Latent debt surfaced (NOT fixed here — out of scope): CalibrationWizard quality color never applied; SettingsTab lab-import drops birthdate.

No version bump (lint/style, no runtime effect — MAINTENANCE.md §1).