### PR TITLE
refactor(db): finish DatabaseHandler dependency injection (R3)

### DIFF
--- a/Project/controllers/projects_controller.py
+++ b/Project/controllers/projects_controller.py
@@ -1,10 +1,11 @@
 from models.animal import Animal
-from models.database_handler import DatabaseHandler
 
 
 class ProjectsController:
-    def __init__(self):
-        self.db_handler = DatabaseHandler()
+    def __init__(self, database_handler):
+        if database_handler is None:
+            raise ValueError("database_handler is required")
+        self.db_handler = database_handler
 
     # Animal-related methods
     def add_animal(self, name, initial_weight, last_weight, last_weighted):

--- a/Project/main.py
+++ b/Project/main.py
@@ -184,7 +184,7 @@ def setup():
         f"✓ RelayUnitManager initialized in {relay_unit_manager.get_hardware_mode()} mode with {len(relay_unit_manager.get_all_relay_units())} units"
     )
 
-    controller = ProjectsController()
+    controller = ProjectsController(database_handler)
     pump_controller = PumpController(relay_handler, database_handler)
     controller.pump_controller = pump_controller
 

--- a/Project/tests/unit/test_db_handler_di.py
+++ b/Project/tests/unit/test_db_handler_di.py
@@ -1,0 +1,73 @@
+"""Regression tests for the database-handler DI contract (R3).
+
+After R3 (finish DI), the two classes that previously self-constructed
+their own ``DatabaseHandler`` — ``ProjectsController`` and
+``ScheduleDropArea`` — must instead accept the canonical handler as a
+required constructor argument. These tests pin that contract so a future
+edit can't silently re-introduce a second writer to the DB.
+
+Background: see DATABASE_HANDLER_REFACTOR_DESIGN.md §10 ("DI feasibility")
+— two redundant ``DatabaseHandler()`` instances each re-ran
+``create_tables()`` on startup; the goal was one canonical handle.
+
+``ProjectsController`` is Qt-free; ``ScheduleDropArea`` imports PyQt5 and
+is skipped where PyQt5 is unavailable (same convention as test_gui_smoke).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_projects_controller_requires_database_handler(database_handler):
+    """Injected handler must be stored verbatim — no self-construct."""
+    from controllers.projects_controller import ProjectsController  # noqa: PLC0415
+
+    controller = ProjectsController(database_handler)
+    assert controller.db_handler is database_handler
+
+
+def test_projects_controller_rejects_missing_handler():
+    """Constructing without a handler must fail loudly, not silently work."""
+    from controllers.projects_controller import ProjectsController  # noqa: PLC0415
+
+    with pytest.raises(TypeError):
+        ProjectsController()  # signature requires database_handler
+    with pytest.raises(ValueError):
+        ProjectsController(None)
+
+
+def test_schedule_drop_area_requires_database_handler(database_handler):
+    """ScheduleDropArea must accept the injected handler and store it."""
+    pytest.importorskip("PyQt5")
+    import os  # noqa: PLC0415
+
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PyQt5.QtWidgets import QApplication  # noqa: PLC0415
+
+    from ui.schedule_drop_area import ScheduleDropArea  # noqa: PLC0415
+
+    app = QApplication.instance() or QApplication([])
+    try:
+        area = ScheduleDropArea(database_handler)
+        assert area.database_handler is database_handler
+    finally:
+        if app is not None:
+            app.processEvents()
+
+
+def test_schedule_drop_area_rejects_missing_handler():
+    """ScheduleDropArea must refuse a None/absent handler."""
+    pytest.importorskip("PyQt5")
+    import os  # noqa: PLC0415
+
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    from PyQt5.QtWidgets import QApplication  # noqa: PLC0415
+
+    from ui.schedule_drop_area import ScheduleDropArea  # noqa: PLC0415
+
+    _ = QApplication.instance() or QApplication([])
+    with pytest.raises(TypeError):
+        ScheduleDropArea()  # signature requires database_handler
+    with pytest.raises(ValueError):
+        ScheduleDropArea(None)

--- a/Project/ui/run_stop_section.py
+++ b/Project/ui/run_stop_section.py
@@ -118,7 +118,7 @@ class RunStopSection(QWidget):
         schedule_group = QGroupBox("Schedule Queue")
         schedule_layout = QVBoxLayout()
         schedule_layout.setContentsMargins(12, 12, 12, 12)
-        self.schedule_drop_area = ScheduleDropArea()
+        self.schedule_drop_area = ScheduleDropArea(self.database_handler)
         self.schedule_drop_area.schedule_dropped.connect(self.on_schedule_dropped)
         print("Connected schedule_dropped signal to on_schedule_dropped slot")
         schedule_layout.addWidget(self.schedule_drop_area)

--- a/Project/ui/schedule_drop_area.py
+++ b/Project/ui/schedule_drop_area.py
@@ -1,7 +1,6 @@
 import datetime
 import traceback
 
-from models.database_handler import DatabaseHandler
 from models.Schedule import Schedule
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtWidgets import (
@@ -20,14 +19,15 @@ class ScheduleDropArea(QWidget):
     mode_changed = pyqtSignal(str)
     schedule_dropped = pyqtSignal(object)  # Signal for when schedule is dropped
 
-    def __init__(self, parent=None):
+    def __init__(self, database_handler, parent=None):
         super().__init__(parent)
+        if database_handler is None:
+            raise ValueError("database_handler is required")
         self.layout = QVBoxLayout()
         self.layout.setContentsMargins(0, 0, 0, 0)  # Remove margins to maximize space
         self.setLayout(self.layout)
 
-        # Initialize database handler
-        self.database_handler = DatabaseHandler()
+        self.database_handler = database_handler
 
         # Drop area
         self.drop_widget = QWidget()

--- a/Project/ui/splash_screen.py
+++ b/Project/ui/splash_screen.py
@@ -91,7 +91,7 @@ class InitializationWorker(QThread):
             from controllers.projects_controller import ProjectsController
             from controllers.pump_controller import PumpController
 
-            controller = ProjectsController()
+            controller = ProjectsController(self._components['database_handler'])
             pump_controller = PumpController(
                 self._components['relay_handler'], self._components['database_handler']
             )


### PR DESCRIPTION
Two classes were still self-constructing a DatabaseHandler at __init__ time (ProjectsController, ScheduleDropArea), giving the live app three DB handles instead of one — each redundant instance also re-ran create_tables() on startup. R3 from the design doc finishes the DI pattern the rest of the codebase already follows: both classes now accept the canonical handler as a required constructor argument.

Changes:
- ProjectsController.__init__(self, database_handler): required, raises on None; DatabaseHandler import dropped.
- ScheduleDropArea.__init__(self, database_handler, parent=None): required, raises on None; DatabaseHandler import dropped.
- main.py:187 — pass the canonical database_handler created at line 162.
- ui/run_stop_section.py:121 — pass self.database_handler (already held by RunStopSection since its own DI was finished earlier).
- ui/splash_screen.py:94 — pass the splash worker's own _components handle (splash itself stays deferred per design doc §10, splash flag USE_SPLASH_SCREEN=False; this is purely the transitive signature fix).

Tests: new Project/tests/unit/test_db_handler_di.py pins the contract (injected handler stored verbatim, missing/None refused). Qt-free ProjectsController tests run everywhere; Qt-needing ScheduleDropArea tests skip without PyQt5 and run on the Pi suite.

No schema change, no runtime behavior change, no version bump (per design doc §10).