### PR TITLE
fix(ui): repair Delivery hardware-mode help text and polish the dropdown menu (v1.9.1)

### DIFF
--- a/Project/ui/SettingsTab.py
+++ b/Project/ui/SettingsTab.py
@@ -175,7 +175,7 @@ class SettingsTab(QWidget):
             # Build updated settings dictionary from UI widgets
             updated_settings = {
                 # Hardware mode
-                'hardware_mode': self.hardware_mode_combo.currentText(),
+                'hardware_mode': self.hardware_mode_combo.currentData() or 'solenoid',
                 # Theme (if exists)
                 'theme': self.theme_combo.currentText()
                 if hasattr(self, 'theme_combo')
@@ -241,19 +241,27 @@ class SettingsTab(QWidget):
         mode_layout.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
 
         self.hardware_mode_combo = QComboBox()
-        self.hardware_mode_combo.addItems(['solenoid', 'pump'])
+        # Display capitalized labels; store the canonical lowercase value as
+        # userData so the saved setting (consumed by the strategy factory /
+        # relay worker) stays 'solenoid' / 'pump'.
+        self.hardware_mode_combo.addItem("Solenoid", "solenoid")
+        self.hardware_mode_combo.addItem("Pump", "pump")
         current_mode = self.settings.get('hardware_mode', 'solenoid')
-        self.hardware_mode_combo.setCurrentText(current_mode)
+        mode_idx = self.hardware_mode_combo.findData(current_mode)
+        self.hardware_mode_combo.setCurrentIndex(mode_idx if mode_idx >= 0 else 0)
         self.hardware_mode_combo.currentTextChanged.connect(self._on_hardware_mode_changed)
         mode_layout.addRow("Hardware Mode:", self.hardware_mode_combo)
 
         mode_help = QLabel(
-            "• <b>Solenoid</b> (default): Flow sensor-based volumetric control with real-time feedback\n"
-            "• <b>Pump</b>: Time-based peristaltic pump control (legacy mode)"
+            "• <b>Solenoid</b> (default): flow-sensor volumetric control with "
+            "real-time feedback<br>"
+            "• <b>Pump</b>: time-based peristaltic pump control (legacy mode)"
         )
         mode_help.setWordWrap(True)
         mode_help.setObjectName("HelpText")
-        mode_layout.addRow("", mode_help)
+        # Span the full row (no indent into the field column) so the two
+        # bullets have room and don't wrap awkwardly.
+        mode_layout.addRow(mode_help)
 
         mode_group.setLayout(mode_layout)
         layout.addWidget(mode_group)
@@ -449,8 +457,9 @@ class SettingsTab(QWidget):
                 )
                 # Revert to previous mode
                 old_mode = self.settings.get('hardware_mode', 'solenoid')
+                old_idx = self.hardware_mode_combo.findData(old_mode)
                 self.hardware_mode_combo.blockSignals(True)
-                self.hardware_mode_combo.setCurrentText(old_mode)
+                self.hardware_mode_combo.setCurrentIndex(old_idx if old_idx >= 0 else 0)
                 self.hardware_mode_combo.blockSignals(False)
                 return
 
@@ -465,7 +474,7 @@ class SettingsTab(QWidget):
 
         Progressive Disclosure: Only show relevant settings
         """
-        is_solenoid = self.hardware_mode_combo.currentText() == 'solenoid'
+        is_solenoid = self.hardware_mode_combo.currentData() == 'solenoid'
         self.solenoid_group.setVisible(is_solenoid)
         self.pump_group.setVisible(not is_solenoid)
 

--- a/Project/ui/SettingsTab.py
+++ b/Project/ui/SettingsTab.py
@@ -231,14 +231,15 @@ class SettingsTab(QWidget):
         layout.setSpacing(12)
 
         # ==================== MODE SELECTION ====================
+        # Two-column card: a compact selector on the left, the explanatory
+        # bullets filling the space to its right (top-aligned), so the wide
+        # card reads as one balanced row instead of a half-width control with
+        # a large blank gap beside/below it.
         mode_group = QGroupBox("Delivery Hardware Mode")
-        mode_layout = QFormLayout()
-        mode_layout.setContentsMargins(12, 12, 12, 12)
-        mode_layout.setSpacing(8)
-        # Fix label truncation: allow labels to expand and wrap
-        # Reference: https://doc.qt.io/qt-5/qformlayout.html#FieldGrowthPolicy-enum
-        mode_layout.setFieldGrowthPolicy(QFormLayout.ExpandingFieldsGrow)
-        mode_layout.setLabelAlignment(Qt.AlignLeft | Qt.AlignVCenter)
+        mode_layout = QGridLayout()
+        mode_layout.setContentsMargins(16, 12, 16, 12)
+        mode_layout.setHorizontalSpacing(16)
+        mode_layout.setVerticalSpacing(8)
 
         self.hardware_mode_combo = QComboBox()
         # Display capitalized labels; store the canonical lowercase value as
@@ -246,11 +247,19 @@ class SettingsTab(QWidget):
         # relay worker) stays 'solenoid' / 'pump'.
         self.hardware_mode_combo.addItem("Solenoid", "solenoid")
         self.hardware_mode_combo.addItem("Pump", "pump")
+        self.hardware_mode_combo.setMinimumWidth(150)
+        self.hardware_mode_combo.setMaximumWidth(200)
         current_mode = self.settings.get('hardware_mode', 'solenoid')
         mode_idx = self.hardware_mode_combo.findData(current_mode)
         self.hardware_mode_combo.setCurrentIndex(mode_idx if mode_idx >= 0 else 0)
         self.hardware_mode_combo.currentTextChanged.connect(self._on_hardware_mode_changed)
-        mode_layout.addRow("Hardware Mode:", self.hardware_mode_combo)
+
+        mode_layout.addWidget(
+            QLabel("Hardware Mode:"), 0, 0, Qt.AlignLeft | Qt.AlignVCenter
+        )
+        mode_layout.addWidget(
+            self.hardware_mode_combo, 0, 1, Qt.AlignLeft | Qt.AlignVCenter
+        )
 
         mode_help = QLabel(
             "• <b>Solenoid</b> (default): flow-sensor volumetric control with "
@@ -259,9 +268,13 @@ class SettingsTab(QWidget):
         )
         mode_help.setWordWrap(True)
         mode_help.setObjectName("HelpText")
-        # Span the full row (no indent into the field column) so the two
-        # bullets have room and don't wrap awkwardly.
-        mode_layout.addRow(mode_help)
+        mode_layout.addWidget(mode_help, 0, 2, Qt.AlignTop | Qt.AlignLeft)
+
+        # Keep the label/control columns compact; the help column absorbs the
+        # remaining width so the bullets sit top-right rather than leaving a gap.
+        mode_layout.setColumnStretch(0, 0)
+        mode_layout.setColumnStretch(1, 0)
+        mode_layout.setColumnStretch(2, 1)
 
         mode_group.setLayout(mode_layout)
         layout.addWidget(mode_group)

--- a/Project/ui/style/app-dark.qss
+++ b/Project/ui/style/app-dark.qss
@@ -129,6 +129,17 @@ QComboBox QAbstractItemView {
     selection-background-color: #134E4A;
     selection-color: #2DD4BF;
 }
+QComboBox QAbstractItemView::item {
+    min-height: 28px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    color: #E2E8F0;
+}
+QComboBox QAbstractItemView::item:selected,
+QComboBox QAbstractItemView::item:hover {
+    background: #134E4A;
+    color: #2DD4BF;
+}
 
 /* SpinBox buttons */
 QSpinBox::up-button, QDoubleSpinBox::up-button,

--- a/Project/ui/style/app-light.qss
+++ b/Project/ui/style/app-light.qss
@@ -129,6 +129,17 @@ QComboBox QAbstractItemView {
     selection-background-color: #E6FFFA;
     selection-color: #0D9488;
 }
+QComboBox QAbstractItemView::item {
+    min-height: 28px;
+    padding: 6px 10px;
+    border-radius: 6px;
+    color: #1A1D1F;
+}
+QComboBox QAbstractItemView::item:selected,
+QComboBox QAbstractItemView::item:hover {
+    background: #E6FFFA;
+    color: #0D9488;
+}
 
 /* SpinBox buttons */
 QSpinBox::up-button, QDoubleSpinBox::up-button,

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"


### PR DESCRIPTION
 (v1.9.1)

The mode-selection help label mixed <b> tags with "\n". A QLabel with any HTML switches to rich-text mode where "\n" is ignored, so the two bullets collapsed onto one run-on, awkwardly wrapped line. Use <br> and give the label its own full-width row so both bullets read cleanly.

Polish the hardware-mode dropdown: display capitalized labels (Solenoid / Pump) while storing the canonical lowercase value as userData, so the saved hardware_mode setting consumed by the strategy factory and relay worker is unchanged. Add QComboBox popup item padding / min-height / hover styling in both themes — the popup had no ::item rule, so entries rendered cramped.

UI-only; no delivery behavior change. Pump mode remains selectable and is still hidden under solenoid by the existing visibility toggle.