### PR TITLE
style(ui): white login prompt surface and drop the dead Login button

### DIFF
--- a/Project/tests/unit/test_login_gate_widget.py
+++ b/Project/tests/unit/test_login_gate_widget.py
@@ -1,0 +1,55 @@
+"""Regression guard for the logged-out login prompt (QA items #1, #3).
+
+Item #3: the prompt used to carry a "Login" button that only re-selected the
+already-current Profile tab, so it appeared to do nothing — it has been removed.
+Item #1: the prompt now carries the ``LoginGatePrompt`` objectName that the
+theme QSS uses to paint it with the card surface instead of the grey app
+background.
+
+Skips when PyQt5 is unavailable; CI installs ``python3-pyqt5`` so it runs there.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PyQt5.QtWidgets import QApplication  # noqa: PLC0415
+
+    return QApplication.instance() or QApplication([])
+
+
+def _make_gate(qapp):
+    from PyQt5.QtCore import QObject, pyqtSignal  # noqa: PLC0415
+    from PyQt5.QtWidgets import QWidget  # noqa: PLC0415
+    from ui.login_gate_widget import LoginGateWidget  # noqa: PLC0415
+
+    class StubLoginSystem(QObject):
+        login_status_changed = pyqtSignal()
+
+        def is_logged_in(self):
+            return False
+
+    return LoginGateWidget(QWidget(), StubLoginSystem())
+
+
+def test_login_prompt_has_no_button(qapp):
+    """The needless 'Login' button is gone from the logged-out prompt."""
+    from PyQt5.QtWidgets import QPushButton  # noqa: PLC0415
+
+    gate = _make_gate(qapp)
+    assert gate.login_prompt.findChildren(QPushButton) == []
+
+
+def test_login_prompt_uses_card_surface_objectname(qapp):
+    """The prompt is tagged for the card-coloured background in the theme QSS."""
+    gate = _make_gate(qapp)
+    assert gate.login_prompt.objectName() == "LoginGatePrompt"

--- a/Project/ui/login_gate_widget.py
+++ b/Project/ui/login_gate_widget.py
@@ -1,6 +1,6 @@
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QFont
-from PyQt5.QtWidgets import QLabel, QPushButton, QStackedWidget, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QLabel, QStackedWidget, QVBoxLayout, QWidget
 
 
 class LoginGateWidget(QStackedWidget):
@@ -29,41 +29,30 @@ class LoginGateWidget(QStackedWidget):
 
     def _create_login_prompt(self):
         """Create the login prompt widget with a clean, minimal design."""
+        # objectName drives the card-coloured background defined in the theme
+        # QSS (white in light, dark-card in dark) so the prompt reads as an
+        # intentional surface rather than the bare grey app background.
         container = QWidget()
+        container.setObjectName("LoginGatePrompt")
         layout = QVBoxLayout()
         layout.setAlignment(Qt.AlignCenter)
 
-        # Message
+        # Message. The login form itself lives in the always-visible Profile
+        # tab, so this prompt is informational only — no button (the old
+        # "Login" button just re-selected the already-current Profile tab and
+        # appeared to do nothing).
         message = QLabel("Please log in to access projects")
         message.setAlignment(Qt.AlignCenter)
         font = QFont()
         font.setPointSize(14)
         message.setFont(font)
 
-        # Login button
-        login_button = QPushButton("Login")
-        login_button.setFixedWidth(200)
-        login_button.setFixedHeight(40)
-        login_button.clicked.connect(self._show_login_dialog)
-        login_button.setProperty("variant", "primary")
-
-        # Add widgets to layout with spacing
         layout.addStretch()
         layout.addWidget(message)
-        layout.addSpacing(20)
-        layout.addWidget(login_button, alignment=Qt.AlignCenter)
         layout.addStretch()
 
         container.setLayout(layout)
         return container
-
-    def _show_login_dialog(self):
-        """Show the login tab in the settings section."""
-        main_window = self.window()  # Get the top-level window
-        if hasattr(main_window, 'main_tab_widget'):
-            # Get the index of the Profile tab
-            profile_tab_index = main_window.main_tab_widget.indexOf(main_window.user_tab)
-            main_window.main_tab_widget.setCurrentIndex(profile_tab_index)
 
     def _handle_login_status(self):
         """Update the visible widget based on login status."""

--- a/Project/ui/style/app-dark.qss
+++ b/Project/ui/style/app-dark.qss
@@ -48,6 +48,11 @@ QFrame#Card:hover, QFrame[card="true"]:hover {
     border-color: #4A5568;
 }
 
+/* Logged-out login prompt: card surface instead of the bare app background */
+QWidget#LoginGatePrompt, QWidget#LoginGatePrompt QLabel {
+    background-color: #1E2530;
+}
+
 /* ============================================
    TYPOGRAPHY HELPERS
    ============================================ */

--- a/Project/ui/style/app-light.qss
+++ b/Project/ui/style/app-light.qss
@@ -48,6 +48,11 @@ QFrame#Card:hover, QFrame[card="true"]:hover {
     border-color: #CBD5E0;
 }
 
+/* Logged-out login prompt: white surface instead of the grey app background */
+QWidget#LoginGatePrompt, QWidget#LoginGatePrompt QLabel {
+    background-color: #FFFFFF;
+}
+
 /* ============================================
    TYPOGRAPHY HELPERS
    ============================================ */


### PR DESCRIPTION
The logged-out prompt sat on the bare grey app background and carried a "Login" button that only re-selected the already-current Profile tab, so it appeared to do nothing (QA items #1, #3).

Remove the button (the login form lives in the always-visible Profile tab) and tag the prompt container with the LoginGatePrompt objectName, themed to the card surface (white in light, dark-card in dark) in both QSS files. Add an offscreen guard test asserting the prompt has no button and keeps the objectName.