### PR TITLE
style(ui): centre the Schedules empty state instead of bottom-pinning it

### DIFF
--- a/Project/tests/unit/test_schedules_empty_state.py
+++ b/Project/tests/unit/test_schedules_empty_state.py
@@ -1,0 +1,69 @@
+"""Regression test for the Schedules empty-state centering (QA item #6).
+
+When there are no schedules the "No Schedules / Create Schedule" prompt used to
+sit pinned to the bottom: the code hid the grid's inner widget but not the
+surrounding scroll area, so the scroll kept its stretch and pushed the
+no-stretch empty state down. The fix hides the scroll area itself and gives the
+empty state the stretch so its AlignCenter layout centres it.
+
+Skips when PyQt5 is unavailable; CI installs ``python3-pyqt5`` so it runs there.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PyQt5.QtWidgets import QApplication  # noqa: PLC0415
+
+    return QApplication.instance() or QApplication([])
+
+
+def _make_hub(qapp):
+    from PyQt5.QtCore import QObject, pyqtSignal  # noqa: PLC0415
+    from ui.schedules_hub import SchedulesHub  # noqa: PLC0415
+
+    class StubLoginSystem(QObject):
+        login_status_changed = pyqtSignal()
+
+        def get_current_trainer(self):
+            return None
+
+        def is_logged_in(self):
+            return False
+
+    database_handler = SimpleNamespace(
+        get_all_schedules=lambda: [],
+        get_schedules_by_trainer=lambda _tid: [],
+    )
+    return SchedulesHub(
+        settings={},
+        print_to_terminal=lambda *_: None,
+        database_handler=database_handler,
+        login_system=StubLoginSystem(),
+    )
+
+
+def test_empty_state_shown_and_scroll_hidden(qapp):
+    """With no schedules the empty state shows and the scroll area is hidden."""
+    hub = _make_hub(qapp)
+    assert hub._scroll.isHidden()
+    assert not hub._empty_state.isHidden()
+
+
+def test_empty_state_has_stretch_for_vertical_centering(qapp):
+    """The empty state carries layout stretch so it fills/centres, not bottom-pins."""
+    hub = _make_hub(qapp)
+    layout = hub.layout()
+    idx = layout.indexOf(hub._empty_state)
+    assert idx != -1
+    assert layout.stretch(idx) == 1

--- a/Project/ui/schedules_hub.py
+++ b/Project/ui/schedules_hub.py
@@ -878,7 +878,8 @@ class SchedulesHub(QWidget):
         self._grid_layout.setContentsMargins(0, 0, 0, 0)
 
         scroll.setWidget(self._grid_container)
-        layout.addWidget(scroll, 1)
+        self._scroll = scroll
+        layout.addWidget(self._scroll, 1)
 
         # Empty state
         self._empty_state = QWidget()
@@ -905,7 +906,10 @@ class SchedulesHub(QWidget):
         empty_layout.addWidget(create_btn, alignment=Qt.AlignCenter)
 
         self._empty_state.hide()
-        layout.addWidget(self._empty_state)
+        # Stretch so the empty state fills the space the scroll area vacates and
+        # its AlignCenter layout centres the message vertically, instead of
+        # pinning it to the bottom under a still-expanded scroll area.
+        layout.addWidget(self._empty_state, 1)
 
     def _toggle_select_mode(self) -> None:
         self._select_mode = not self._select_mode
@@ -1029,11 +1033,11 @@ class SchedulesHub(QWidget):
 
         if not schedules:
             self._empty_state.show()
-            self._grid_container.hide()
+            self._scroll.hide()
             return
 
         self._empty_state.hide()
-        self._grid_container.show()
+        self._scroll.show()
 
         cols = 3
         for idx, schedule in enumerate(schedules):


### PR DESCRIPTION
When no schedules exist, _display_schedules hid the grid's inner widget but left the surrounding scroll area visible with its stretch, so the "No Schedules / Create Schedule" prompt was pushed to the bottom of the tab (QA item #6).

Hide the scroll area itself and give the empty state the layout stretch so its AlignCenter layout centres the prompt vertically. Add an offscreen test asserting the empty state shows with the scroll hidden and carries the stretch.