### PR TITLE
style(help): space out Related-topics links

### DIFF
--- a/Project/tests/unit/test_help_related_topics.py
+++ b/Project/tests/unit/test_help_related_topics.py
@@ -1,0 +1,26 @@
+"""Regression test for Related-topics link spacing in help pages (QA item #12).
+
+The CSS uses ``margin-right`` on the inline ``<a>`` links, but QTextBrowser's
+rich-text engine ignores margins on inline elements, so the links rendered
+concatenated with no gap (e.g. "First Time SetupBasic OperationsExecution
+Monitor"). The generator now joins them with an explicit non-breaking-space
+separator. This is a pure string test — no Qt required.
+"""
+
+from __future__ import annotations
+
+from utils.help_content_manager import HelpContentManager
+
+
+def test_related_topic_links_are_separated():
+    mgr = HelpContentManager()
+
+    # System Overview has several related topics.
+    related = mgr.get_related("System Overview")
+    assert len(related) > 1
+
+    html = mgr.get_content("System Overview")
+    # No two links are rendered directly adjacent (the old concatenation bug).
+    assert "</a><a" not in html
+    # An explicit separator sits between the links.
+    assert "&middot;" in html

--- a/Project/utils/help_content_manager.py
+++ b/Project/utils/help_content_manager.py
@@ -1398,7 +1398,12 @@ class HelpContentManager:
         related = self.get_related(topic_key)
         if not related:
             return ""
-        links = "".join(f"<a href='topic:{quote(k)}'>{k}</a>" for k in related)
+        # QTextBrowser's rich-text engine ignores `margin` on inline <a>, so the
+        # CSS margin-right alone renders the links concatenated with no gap.
+        # Join with an explicit non-breaking-space separator so they read as a
+        # spaced, bulleted list.
+        sep = "&nbsp;&nbsp;&middot;&nbsp;&nbsp;"
+        links = sep.join(f"<a href='topic:{quote(k)}'>{k}</a>" for k in related)
         return f"<div class='related-topics'><strong>Related topics:</strong> {links}</div>"
 
     def _format_content(self, html_body: str, theme: str, extra_css: str = "") -> str:


### PR DESCRIPTION
The related-topics links relied on a CSS margin-right, but QTextBrowser's rich-text engine ignores margins on inline <a> elements, so the links rendered concatenated with no gap (QA item #12). Join them with an explicit non-breaking-space middot separator instead. Add a pure-string regression test.