### PR TITLE
refactor(wizard): reclaim vertical space and homogenise step headers

### DIFF
--- a/Project/tests/unit/test_wizard_header.py
+++ b/Project/tests/unit/test_wizard_header.py
@@ -1,0 +1,73 @@
+"""Tests for the wizard header refactor (QA item #5).
+
+Covers:
+- create_step_header() produces a single, uniform header (48px icon, the
+  StepIcon/StepTitle/StepDescription objectNames) — replacing the four
+  divergent per-step _create_header methods (36 vs 48px icons, inline fonts on
+  the Review step) that read as inconsistent headers.
+- WizardContainer exposes a persistent "Start Over" control that emits
+  restart_requested (it used to live in a separate header band above the tab).
+
+Skips when PyQt5 is unavailable; CI installs python3-pyqt5 so it runs there.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PyQt5.QtWidgets import QApplication  # noqa: PLC0415
+
+    return QApplication.instance() or QApplication([])
+
+
+def test_create_step_header_is_uniform(qapp):
+    from PyQt5.QtWidgets import QLabel  # noqa: PLC0415
+    from ui.schedule_wizard import create_step_header  # noqa: PLC0415
+
+    header = create_step_header("⚙", "Configure", "set things")
+    labels = header.findChildren(QLabel)
+
+    icons = [w for w in labels if w.objectName() == "StepIcon"]
+    titles = [w for w in labels if w.objectName() == "StepTitle"]
+    descs = [w for w in labels if w.objectName() == "StepDescription"]
+
+    assert len(icons) == 1
+    # The canonical icon size (the old compact steps used 36px).
+    assert icons[0].width() == 48 and icons[0].height() == 48
+    assert titles and titles[0].text() == "Configure"
+    assert descs and descs[0].text() == "set things"
+
+
+def test_steps_no_longer_define_local_header_factory(qapp):
+    """Every step uses the shared helper, not its own _create_header."""
+    import ui.schedule_wizard as sw  # noqa: PLC0415
+
+    for cls_name in (
+        "Step1SelectType",
+        "Step2SelectAnimals",
+        "Step3ConfigureParameters",
+        "Step4Review",
+    ):
+        cls = getattr(sw, cls_name)
+        assert not hasattr(cls, "_create_header"), f"{cls_name} still has _create_header"
+
+
+def test_wizard_container_start_over_emits_restart(qapp):
+    from ui.components.wizard import WizardContainer, WizardStep  # noqa: PLC0415
+
+    container = WizardContainer([WizardStep("a", "A", "d"), WizardStep("b", "B", "d")])
+    assert hasattr(container, "_start_over_button")
+
+    fired = []
+    container.restart_requested.connect(lambda: fired.append(True))
+    container._start_over_button.click()
+    assert fired == [True]

--- a/Project/ui/components/wizard.py
+++ b/Project/ui/components/wizard.py
@@ -175,6 +175,7 @@ class WizardContainer(QWidget):
     step_changed = pyqtSignal(int)
     completed = pyqtSignal()
     cancelled = pyqtSignal()
+    restart_requested = pyqtSignal()
 
     def __init__(self, steps: List[WizardStep], parent: Optional[QWidget] = None):
         super().__init__(parent)
@@ -188,9 +189,29 @@ class WizardContainer(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
-        # Progress indicator
+        # Progress indicator with a persistent "Start Over" control on the same
+        # band as the step titles (visible on every page).
         self._progress = WizardProgress(self._steps)
-        layout.addWidget(self._progress)
+
+        progress_row = QWidget()
+        progress_row_layout = QHBoxLayout(progress_row)
+        progress_row_layout.setContentsMargins(0, 0, 16, 0)
+        progress_row_layout.setSpacing(0)
+        progress_row_layout.addWidget(self._progress, 1)
+
+        self._start_over_button = QPushButton("Start Over")
+        self._start_over_button.setObjectName("WizardStartOverButton")
+        self._start_over_button.setToolTip("Reset the wizard to create a new schedule")
+        self._start_over_button.setCursor(Qt.PointingHandCursor)
+        self._start_over_button.setStyleSheet(
+            "QPushButton { background-color: #F3F4F6; border: 1px solid #D1D5DB;"
+            " border-radius: 6px; padding: 6px 12px; font-weight: 500; }"
+            " QPushButton:hover { background-color: #E5E7EB; }"
+        )
+        self._start_over_button.clicked.connect(self.restart_requested.emit)
+        progress_row_layout.addWidget(self._start_over_button, 0, Qt.AlignVCenter)
+
+        layout.addWidget(progress_row)
 
         # Separator
         separator = QFrame()

--- a/Project/ui/schedule_wizard.py
+++ b/Project/ui/schedule_wizard.py
@@ -49,6 +49,47 @@ from PyQt5.QtWidgets import (
 from .components.interactive_card import InteractiveCard, SelectableCardGroup
 from .components.wizard import WizardContainer, WizardStep
 
+
+# ============================================================================
+# SHARED STEP HEADER
+# ============================================================================
+def create_step_header(icon: str, title: str, description: str) -> QWidget:
+    """Build the standard step header (icon + title + description).
+
+    Shared by every wizard step so the icon size, title font, spacing and
+    alignment are identical across pages. Each step previously had its own
+    ``_create_header`` with diverging icon sizes (36 vs 48 px) and, on the
+    Review step, hard-coded inline fonts — which read as inconsistent headers.
+    Visual styling comes from the ``StepIcon`` / ``StepTitle`` /
+    ``StepDescription`` objectNames in the theme QSS.
+    """
+    container = QWidget()
+    layout = QHBoxLayout(container)
+    layout.setContentsMargins(0, 0, 0, 16)
+    layout.setSpacing(16)
+
+    icon_label = QLabel(icon)
+    icon_label.setObjectName("StepIcon")
+    icon_label.setFixedSize(48, 48)
+    icon_label.setAlignment(Qt.AlignCenter)
+    layout.addWidget(icon_label)
+
+    text_layout = QVBoxLayout()
+    text_layout.setSpacing(4)
+
+    title_label = QLabel(title)
+    title_label.setObjectName("StepTitle")
+    text_layout.addWidget(title_label)
+
+    desc_label = QLabel(description)
+    desc_label.setObjectName("StepDescription")
+    desc_label.setWordWrap(True)
+    text_layout.addWidget(desc_label)
+
+    layout.addLayout(text_layout, 1)
+    return container
+
+
 # ============================================================================
 # HARDWARE LIMITS HELPER
 # ============================================================================
@@ -139,7 +180,7 @@ class Step1SelectType(QWidget):
         layout.setSpacing(20)
 
         # Step header
-        header = self._create_header(
+        header = create_step_header(
             icon="",
             title="Select Schedule Type",
             description="Choose how you want to deliver water to your animals",
@@ -166,37 +207,6 @@ class Step1SelectType(QWidget):
 
         layout.addLayout(cards_layout)
         layout.addStretch()
-
-    def _create_header(self, icon: str, title: str, description: str) -> QWidget:
-        """Create step header with icon, title, and description."""
-        container = QWidget()
-        layout = QHBoxLayout(container)
-        layout.setContentsMargins(0, 0, 0, 16)
-        layout.setSpacing(16)
-
-        # Icon
-        icon_label = QLabel(icon)
-        icon_label.setObjectName("StepIcon")
-        icon_label.setFixedSize(48, 48)
-        icon_label.setAlignment(Qt.AlignCenter)
-        layout.addWidget(icon_label)
-
-        # Text
-        text_layout = QVBoxLayout()
-        text_layout.setSpacing(4)
-
-        title_label = QLabel(title)
-        title_label.setObjectName("StepTitle")
-        text_layout.addWidget(title_label)
-
-        desc_label = QLabel(description)
-        desc_label.setObjectName("StepDescription")
-        desc_label.setWordWrap(True)
-        text_layout.addWidget(desc_label)
-
-        layout.addLayout(text_layout, 1)
-
-        return container
 
     def _on_type_selected(self, type_key: str) -> None:
         """Handle schedule type selection."""
@@ -249,7 +259,7 @@ class Step2SelectAnimals(QWidget):
         layout.setSpacing(8)  # Reduced spacing
 
         # Compact step header
-        header = self._create_header(
+        header = create_step_header(
             icon="🐭",
             title="Select Animals",
             description="Choose which animals will receive water from this schedule",
@@ -320,35 +330,6 @@ class Step2SelectAnimals(QWidget):
         list_layout.addLayout(btn_layout)
 
         layout.addWidget(list_container, 1)
-
-    def _create_header(self, icon: str, title: str, description: str) -> QWidget:
-        """Create compact step header with icon, title, and description."""
-        container = QWidget()
-        layout = QHBoxLayout(container)
-        layout.setContentsMargins(0, 0, 0, 8)  # Reduced bottom margin
-        layout.setSpacing(10)  # Reduced spacing
-
-        icon_label = QLabel(icon)
-        icon_label.setObjectName("StepIcon")
-        icon_label.setFixedSize(36, 36)  # Smaller icon
-        icon_label.setAlignment(Qt.AlignCenter)
-        layout.addWidget(icon_label)
-
-        text_layout = QVBoxLayout()
-        text_layout.setSpacing(4)
-
-        title_label = QLabel(title)
-        title_label.setObjectName("StepTitle")
-        text_layout.addWidget(title_label)
-
-        desc_label = QLabel(description)
-        desc_label.setObjectName("StepDescription")
-        desc_label.setWordWrap(True)
-        text_layout.addWidget(desc_label)
-
-        layout.addLayout(text_layout, 1)
-
-        return container
 
     def load_animals(self, trainer_id: Optional[int] = None) -> None:
         """Load available animals from database."""
@@ -497,7 +478,7 @@ class Step3ConfigureParameters(QWidget):
         layout.setSpacing(20)
 
         # Step header
-        header = self._create_header(
+        header = create_step_header(
             icon="⚙",
             title="Configure Parameters",
             description="Set timing and volume for each animal",
@@ -518,35 +499,6 @@ class Step3ConfigureParameters(QWidget):
 
         # Will be populated when animals are set
         self._build_empty_state()
-
-    def _create_header(self, icon: str, title: str, description: str) -> QWidget:
-        """Create step header."""
-        container = QWidget()
-        layout = QHBoxLayout(container)
-        layout.setContentsMargins(0, 0, 0, 16)
-        layout.setSpacing(16)
-
-        icon_label = QLabel(icon)
-        icon_label.setObjectName("StepIcon")
-        icon_label.setFixedSize(48, 48)
-        icon_label.setAlignment(Qt.AlignCenter)
-        layout.addWidget(icon_label)
-
-        text_layout = QVBoxLayout()
-        text_layout.setSpacing(4)
-
-        title_label = QLabel(title)
-        title_label.setObjectName("StepTitle")
-        text_layout.addWidget(title_label)
-
-        desc_label = QLabel(description)
-        desc_label.setObjectName("StepDescription")
-        desc_label.setWordWrap(True)
-        text_layout.addWidget(desc_label)
-
-        layout.addLayout(text_layout, 1)
-
-        return container
 
     def set_animals(self, animals: List[Dict[str, Any]]) -> None:
         """
@@ -1198,7 +1150,7 @@ class Step4Review(QWidget):
         layout.setSpacing(12)
 
         # Compact step header
-        header = self._create_header(
+        header = create_step_header(
             icon="✓",
             title="Review & Save",
             description="Confirm your schedule settings before saving",
@@ -1225,40 +1177,6 @@ class Step4Review(QWidget):
 
         scroll_area.setWidget(summary_group)
         layout.addWidget(scroll_area, 1)  # stretch=1 to fill space
-
-    def _create_header(self, icon: str, title: str, description: str) -> QWidget:
-        """Create compact step header."""
-        container = QWidget()
-        layout = QHBoxLayout(container)
-        layout.setContentsMargins(0, 0, 0, 8)
-        layout.setSpacing(12)
-
-        icon_label = QLabel(icon)
-        icon_label.setFixedSize(36, 36)
-        icon_label.setAlignment(Qt.AlignCenter)
-        icon_label.setStyleSheet("""
-            font-size: 18px;
-            color: #0D9488;
-            background: #E6FFFA;
-            border-radius: 18px;
-        """)
-        layout.addWidget(icon_label)
-
-        text_layout = QVBoxLayout()
-        text_layout.setSpacing(2)
-
-        title_label = QLabel(title)
-        title_label.setStyleSheet("font-size: 16px; font-weight: 600; color: #1F2937;")
-        text_layout.addWidget(title_label)
-
-        desc_label = QLabel(description)
-        desc_label.setStyleSheet("font-size: 11px; color: #6B7280;")
-        desc_label.setWordWrap(True)
-        text_layout.addWidget(desc_label)
-
-        layout.addLayout(text_layout, 1)
-
-        return container
 
     def set_config(self, config: Dict[str, Any]) -> None:
         """Set the configuration to display."""
@@ -1386,6 +1304,7 @@ class ScheduleCreationWizard(QWidget):
 
     schedule_created = pyqtSignal(dict)
     cancelled = pyqtSignal()
+    restart_requested = pyqtSignal()
 
     def __init__(
         self,
@@ -1443,6 +1362,7 @@ class ScheduleCreationWizard(QWidget):
         self._wizard.step_changed.connect(self._on_step_changed)
         self._wizard.completed.connect(self._on_complete)
         self._wizard.cancelled.connect(self.cancelled.emit)
+        self._wizard.restart_requested.connect(self.restart_requested.emit)
 
         # Create step content widgets
         self._step1 = Step1SelectType()

--- a/Project/ui/wizard_tab.py
+++ b/Project/ui/wizard_tab.py
@@ -7,7 +7,7 @@ allowing side-by-side comparison with the traditional Schedules tab method.
 """
 
 from PyQt5.QtCore import pyqtSignal
-from PyQt5.QtWidgets import QHBoxLayout, QLabel, QMessageBox, QPushButton, QVBoxLayout, QWidget
+from PyQt5.QtWidgets import QMessageBox, QVBoxLayout, QWidget
 
 from .schedule_wizard import ScheduleCreationWizard
 
@@ -64,48 +64,11 @@ class WizardTab(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
-        # Header with reset button (fixed at top)
-        header = QWidget()
-        header.setObjectName("WizardTabHeader")
-        header.setStyleSheet("""
-            #WizardTabHeader {
-                background-color: #F8FAFB;
-                border-bottom: 1px solid #E5E7EB;
-                padding: 8px;
-            }
-        """)
-        header_layout = QHBoxLayout(header)
-        header_layout.setContentsMargins(12, 8, 12, 8)
-
-        # Title
-        title = QLabel("New Schedule Wizard")
-        title.setStyleSheet("font-size: 14px; font-weight: 600; color: #0D9488;")
-        header_layout.addWidget(title)
-
-        header_layout.addStretch()
-
-        # Reset button
-        reset_btn = QPushButton("Start Over")
-        reset_btn.setToolTip("Reset wizard to create a new schedule")
-        reset_btn.clicked.connect(self._reset_wizard)
-        reset_btn.setStyleSheet("""
-            QPushButton {
-                background-color: #F3F4F6;
-                border: 1px solid #D1D5DB;
-                border-radius: 6px;
-                padding: 6px 12px;
-                font-weight: 500;
-            }
-            QPushButton:hover {
-                background-color: #E5E7EB;
-            }
-        """)
-        header_layout.addWidget(reset_btn)
-
-        layout.addWidget(header)
-
-        # Wizard container (STATIC - no outer scroll)
-        # Scrolling is handled internally by each step that needs it (Step 3)
+        # Wizard container (STATIC - no outer scroll). The old "New Schedule
+        # Wizard" header band was removed to reclaim vertical space for the
+        # Select Animals step; the persistent "Start Over" control now lives in
+        # the wizard's own progress band. Scrolling is handled internally by
+        # each step that needs it (Step 3).
         self._wizard = ScheduleCreationWizard(
             database_handler=self._database_handler,
             login_system=self._login_system,
@@ -115,8 +78,8 @@ class WizardTab(QWidget):
         # Connect wizard signals
         self._wizard.schedule_created.connect(self._on_schedule_created)
         self._wizard.cancelled.connect(self._on_cancelled)
+        self._wizard.restart_requested.connect(self._reset_wizard)
 
-        # Add wizard directly (no scroll wrapper)
         layout.addWidget(self._wizard, 1)
 
     def _on_schedule_created(self, config: dict):
@@ -165,8 +128,9 @@ class WizardTab(QWidget):
         )
         self._wizard.schedule_created.connect(self._on_schedule_created)
         self._wizard.cancelled.connect(self._on_cancelled)
+        self._wizard.restart_requested.connect(self._reset_wizard)
 
-        # Add to layout (at position 1 after header, with stretch)
+        # Add to layout (fills the tab, with stretch)
         layout.addWidget(self._wizard, 1)
 
         self._print_to_terminal("[Wizard Tab] Wizard reset - ready for new schedule")


### PR DESCRIPTION
QA item #5. Three changes to the schedule wizard:

- Remove the "New Schedule Wizard" header band from WizardTab. It consumed ~50px of vertical height above every step; dropping it gives the Select Animals list more room.
- Move "Start Over" into the wizard's own progress band so it persists across all steps. WizardContainer gains a restart_requested signal that WizardTab connects to its reset.
- Replace the four divergent per-step _create_header methods (36px vs 48px icons, hard-coded inline fonts on the Review step) with one shared create_step_header() so the icon size, title font, spacing and centring are identical on every page.

Tested headlessly (offscreen): WizardTab constructs and Start Over recreates the wizard; new unit tests cover the uniform header and the persistent restart signal. Final visual alignment to be confirmed on a Pi.