### PR TITLE
fix(ui): centre calibration action buttons; bump version to 1.9.2

### DIFF
--- a/Project/tests/unit/test_calibration_action_cell.py
+++ b/Project/tests/unit/test_calibration_action_cell.py
@@ -1,0 +1,48 @@
+"""Structural test for the calibration Action-button cell wrapper (QA item #13).
+
+A bare fixed-height button handed to setCellWidget gets stretched/anchored and
+visually straddles the boundary between two rows. The button is now wrapped in
+a centring container so it sits centred in its cell. Pixel centring depends on
+a real display (the offscreen QPA cannot lay out cell widgets), so this test
+only guards the structure: the cell is a container holding the button with a
+centring layout.
+
+Skips when PyQt5 is unavailable; CI installs python3-pyqt5 so it runs there.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PyQt5.QtWidgets import QApplication  # noqa: PLC0415
+
+    return QApplication.instance() or QApplication([])
+
+
+def test_action_cell_wraps_and_centres_button(qapp):
+    from PyQt5.QtCore import Qt  # noqa: PLC0415
+    from PyQt5.QtWidgets import QPushButton, QWidget  # noqa: PLC0415
+    from ui.SettingsTab import SettingsTab  # noqa: PLC0415
+
+    button = QPushButton("Calibrate")
+    cell = SettingsTab._make_action_cell(button)
+
+    # The cell handed to setCellWidget is a container, not the bare button.
+    assert isinstance(cell, QWidget)
+    assert not isinstance(cell, QPushButton)
+
+    layout = cell.layout()
+    assert layout is not None
+    # The button lives inside the container.
+    assert button.parent() is cell
+    # The layout centres its contents (so the fixed-height button is centred).
+    assert layout.alignment() & Qt.AlignCenter

--- a/Project/ui/SettingsTab.py
+++ b/Project/ui/SettingsTab.py
@@ -816,7 +816,7 @@ class SettingsTab(QWidget):
                 btn.setMinimumWidth(90)
                 btn.setToolTip(f"Recalibrate cage {cage_id}")
                 btn.clicked.connect(lambda checked, c=cage_id: self._launch_calibration_wizard(c))
-                self.calibration_table.setCellWidget(row, 5, btn)
+                self.calibration_table.setCellWidget(row, 5, self._make_action_cell(btn))
 
             else:
                 # Not calibrated - show warning
@@ -849,7 +849,26 @@ class SettingsTab(QWidget):
                 btn.setMinimumWidth(90)
                 btn.setToolTip(f"Calibrate cage {cage_id} (250 pulses)")
                 btn.clicked.connect(lambda checked, c=cage_id: self._launch_calibration_wizard(c))
-                self.calibration_table.setCellWidget(row, 5, btn)
+                self.calibration_table.setCellWidget(row, 5, self._make_action_cell(btn))
+
+    @staticmethod
+    def _make_action_cell(button):
+        """Centre an action button within its calibration-table cell.
+
+        ``setCellWidget`` stretches the supplied widget to the full row height,
+        so a bare fixed-height button gets anchored to the top and visually
+        overflows / straddles the boundary between two rows. Wrapping it in a
+        container with a centring layout keeps the button vertically centred
+        with even gaps between rows.
+        """
+        from PyQt5.QtWidgets import QHBoxLayout, QWidget
+
+        cell = QWidget()
+        cell_layout = QHBoxLayout(cell)
+        cell_layout.setContentsMargins(6, 4, 6, 4)
+        cell_layout.setAlignment(Qt.AlignCenter)
+        cell_layout.addWidget(button)
+        return cell
 
     def _launch_calibration_wizard(self, cage_id):
         """

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.9.1"
+__version__ = "1.9.2"


### PR DESCRIPTION
QA item #13. The Calibrate/Recalibrate buttons were handed bare to setCellWidget, which stretches the widget to the full row height; the fixed-height button ended up anchored and visually straddling the boundary between two rows (a continuous green column offset half a row from the data cells). Wrap each button in a centring container via _make_action_cell so it sits centred in its cell with even gaps between rows.

Bump Project/version.py 1.9.1 -> 1.9.2 for the v1.9.2 release that bundles this and the QA cosmetic/docs batch.

Note: the offscreen QPA cannot lay out table cell widgets (propagateSizeHints unsupported), so the vertical centring is structurally tested but must be visually confirmed on a real display before tagging.