### PR TITLE
feat(ui): hide Settings for guests, keep Help available

### DIFF
--- a/Project/tests/unit/test_help_logged_out.py
+++ b/Project/tests/unit/test_help_logged_out.py
@@ -1,0 +1,72 @@
+"""Help is available to guests (QA item #2).
+
+The Settings tab stays gated on login (it controls the device), but Help is
+static read-only documentation and should be reachable while logged out. This
+exercises the real _update_tab_access logic against a real QTabWidget, and
+checks the help copy no longer claims Help is disabled.
+
+Skips when PyQt5 is unavailable; CI installs python3-pyqt5 so it runs there.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PyQt5.QtWidgets import QApplication  # noqa: PLC0415
+
+    return QApplication.instance() or QApplication([])
+
+
+def _tab_access(qapp, *, logged_in):
+    from PyQt5.QtWidgets import QTabWidget, QWidget  # noqa: PLC0415
+
+    from ui.gui import RodentRefreshmentGUI  # noqa: PLC0415
+
+    tabs = QTabWidget()
+    profile, settings, help_ = QWidget(), QWidget(), QWidget()
+    tabs.addTab(profile, "Profile")
+    settings_idx = tabs.addTab(settings, "Settings")
+    help_idx = tabs.addTab(help_, "Help")
+
+    fake = SimpleNamespace(
+        login_system=SimpleNamespace(is_logged_in=lambda: logged_in),
+        main_tab_widget=tabs,
+        settings_tab_index=settings_idx,
+        help_tab_index=help_idx,
+        user_tab=profile,
+    )
+    # Call the real method logic, unbound, against the fake instance.
+    RodentRefreshmentGUI._update_tab_access(fake)
+    return tabs, settings_idx, help_idx
+
+
+def test_guest_sees_help_but_not_settings(qapp):
+    tabs, settings_idx, help_idx = _tab_access(qapp, logged_in=False)
+    assert tabs.isTabVisible(help_idx) is True
+    assert tabs.isTabEnabled(help_idx) is True
+    # Settings is hidden entirely for guests (not just disabled).
+    assert tabs.isTabVisible(settings_idx) is False
+
+
+def test_settings_visible_when_logged_in(qapp):
+    tabs, settings_idx, help_idx = _tab_access(qapp, logged_in=True)
+    assert tabs.isTabVisible(help_idx) is True
+    assert tabs.isTabVisible(settings_idx) is True
+    assert tabs.isTabEnabled(settings_idx) is True
+
+
+def test_help_copy_does_not_say_help_is_disabled():
+    from utils.help_content_manager import HelpContentManager  # noqa: PLC0415
+
+    html = HelpContentManager().get_content("System Overview")
+    assert "Help</strong> tabs are disabled" not in html

--- a/Project/ui/gui.py
+++ b/Project/ui/gui.py
@@ -762,13 +762,14 @@ class RodentRefreshmentGUI(QWidget):
         """Update tab accessibility based on login status"""
         is_logged_in = self.login_system.is_logged_in()
 
-        # Disable/enable tabs
+        # Settings is gated on login (it controls the device): hide it entirely
+        # for guests so only Profile and Help show. Help is static, read-only
+        # documentation and stays available to everyone.
+        self.main_tab_widget.setTabVisible(self.settings_tab_index, is_logged_in)
         self.main_tab_widget.setTabEnabled(self.settings_tab_index, is_logged_in)
-        self.main_tab_widget.setTabEnabled(self.help_tab_index, is_logged_in)
+        self.main_tab_widget.setTabVisible(self.help_tab_index, True)
+        self.main_tab_widget.setTabEnabled(self.help_tab_index, True)
 
-        # If on a restricted tab while logging out, switch to profile tab
-        if not is_logged_in and self.main_tab_widget.currentIndex() in [
-            self.settings_tab_index,
-            self.help_tab_index,
-        ]:
+        # If the Settings tab was current when logging out, fall back to Profile.
+        if not is_logged_in and self.main_tab_widget.currentIndex() == self.settings_tab_index:
             self.main_tab_widget.setCurrentWidget(self.user_tab)

--- a/Project/utils/help_content_manager.py
+++ b/Project/utils/help_content_manager.py
@@ -219,10 +219,11 @@ def _build_content() -> Dict[str, HelpContent]:
   </ul>
 
   <h2>Access Control</h2>
-  <p>The app starts in <strong>guest mode</strong>.  The <strong>Settings</strong> and
-  <strong>Help</strong> tabs are disabled until you log in on the <strong>Profile</strong>
-  tab.  In guest mode the Animals tab shows all animals; after login it shows only your
-  own animals (or all animals in Super Mode).</p>
+  <p>The app starts in <strong>guest mode</strong>.  The <strong>Settings</strong> tab is
+  disabled until you log in on the <strong>Profile</strong> tab; the <strong>Help</strong>
+  tab (this documentation) stays available to everyone.  In guest mode the Animals tab
+  shows all animals; after login it shows only your own animals (or all animals in Super
+  Mode).</p>
 
   <h2>Quick Start</h2>
   <ol>
@@ -270,7 +271,7 @@ def _build_content() -> Dict[str, HelpContent]:
 
   <h2>1 — Log In</h2>
   <p>Open the <strong>Profile</strong> tab and log in.  This unlocks the
-  <strong>Settings</strong> and <strong>Help</strong> tabs.</p>
+  <strong>Settings</strong> tab.</p>
 
   <h2>2 — Choose Hardware Mode</h2>
   <p>Go to <strong>Settings → Delivery</strong> and set the <strong>Hardware Mode</strong>


### PR DESCRIPTION
QA item #2. Settings controls the device, so for guests it is now hidden entirely (setTabVisible) rather than shown-but-disabled — logged-out users see only Profile and Help. Help is static, read-only documentation and stays available to everyone.

Update the System Overview / First Time Setup help copy that claimed Help is disabled in guest mode. Test exercises the real _update_tab_access logic: Settings hidden + Help visible when logged out, both visible when logged in.