### PR TITLE
fix(delivery): default SolenoidFlowStrategy to pulse mode

### DIFF
--- a/Project/strategies/solenoid_flow_strategy.py
+++ b/Project/strategies/solenoid_flow_strategy.py
@@ -35,7 +35,7 @@ class SolenoidFlowStrategy:
     Automatically selected via `settings['use_pulse_delivery']`:
     - True: Pulse mode (Parker valves)
     - False: Continuous mode (Lee valves)
-    - Default: False (backward compatible)
+    - Default: True (pulse — safer/more precise; SystemController enforces this)
 
     **Empirical Pulse Profiles (from valve_characterization tests):**
     - 10ms:  0.0234 mL (CV: 0.0%)
@@ -85,8 +85,12 @@ class SolenoidFlowStrategy:
         if not self._sensor_available:
             self._logger.info("Running in CALIBRATION-ONLY mode (no flow sensor)")
 
-        # Pulse mode detection (from empirical characterization tests)
-        self._use_pulse_mode = bool(settings.get('use_pulse_delivery', False))
+        # Pulse mode detection (from empirical characterization tests).
+        # Defaults to pulse: SystemController force-enforces use_pulse_delivery=True
+        # on every settings load, so pulse is the canonical mode. The fallback here
+        # matches that intent for any path that constructs the strategy directly
+        # (e.g. tests) — continuous only runs when explicitly disabled.
+        self._use_pulse_mode = bool(settings.get('use_pulse_delivery', True))
         self._pulse_settling_ms = int(settings.get('pulse_settling_ms', 100))
 
         # CRITICAL DEBUG: Log pulse mode detection

--- a/Project/tests/unit/test_solenoid_default_pulse.py
+++ b/Project/tests/unit/test_solenoid_default_pulse.py
@@ -1,0 +1,32 @@
+"""SolenoidFlowStrategy defaults to pulse mode (QA item #14a).
+
+SystemController force-enforces use_pulse_delivery=True on every settings load,
+so pulse is the canonical delivery mode. This guards the strategy's own
+fallback so it agrees with that intent (pulse unless explicitly disabled) for
+any path that builds the strategy directly. Validated on-device (Pi).
+"""
+
+from __future__ import annotations
+
+from strategies.solenoid_flow_strategy import SolenoidFlowStrategy
+
+
+def _make(settings):
+    return SolenoidFlowStrategy(
+        solenoid_controller=object(),
+        flow_sensor=None,
+        calibration_store=None,
+        settings=settings,
+    )
+
+
+def test_defaults_to_pulse_when_setting_absent():
+    assert _make({})._use_pulse_mode is True
+
+
+def test_continuous_only_when_explicitly_disabled():
+    assert _make({"use_pulse_delivery": False})._use_pulse_mode is False
+
+
+def test_pulse_when_explicitly_enabled():
+    assert _make({"use_pulse_delivery": True})._use_pulse_mode is True


### PR DESCRIPTION
QA item #14a. SystemController already force-enforces use_pulse_delivery=True on every settings load, so pulse is the canonical mode in production — but the strategy's own fallback read use_pulse_delivery with a default of False, which was misleading and would pick continuous for any path that builds the strategy without the enforced settings (e.g. tests). Default that fallback to True so the strategy agrees with the enforced intent; continuous still runs only when use_pulse_delivery is explicitly False.

No production behaviour change (pulse was already enforced). Validated on a Pi (10.12.103.207): empty settings -> pulse, explicit False -> continuous, and the deployed SystemController force-merge confirmed. Unit-tested.