### PR TITLE
fix(ui): nudge calibration buttons up so they stay within their row

### DIFF
--- a/Project/ui/SettingsTab.py
+++ b/Project/ui/SettingsTab.py
@@ -639,6 +639,11 @@ class SettingsTab(QWidget):
         )  # Tab scrolls instead
         self.calibration_table.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self.calibration_table.setVerticalScrollMode(QAbstractItemView.ScrollPerPixel)
+        # The global `QTableWidget::item` padding has a 12px top inset, which
+        # pushes setCellWidget action buttons down so they dip into the next
+        # row. Trim the item padding for this table so the Calibrate buttons sit
+        # centred. Padding-only override keeps the theme's row border.
+        self.calibration_table.setStyleSheet("QTableWidget::item { padding: 4px 16px; }")
         # Rely on global QSS styling
 
         # Column resize modes - all fixed widths for consistent layout


### PR DESCRIPTION
The Calibrate/Recalibrate buttons sat low and dipped into the next row: the global QTableWidget::item style has a 12px top padding, and setCellWidget places the button inside that padded area. Scope a smaller item padding (4px 16px) on the calibration table so the buttons centre vertically. Padding- only override, so the theme's row border is preserved. Verified by rendering on a Pi (button centre delta 12px -> 0px).