### PR TITLE
docs(brand): enlarge the logo by hugging the box to the lockup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **A Simple Water Delivery System for Laboratory Animal Care**
 
 <p align="center">
-  <img src="docs/brand/logo-triple-drop-dark.svg" alt="RRR — Rodent Refreshment Regulator" width="440">
+  <img src="docs/brand/logo-triple-drop-dark.svg" alt="RRR — Rodent Refreshment Regulator" width="460">
 </p>
 
 ## What is the Rodent Refreshment Regulator?

--- a/docs/brand/logo-triple-drop-dark.svg
+++ b/docs/brand/logo-triple-drop-dark.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- RRR brand — Logo 01 "Triple Drop", dark variant, recoloured to the app teal (#14B8A6). -->
-<svg xmlns="http://www.w3.org/2000/svg" width="520" height="140" viewBox="0 0 520 140" role="img" aria-label="Rodent Refreshment Regulator">
-  <rect x="0" y="0" width="520" height="140" rx="20" fill="#0F1419"/>
+<!-- RRR brand — Logo 01 "Triple Drop", dark variant, recoloured to the app teal (#14B8A6).
+     Box hugs the lockup so the mark reads large; RRR centre-line aligned with the drops. -->
+<svg xmlns="http://www.w3.org/2000/svg" width="372" height="120" viewBox="0 0 372 120" role="img" aria-label="Rodent Refreshment Regulator">
+  <rect x="0" y="0" width="372" height="120" rx="18" fill="#0F1419"/>
 
-  <!-- droplets + wordmark as one lockup, centred in the box; RRR centre-line
-       aligned with the droplet cluster centre -->
-  <g transform="translate(100,0)">
-    <g transform="translate(38,58)">
+  <!-- droplets + wordmark as one lockup, centred in the box -->
+  <g transform="translate(37,0)">
+    <g transform="translate(38,45)">
       <path d="M -22 -16 C -10 0 -6 10 -6 16
          A 16 16 0 1 1 -38 16
          C -38 10 -34 0 -22 -16 Z" fill="rgba(255,255,255,0.25)"/>
@@ -19,8 +19,8 @@
     </g>
 
     <g font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif">
-      <text x="92" y="84" font-size="56" font-weight="800" letter-spacing="-1.2" fill="#FFFFFF">RRR</text>
-      <text x="94" y="108" font-size="11" font-weight="600" letter-spacing="2.4" fill="#A0AEC0">REFRESHMENT REGULATOR</text>
+      <text x="92" y="71" font-size="56" font-weight="800" letter-spacing="-1.2" fill="#FFFFFF">RRR</text>
+      <text x="94" y="95" font-size="11" font-weight="600" letter-spacing="2.4" fill="#A0AEC0">REFRESHMENT REGULATOR</text>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
The 520x140 box left ~110px of dead padding on each side of the ~300px lockup, so the mark rendered small. Tighten the box to 372x120 around the lockup (RRR still centre-aligned with the drops) and bump the README display width to 460 so the logo reads at a proper size.