### PR TITLE
chore(release): bump version to 1.10.0

### DIFF
--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.9.3"
+__version__ = "1.10.0"


### PR DESCRIPTION
Release 2 (MINOR): guest-accessible Help tab, schedule-window validation with a minimum-safety-window check, pulse-mode delivery default, and the calibration button alignment follow-up.

Tag v1.10.0 on merged main HEAD once the Release 2 PRs are in (verify with: git tag --points-at HEAD).