### PR TITLE
fix(help): open the first topic instead of the redundant landing page

### DIFF
--- a/Project/tests/unit/test_help_first_topic.py
+++ b/Project/tests/unit/test_help_first_topic.py
@@ -1,0 +1,40 @@
+"""Help opens a real topic on first view, not the redundant landing (QA #10).
+
+The landing page repeated the same category/topic list already shown in the
+left tree, so the centre and left panes were redundant on first open. HelpTab
+now selects and loads the first topic instead.
+
+Skips when PyQt5 is unavailable; CI installs python3-pyqt5 so it runs there.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PyQt5.QtWidgets import QApplication  # noqa: PLC0415
+
+    return QApplication.instance() or QApplication([])
+
+
+def test_first_open_loads_first_topic(qapp):
+    from ui.HelpTab import HelpTab  # noqa: PLC0415
+
+    h = HelpTab()
+    h.show()  # fires showEvent -> _select_first_topic
+    qapp.processEvents()
+
+    # A real topic is loaded, not the landing page.
+    assert h.current_topic_key, "no topic selected on first open"
+    first_category_topics = next(iter(h.help_manager.get_categories().values()))
+    assert h.current_topic_key == first_category_topics[0]
+    # Breadcrumb shows the topic path rather than the bare 'Help' landing label.
+    assert "›" in h.breadcrumb.text()

--- a/Project/ui/HelpTab.py
+++ b/Project/ui/HelpTab.py
@@ -362,9 +362,22 @@ class HelpTab(QWidget):
 
     def showEvent(self, event):
         super().showEvent(event)
-        self.refresh_theme()
         if not self.current_topic_key:
-            # Show landing page
-            theme = self._current_theme()
-            self.content_browser.setHtml(self.help_manager.get_landing_page(theme))
-            self.breadcrumb.setText("Help")
+            # Open the first topic on launch instead of a landing page that just
+            # repeats the left-hand topic tree (the centre and left panes were
+            # redundant on first open). Falls back to the landing page only if
+            # the tree somehow has no topics.
+            self._select_first_topic()
+        self.refresh_theme()
+
+    def _select_first_topic(self):
+        """Select and load the first topic in the tree (e.g. System Overview)."""
+        for i in range(self.topic_tree.topLevelItemCount()):
+            category = self.topic_tree.topLevelItem(i)
+            if category.childCount():
+                first = category.child(0)
+                self.topic_tree.setCurrentItem(first)
+                key = first.data(0, Qt.UserRole)
+                if key:
+                    self._load_topic(key)
+                return


### PR DESCRIPTION
QA item #10. On first open the Help tab showed a landing page that simply re-listed the same categories and topics already in the left-hand tree, so the centre and left panes were redundant. Select and load the first topic (System Overview) on launch instead, so the content pane shows real help and the tree highlights the current topic. Falls back to the landing page only if the tree has no topics. Verified by rendering the tab; unit-tested.