### PR TITLE
fix(ui): show all combobox items (drop the clipped scrollable popup)

### DIFF
--- a/Project/tests/unit/test_combobox_popup_qss.py
+++ b/Project/tests/unit/test_combobox_popup_qss.py
@@ -1,0 +1,20 @@
+"""Both themes use the non-scrollable combo popup (QA item #7).
+
+With a stylesheet applied, Qt switches QComboBox to a scrollable popup whose
+height is computed from the font row height rather than the styled
+(min-height + padding) row height, so the last item is clipped behind a scroll
+arrow. `combobox-popup: 0` reverts to the classic popup that fits all items.
+Guard that the rule stays in both theme stylesheets. Pure file read — no Qt.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+STYLE_DIR = Path(__file__).resolve().parents[2] / "ui" / "style"
+
+
+def test_both_themes_use_fit_to_contents_combo_popup():
+    for name in ("app-light.qss", "app-dark.qss"):
+        text = (STYLE_DIR / name).read_text(encoding="utf-8")
+        assert "combobox-popup: 0" in text, f"{name} is missing combobox-popup: 0"

--- a/Project/ui/style/app-dark.qss
+++ b/Project/ui/style/app-dark.qss
@@ -92,6 +92,11 @@ QLineEdit, QPlainTextEdit, QTextEdit, QSpinBox, QDoubleSpinBox, QComboBox {
 QComboBox { 
     min-height: 36px;
     padding-right: 28px;
+    /* Use the classic popup that sizes to fit all items. With a stylesheet Qt
+       switches to a scrollable popup whose height is computed from the font
+       row height, not the styled (min-height + padding) row height, so the last
+       item gets clipped behind a scroll arrow. */
+    combobox-popup: 0;
 }
 QLineEdit:hover, QPlainTextEdit:hover, QTextEdit:hover, 
 QSpinBox:hover, QDoubleSpinBox:hover, QComboBox:hover {

--- a/Project/ui/style/app-light.qss
+++ b/Project/ui/style/app-light.qss
@@ -92,6 +92,11 @@ QLineEdit, QPlainTextEdit, QTextEdit, QSpinBox, QDoubleSpinBox, QComboBox {
 QComboBox { 
     min-height: 36px;
     padding-right: 28px;
+    /* Use the classic popup that sizes to fit all items. With a stylesheet Qt
+       switches to a scrollable popup whose height is computed from the font
+       row height, not the styled (min-height + padding) row height, so the last
+       item gets clipped behind a scroll arrow. */
+    combobox-popup: 0;
 }
 QLineEdit:hover, QPlainTextEdit:hover, QTextEdit:hover, 
 QSpinBox:hover, QDoubleSpinBox:hover, QComboBox:hover {


### PR DESCRIPTION
QA item #7. In v1.10.0 the dropdowns (sex selector, hardware mode, theme) clip their last item behind a scroll arrow. With a stylesheet applied, Qt uses a scrollable QComboBox popup whose height is computed from the font row height, not the styled row height (the QSS gives items min-height 28px + padding, ~40px rendered), so the popup is too short and clips. Set `combobox-popup: 0` in both themes to use the classic popup that sizes to fit all items.

Verified by rendering the popup (all items shown, styling preserved). Note: the clip only manifests in the real maximized app — a standalone/offscreen combo does not reproduce it — so please confirm on the running device.