### PR TITLE
fix(ui): make labels transparent so cards aren't dotted with grey boxes

### DIFF
--- a/Project/tests/unit/test_label_transparent_qss.py
+++ b/Project/tests/unit/test_label_transparent_qss.py
@@ -1,0 +1,21 @@
+"""Labels are transparent by default in both themes (QA: grey label boxes).
+
+QLabels inherit the grey app background, so on white Cards (login form, profile
+"Welcome" card) the field labels painted grey boxes. A base
+`QLabel { background: transparent; }` makes them blend into their surface.
+Guard the rule stays in both themes. Pure file read — no Qt.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+STYLE_DIR = Path(__file__).resolve().parents[2] / "ui" / "style"
+
+
+def test_both_themes_make_labels_transparent():
+    pattern = re.compile(r"QLabel\s*\{[^}]*background:\s*transparent", re.DOTALL)
+    for name in ("app-light.qss", "app-dark.qss"):
+        text = (STYLE_DIR / name).read_text(encoding="utf-8")
+        assert pattern.search(text), f"{name} missing transparent QLabel base rule"

--- a/Project/ui/style/app-dark.qss
+++ b/Project/ui/style/app-dark.qss
@@ -53,6 +53,13 @@ QWidget#LoginGatePrompt, QWidget#LoginGatePrompt QLabel {
     background-color: #1E2530;
 }
 
+/* Labels are transparent by default so they blend into whatever surface they
+   sit on (e.g. Cards) rather than painting the app background as a box.
+   objectName-styled labels (banners, etc.) override this. */
+QLabel {
+    background: transparent;
+}
+
 /* ============================================
    TYPOGRAPHY HELPERS
    ============================================ */

--- a/Project/ui/style/app-light.qss
+++ b/Project/ui/style/app-light.qss
@@ -53,6 +53,13 @@ QWidget#LoginGatePrompt, QWidget#LoginGatePrompt QLabel {
     background-color: #FFFFFF;
 }
 
+/* Labels are transparent by default so they blend into whatever surface they
+   sit on (e.g. white Cards) rather than painting the grey app background as a
+   box. objectName-styled labels (banners, etc.) override this. */
+QLabel {
+    background: transparent;
+}
+
 /* ============================================
    TYPOGRAPHY HELPERS
    ============================================ */


### PR DESCRIPTION
The login form and the profile "Welcome" card are white Cards, but the field labels (Username/Password, Trainer ID/Last Login) inherited the grey app background and rendered as grey boxes on the white surface. Add a base `QLabel { background: transparent; }` to both themes so labels blend into whatever surface they sit on; objectName-styled labels (banners, etc.) still override it. Verified by rendering the login and welcome cards.