### PR TITLE
refactor(ui): rebuild edit-schedule dialog on wizard Step 3 + persists edits

### DIFF
--- a/Project/docs/INSTANT_SCHEDULE_BUG.md
+++ b/Project/docs/INSTANT_SCHEDULE_BUG.md
@@ -1,0 +1,58 @@
+# Instant-delivery schedules: storage inconsistency (tracked)
+
+**Status:** open. Discovered while refactoring the edit-schedule flow (v1.11.0).
+This is a **separate concern** from edit-schedule and is intentionally *not*
+fixed in that PR (one concern per PR — see [CLAUDE.md](../../CLAUDE.md)).
+
+## Symptom
+
+Instant-delivery schedules created through the wizard appear to save but
+**deliver nothing** when run, because the rows the runtime reads are never
+written.
+
+## Root cause
+
+Two different tables are used for "instant" deliveries, and the write path and
+the read path disagree:
+
+| Path | Code | Table |
+|---|---|---|
+| Wizard create (intended) | `ScheduleCreationWizard._create_schedule` instant branch → `add_schedule(schedule)` | `schedule_instant_deliveries` — but `schedule.instant_deliveries` is **empty** (the wizard called `add_animal`, never `add_instant_delivery`), so **no rows** are written |
+| Wizard create (actual) | same method → `add_schedule_instant()` per animal | **`schedule_time_instants`** — a table that is **never created** in the schema (`DatabaseHandler.__init__`), so the INSERT raises and is swallowed |
+| Runtime read | `run_stop_section.py` / `schedule_drop_area.py` → `get_schedule_instant_deliveries()` | **`schedule_instant_deliveries`** |
+
+Net effect: nothing is written to `schedule_instant_deliveries`, so the runtime
+finds zero deliveries. Staggered schedules are unaffected (separate, coherent
+tables: `schedule_animals` / `schedule_desired_outputs` /
+`schedule_staggered_windows`).
+
+Key references:
+- `add_schedule_instant` →
+  [database_handler.py](../models/database_handler.py) (`INSERT INTO schedule_time_instants`)
+- `get_schedule_instant_deliveries` reads `schedule_instant_deliveries`
+- Wizard instant create branch →
+  [schedule_wizard.py](../ui/schedule_wizard.py) `_create_schedule`
+
+## Why edit-schedule (v1.11.0) sidesteps it
+
+The rebuilt `ScheduleEditDialog` fully supports **staggered** editing. For
+**instant** schedules it shows a short "editing instant schedules isn't
+available yet" notice instead of a half-working form, so no edit can land on the
+broken storage.
+
+## Planned fix (phased)
+
+- **Phase A — unify instant storage (own PR, MINOR).** Make the wizard write
+  real rows to `schedule_instant_deliveries` (populate the schedule via
+  `add_instant_delivery`, or call `add_schedule_instant` against the correct
+  table). Drop or migrate the orphaned `schedule_time_instants` path. Requires a
+  Pi delivery test (instant schedule actually dispenses).
+- **Phase B — enable instant editing.** Once storage is coherent, extend the
+  edit dialog's instant branch to load/save real instant deliveries and
+  re-enable Save (reuse the same `Step3ConfigureParameters` instant mode).
+
+## Test gaps to add with the fix
+
+- A Qt-free DB test that an instant schedule created end-to-end has rows in
+  `schedule_instant_deliveries` and that `get_schedule_instant_deliveries`
+  returns them.

--- a/Project/models/database_handler.py
+++ b/Project/models/database_handler.py
@@ -591,13 +591,20 @@ class DatabaseHandler:
                     query = f"UPDATE schedules SET {', '.join(updates)} WHERE schedule_id = ?"
                     cursor.execute(query, params)
 
-                # Update per-animal desired outputs if provided
+                # Update per-animal desired outputs if provided.
+                # NOTE: the column is ``desired_output`` (see the
+                # schedule_desired_outputs schema). A long-standing bug wrote
+                # ``desired_water_output`` here, which does not exist — the
+                # UPDATE raised OperationalError, was swallowed, and per-animal
+                # volumes silently never saved. The full edit path now uses
+                # update_staggered_schedule(); this method is kept for simple
+                # field-only updates and the column name is corrected.
                 if desired_outputs:
                     for animal_id, volume in desired_outputs.items():
                         cursor.execute(
                             '''
-                            UPDATE schedule_desired_outputs 
-                            SET desired_water_output = ?
+                            UPDATE schedule_desired_outputs
+                            SET desired_output = ?
                             WHERE schedule_id = ? AND animal_id = ?
                         ''',
                             (volume, schedule_id, int(animal_id)),
@@ -1336,6 +1343,127 @@ class DatabaseHandler:
             print(f"DateTime parsing error: {e}")
             traceback.print_exc()
             return None
+
+    def update_staggered_schedule(self, schedule):
+        """Persist edits to an existing staggered schedule, transactionally.
+
+        Mirrors :meth:`add_staggered_schedule` but for a schedule that already
+        exists. Rather than diffing individual fields, it updates the parent
+        ``schedules`` row and **replaces** every child row for this
+        ``schedule_id`` (animals/cage assignments, desired outputs, and the
+        ``schedule_staggered_windows`` the delivery engine actually reads).
+
+        This is deliberately a "delete children + re-insert" replace: the prior
+        ``update_schedule`` only touched the parent row and a (misspelled)
+        desired-outputs column, so cage reassignments and the runtime windows
+        never updated and edits did not reach delivery. Replacing the windows
+        means an edit resets per-window delivery progress and clears any
+        ``cycle_tracking`` rows — correct, since the plan itself changed.
+
+        Args:
+            schedule: a :class:`~models.Schedule.Schedule` carrying the new
+                ``name``/``water_volume``/``start_time``/``end_time``,
+                ``animals``, ``relay_unit_assignments`` and
+                ``desired_water_outputs``. ``schedule.schedule_id`` must be set.
+
+        Returns:
+            True on success, False on any database/parse error (the whole
+            update is rolled back as a single transaction on failure).
+        """
+        schedule_id = schedule.schedule_id
+        if schedule_id is None:
+            print("update_staggered_schedule called with no schedule_id")
+            return False
+        try:
+            with self.connect() as conn:
+                cursor = conn.cursor()
+
+                # Update the parent schedule row.
+                cursor.execute(
+                    '''
+                    UPDATE schedules
+                    SET name = ?, water_volume = ?, start_time = ?,
+                        end_time = ?, delivery_mode = 'staggered'
+                    WHERE schedule_id = ?
+                ''',
+                    (
+                        schedule.name,
+                        schedule.water_volume,
+                        schedule.start_time,
+                        schedule.end_time,
+                        schedule_id,
+                    ),
+                )
+
+                # Replace all child rows for this schedule.
+                cursor.execute(
+                    'DELETE FROM schedule_animals WHERE schedule_id = ?', (schedule_id,)
+                )
+                cursor.execute(
+                    'DELETE FROM schedule_desired_outputs WHERE schedule_id = ?',
+                    (schedule_id,),
+                )
+                cursor.execute(
+                    'DELETE FROM schedule_staggered_windows WHERE schedule_id = ?',
+                    (schedule_id,),
+                )
+                # Stale per-cycle progress would otherwise point at deleted
+                # windows; clear it so the edited schedule starts clean.
+                cursor.execute('DELETE FROM cycle_tracking WHERE schedule_id = ?', (schedule_id,))
+
+                start_time = datetime.fromisoformat(schedule.start_time)
+                end_time = datetime.fromisoformat(schedule.end_time)
+
+                for animal_id in schedule.animals:
+                    relay_unit_id = schedule.relay_unit_assignments.get(str(animal_id))
+                    cursor.execute(
+                        '''
+                        INSERT INTO schedule_animals
+                        (schedule_id, animal_id, relay_unit_id)
+                        VALUES (?, ?, ?)
+                    ''',
+                        (schedule_id, animal_id, relay_unit_id),
+                    )
+
+                    desired_output = schedule.desired_water_outputs.get(
+                        str(animal_id), schedule.water_volume
+                    )
+                    cursor.execute(
+                        '''
+                        INSERT INTO schedule_desired_outputs
+                        (schedule_id, animal_id, desired_output)
+                        VALUES (?, ?, ?)
+                    ''',
+                        (schedule_id, animal_id, desired_output),
+                    )
+
+                    cursor.execute(
+                        '''
+                        INSERT INTO schedule_staggered_windows
+                        (schedule_id, animal_id, start_time, end_time, target_volume)
+                        VALUES (?, ?, ?, ?, ?)
+                    ''',
+                        (
+                            schedule_id,
+                            animal_id,
+                            start_time.isoformat(),
+                            end_time.isoformat(),
+                            desired_output,
+                        ),
+                    )
+
+                conn.commit()
+                print(f"Schedule {schedule_id} updated successfully (staggered).")
+                return True
+
+        except sqlite3.Error as e:
+            print(f"Database error when updating staggered schedule: {e}")
+            traceback.print_exc()
+            return False
+        except ValueError as e:
+            print(f"DateTime parsing error: {e}")
+            traceback.print_exc()
+            return False
 
     def get_active_staggered_windows(self):
         """Get all active staggered delivery windows"""

--- a/Project/tests/unit/test_edit_schedule_dialog.py
+++ b/Project/tests/unit/test_edit_schedule_dialog.py
@@ -1,0 +1,103 @@
+"""Smoke + behaviour tests for the rebuilt ScheduleEditDialog.
+
+The dialog reuses the wizard's ``Step3ConfigureParameters`` and saves through
+``update_staggered_schedule``. These tests assert it (a) pre-fills the saved
+name/volume/cage from the schedule, and (b) actually persists an edit end to
+end. Skips cleanly when PyQt5 is unavailable; CI installs ``python3-pyqt5``.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PyQt5.QtWidgets import QApplication  # noqa: PLC0415
+
+    return QApplication.instance() or QApplication([])
+
+
+def _seed_staggered(database_handler):
+    """Create a 2-animal staggered schedule and return its Schedule object."""
+    from models.Schedule import Schedule  # noqa: PLC0415
+
+    start = datetime.now() + timedelta(days=1)
+    end = start + timedelta(hours=1)
+    sched = Schedule(
+        schedule_id=None,
+        name="Morning ration",
+        water_volume=3.0,
+        start_time=start.isoformat(),
+        end_time=end.isoformat(),
+        created_by=1,
+        is_super_user=0,
+        delivery_mode="staggered",
+    )
+    sched.add_animal(animal_id=1, relay_unit_id=1, desired_volume=1.0)
+    sched.add_animal(animal_id=2, relay_unit_id=2, desired_volume=2.0)
+    sid = database_handler.add_staggered_schedule(sched)
+    assert sid is not None
+
+    # Re-read so we hand the dialog the same shape the hub does.
+    return next(s for s in database_handler.get_all_schedules() if s.schedule_id == sid)
+
+
+def test_dialog_prefills_from_schedule(qapp, database_handler):
+    from ui.schedules_hub import ScheduleEditDialog  # noqa: PLC0415
+
+    schedule = _seed_staggered(database_handler)
+    dlg = ScheduleEditDialog(schedule, database_handler, system_controller=None)
+
+    assert dlg._step3 is not None
+    configs = dlg._step3.get_animal_configs()
+    assert configs[1]["volume"] == 1.0
+    assert configs[2]["volume"] == 2.0
+    assert configs[1]["cage_id"] == 1
+    assert configs[2]["cage_id"] == 2
+    assert dlg._step3._name_input.text() == "Morning ration"
+
+
+def test_dialog_save_persists_edit(qapp, database_handler):
+    from PyQt5.QtWidgets import QDialog  # noqa: PLC0415
+    from ui.schedules_hub import ScheduleEditDialog  # noqa: PLC0415
+
+    schedule = _seed_staggered(database_handler)
+    dlg = ScheduleEditDialog(schedule, database_handler, system_controller=None)
+
+    # Operator bumps animal 1's volume and renames the schedule.
+    dlg._step3._animal_widgets[1]["volume"].setValue(4.0)
+    dlg._step3._name_input.setText("Edited ration")
+
+    dlg._save_changes()
+    assert dlg.result() == QDialog.Accepted
+
+    details = database_handler.get_schedule_details(schedule.schedule_id)[0]
+    assert details["desired_water_outputs"]["1"] == 4.0
+    assert details["desired_water_outputs"]["2"] == 2.0
+
+
+def test_instant_schedule_shows_notice_not_form(qapp, database_handler):
+    from models.Schedule import Schedule  # noqa: PLC0415
+    from ui.schedules_hub import ScheduleEditDialog  # noqa: PLC0415
+
+    instant = Schedule(
+        schedule_id=999,
+        name="Instant one",
+        water_volume=1.0,
+        start_time=datetime.now().isoformat(),
+        end_time=datetime.now().isoformat(),
+        created_by=1,
+        is_super_user=0,
+        delivery_mode="instant",
+    )
+    dlg = ScheduleEditDialog(instant, database_handler, system_controller=None)
+    # Instant mode renders the notice path, not the Step-3 form.
+    assert dlg._step3 is None

--- a/Project/tests/unit/test_update_staggered_schedule.py
+++ b/Project/tests/unit/test_update_staggered_schedule.py
@@ -1,0 +1,139 @@
+"""Regression tests for editing (updating) an existing staggered schedule.
+
+These guard the bugs that made the old edit-schedule dialog non-functional:
+
+1. ``update_schedule`` wrote a column named ``desired_water_output``; the real
+   column is ``desired_output`` — so per-animal volume edits raised
+   OperationalError, were swallowed, and never saved.
+2. The edit path never touched ``schedule_staggered_windows`` (the table the
+   delivery engine reads) nor cage reassignment in ``schedule_animals`` — so a
+   "saved" edit did not reach the runtime.
+
+``update_staggered_schedule`` replaces all child rows transactionally; this test
+asserts volumes, cage assignments, bounds, and the staggered windows all
+persist. Qt-free: DatabaseHandler imports no PyQt5, so it runs everywhere.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from models.database_handler import DatabaseHandler  # noqa: F401 (fixture import path)
+from models.Schedule import Schedule
+
+
+def _staggered(name, start_iso, end_iso, animals, schedule_id=None) -> Schedule:
+    """Build a staggered Schedule. ``animals`` is ``[(animal_id, cage_id, volume)]``."""
+    total = sum(v for _, _, v in animals)
+    sched = Schedule(
+        schedule_id=schedule_id,
+        name=name,
+        water_volume=total,
+        start_time=start_iso,
+        end_time=end_iso,
+        created_by=1,
+        is_super_user=0,
+        delivery_mode="staggered",
+    )
+    for animal_id, cage_id, volume in animals:
+        sched.add_animal(animal_id=animal_id, relay_unit_id=cage_id, desired_volume=volume)
+    return sched
+
+
+def _windows(database_handler, schedule_id):
+    with database_handler.connect() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT animal_id, start_time, end_time, target_volume
+            FROM schedule_staggered_windows
+            WHERE schedule_id = ?
+            ORDER BY animal_id
+            """,
+            (schedule_id,),
+        )
+        return cur.fetchall()
+
+
+def _schedule_name(database_handler, schedule_id):
+    with database_handler.connect() as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT name FROM schedules WHERE schedule_id = ?", (schedule_id,))
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+def test_update_persists_volumes_cages_times_and_windows(database_handler):
+    start = datetime(2026, 6, 1, 9, 0, 0)
+    end = datetime(2026, 6, 1, 10, 0, 0)
+    sid = database_handler.add_staggered_schedule(
+        _staggered("orig", start.isoformat(), end.isoformat(), [(1, 1, 1.0), (2, 2, 2.0)])
+    )
+    assert sid is not None
+
+    # Edit: rename, reassign cages (1→3, 2→4), change volumes, shift the window.
+    new_start = datetime(2026, 6, 2, 14, 0, 0)
+    new_end = datetime(2026, 6, 2, 15, 30, 0)
+    updated = _staggered(
+        "edited",
+        new_start.isoformat(),
+        new_end.isoformat(),
+        [(1, 3, 1.5), (2, 4, 2.5)],
+        schedule_id=sid,
+    )
+    assert database_handler.update_staggered_schedule(updated) is True
+
+    details = database_handler.get_schedule_details(sid)[0]
+
+    # Per-animal volumes persisted (regression for the desired_output column bug)
+    assert details["desired_water_outputs"] == {"1": 1.5, "2": 2.5}
+    # Cage reassignment persisted
+    assert details["relay_unit_assignments"] == {"1": 3, "2": 4}
+    # Bounds + total volume persisted
+    assert details["water_volume"] == 4.0
+    assert details["start_time"] == new_start.isoformat()
+    assert details["end_time"] == new_end.isoformat()
+    assert _schedule_name(database_handler, sid) == "edited"
+
+    # The runtime windows were replaced, not left stale.
+    windows = _windows(database_handler, sid)
+    assert len(windows) == 2
+    for animal_id, w_start, w_end, target in windows:
+        assert w_start == new_start.isoformat()
+        assert w_end == new_end.isoformat()
+        assert target == (1.5 if animal_id == 1 else 2.5)
+
+
+def test_update_can_drop_an_animal(database_handler):
+    start = datetime(2026, 6, 1, 9, 0, 0)
+    end = datetime(2026, 6, 1, 10, 0, 0)
+    sid = database_handler.add_staggered_schedule(
+        _staggered("orig", start.isoformat(), end.isoformat(), [(1, 1, 1.0), (2, 2, 2.0)])
+    )
+
+    # Edit down to a single animal — child rows for the removed animal must go.
+    updated = _staggered(
+        "one-animal", start.isoformat(), end.isoformat(), [(1, 1, 1.0)], schedule_id=sid
+    )
+    assert database_handler.update_staggered_schedule(updated) is True
+
+    details = database_handler.get_schedule_details(sid)[0]
+    assert details["animal_ids"] == [1]
+    assert details["desired_water_outputs"] == {"1": 1.0}
+    assert len(_windows(database_handler, sid)) == 1
+
+
+def test_update_schedule_simple_volume_update_uses_correct_column(database_handler):
+    """The lighter ``update_schedule`` desired-outputs path writes the real column."""
+    start = datetime(2026, 6, 1, 9, 0, 0)
+    end = datetime(2026, 6, 1, 10, 0, 0)
+    sid = database_handler.add_staggered_schedule(
+        _staggered("orig", start.isoformat(), end.isoformat(), [(1, 1, 1.0)])
+    )
+
+    assert (
+        database_handler.update_schedule(schedule_id=sid, desired_outputs={"1": 3.25}) is True
+    )
+
+    details = database_handler.get_schedule_details(sid)[0]
+    assert details["desired_water_outputs"] == {"1": 3.25}

--- a/Project/ui/schedule_wizard.py
+++ b/Project/ui/schedule_wizard.py
@@ -172,6 +172,130 @@ def get_available_cages(system_controller) -> Tuple[int, int, Set[int]]:
 
 
 # ============================================================================
+# SCHEDULE BUILDER (shared by create + edit)
+# ============================================================================
+
+
+def build_schedule_from_config(
+    config: Dict[str, Any],
+    trainer: Optional[Dict[str, Any]],
+    system_controller,
+    schedule_id: Optional[int] = None,
+):
+    """Build a validated :class:`Schedule` from a wizard-style config dict.
+
+    Pure (no I/O) so it is shared by both the creation wizard and the
+    edit-schedule dialog: the wizard passes ``schedule_id=None`` and saves with
+    ``add_staggered_schedule``; the editor passes the existing id and saves with
+    ``update_staggered_schedule``. Cage assignments come from each animal's
+    ``cage_id`` (set via the Step-3 dropdown), falling back to sequential
+    assignment from the remaining valid cages.
+
+    Args:
+        config: ``{"schedule_type", "animals", "parameters": {"name",
+            "animal_configs": {animal_id: {"volume", "cage_id",
+            "start_time"/"end_time" or "delivery_time"}}}}``.
+        trainer: current trainer dict (``trainer_id``/``role``) or None.
+        system_controller: used for hardware cage limits.
+        schedule_id: existing id for an edit, or None to create.
+
+    Returns:
+        A populated ``Schedule`` with animals + cage assignments.
+
+    Raises:
+        ValueError: too many animals for available cages, or a cage that is the
+            master relay / invalid / already assigned to another animal.
+    """
+    from models.Schedule import Schedule
+
+    params = config["parameters"]
+    schedule_type = config["schedule_type"]
+    animals = config["animals"]
+    animal_configs = params.get("animal_configs", {})
+
+    trainer_id = trainer.get("trainer_id", 1) if trainer else 1
+    is_super = 1 if trainer and trainer.get("role") == "super" else 0
+
+    # Derive overall schedule bounds + total volume from the per-animal configs.
+    all_starts: List[datetime] = []
+    all_ends: List[datetime] = []
+    total_volume = 0.0
+    for cfg in animal_configs.values():
+        if schedule_type == "staggered":
+            all_starts.append(cfg.get("start_time", datetime.now()))
+            all_ends.append(cfg.get("end_time", datetime.now() + timedelta(hours=1)))
+        else:
+            delivery = cfg.get("delivery_time", datetime.now())
+            all_starts.append(delivery)
+            all_ends.append(delivery)
+        total_volume += cfg.get("volume", 1.0)
+
+    if all_starts:
+        schedule_start = min(all_starts)
+        schedule_end = max(all_ends)
+    else:
+        schedule_start = datetime.now()
+        schedule_end = datetime.now() + timedelta(hours=1)
+
+    schedule = Schedule(
+        schedule_id=schedule_id,
+        name=params.get("name", "Untitled Schedule"),
+        water_volume=total_volume,
+        start_time=schedule_start.isoformat()
+        if isinstance(schedule_start, datetime)
+        else schedule_start,
+        end_time=schedule_end.isoformat() if isinstance(schedule_end, datetime) else schedule_end,
+        created_by=trainer_id,
+        is_super_user=is_super,
+        delivery_mode=schedule_type,
+    )
+
+    max_cages, master_relay, valid_cages = get_available_cages(system_controller)
+    if len(animals) > max_cages:
+        raise ValueError(
+            f"Schedule has {len(animals)} animals but only {max_cages} cages available. "
+            f"Relay {master_relay} is reserved for master solenoid."
+        )
+
+    valid_cage_list = sorted(valid_cages)
+    used_cages: Set[int] = set()
+    for animal_id in animals:
+        animal_cfg = animal_configs.get(animal_id, {})
+        volume = animal_cfg.get("volume", 1.0)
+        cage_id = animal_cfg.get("cage_id")
+
+        if cage_id is None:
+            available = [c for c in valid_cage_list if c not in used_cages]
+            if not available:
+                raise ValueError(
+                    f"Cannot assign cage to animal {animal_id}: no more cages available. "
+                    f"Max cages: {max_cages}"
+                )
+            cage_id = available[0]
+
+        if cage_id == master_relay:
+            raise ValueError(
+                f"Animal {animal_id} cannot be assigned to cage {cage_id} "
+                f"(reserved for master solenoid)"
+            )
+        if cage_id not in valid_cages:
+            raise ValueError(
+                f"Animal {animal_id} assigned to invalid cage {cage_id}. "
+                f"Valid cages: {sorted(valid_cages)}"
+            )
+        if cage_id in used_cages:
+            raise ValueError(
+                f"Cage {cage_id} is already assigned to another animal. "
+                f"Each animal must have a unique cage."
+            )
+
+        used_cages.add(cage_id)
+        schedule.add_animal(animal_id, cage_id, volume)
+
+    return schedule
+
+
+# ============================================================================
 # SCHEDULE TYPE DEFINITIONS
 # ============================================================================
 
@@ -534,7 +658,11 @@ class Step3ConfigureParameters(QWidget):
         # Will be populated when animals are set
         self._build_empty_state()
 
-    def set_animals(self, animals: List[Dict[str, Any]]) -> None:
+    def set_animals(
+        self,
+        animals: List[Dict[str, Any]],
+        preset_configs: Optional[Dict[int, Dict[str, Any]]] = None,
+    ) -> None:
         """
         Set selected animals for per-animal configuration.
 
@@ -542,6 +670,15 @@ class Step3ConfigureParameters(QWidget):
         - Loads cage options from database for dropdowns
         - Assigns default cages sequentially (animal 1 → cage 1, etc.)
         - Users can override cage assignments via dropdown
+
+        Args:
+            animals: ``[{"id", "lab_id", "name"}, ...]`` for the rows.
+            preset_configs: optional ``{animal_id: {"start_time", "end_time",
+                "volume", "cage_id", ...}}`` used to pre-fill the form when
+                **editing** an existing schedule. When omitted (the creation
+                wizard) each animal gets the usual defaults with a sequential
+                cage assignment. Any animal missing from ``preset_configs``
+                still falls back to those defaults.
         """
         self._selected_animals = animals
         self._animal_configs = {}
@@ -553,9 +690,14 @@ class Step3ConfigureParameters(QWidget):
         # Get list of valid cage IDs for sequential default assignment
         valid_cage_ids = [c['cage_id'] for c in self._cage_options]
 
-        # Initialize default config for each animal with sequential cage assignment
+        # Initialize config for each animal: a provided preset wins, otherwise
+        # the usual defaults with a sequential cage assignment.
         for idx, animal in enumerate(animals):
             animal_id = animal["id"]
+
+            if preset_configs and animal_id in preset_configs:
+                self._animal_configs[animal_id] = dict(preset_configs[animal_id])
+                continue
 
             # Default cage: sequential assignment (1, 2, 3, ...)
             # If more animals than cages, cycle back or leave unassigned
@@ -1091,6 +1233,27 @@ class Step3ConfigureParameters(QWidget):
         """Get per-animal configurations."""
         return self._animal_configs.copy()
 
+    def load_for_edit(
+        self,
+        animals: List[Dict[str, Any]],
+        preset_configs: Dict[int, Dict[str, Any]],
+        name: str,
+        schedule_type: str = "staggered",
+    ) -> None:
+        """Populate the form from an existing schedule (edit-schedule dialog).
+
+        Builds the per-animal rows from ``preset_configs`` then restores the
+        saved name, times, volumes and cage selections into the widgets — the
+        same path the wizard uses for back-navigation, so the edit dialog and
+        the wizard stay behaviourally identical. Keeps all private-state access
+        inside this widget.
+        """
+        self.set_animals(animals, preset_configs=preset_configs)
+        self.set_schedule_type(schedule_type)
+        if hasattr(self, "_name_input") and self._name_input is not None:
+            self._name_input.setText(name or "")
+        self._restore_widget_values()
+
     def _restore_widget_values(self) -> None:
         """
         Restore widget values from saved _animal_configs.
@@ -1106,40 +1269,52 @@ class Step3ConfigureParameters(QWidget):
                 self._name_input.setText(saved_name)
                 self._name_input.blockSignals(False)
 
-        # Restore per-animal widget values
+        # Restore per-animal widget values.
+        # NOTE: the staggered row stores its time widgets under the keys
+        # "start"/"end" (see _create_staggered_animal_row), not
+        # "start_time"/"end_time". A prior version checked the latter, so time
+        # restore was silently dead — back-navigation lost the times and the
+        # edit dialog could not pre-fill them. Keys are corrected here.
         for animal_id, widgets in self._animal_widgets.items():
             config = self._animal_configs.get(animal_id, {})
 
             if self._schedule_type == "staggered":
-                # Restore start time
-                if "start_time" in widgets and "start_time" in config:
-                    start = config["start_time"]
-                    if isinstance(start, datetime):
-                        widgets["start_time"].blockSignals(True)
-                        widgets["start_time"].setDateTime(QDateTime(start))
-                        widgets["start_time"].blockSignals(False)
-
-                # Restore end time
-                if "end_time" in widgets and "end_time" in config:
-                    end = config["end_time"]
-                    if isinstance(end, datetime):
-                        widgets["end_time"].blockSignals(True)
-                        widgets["end_time"].setDateTime(QDateTime(end))
-                        widgets["end_time"].blockSignals(False)
+                # Snapshot both times BEFORE touching either widget. Setting
+                # start bumps the end widget's minimum to start+60s, which can
+                # auto-clamp the end widget's current value and fire its
+                # dateTimeChanged — overwriting config["end_time"] in place. If
+                # we read config["end_time"] only after setting start we'd
+                # restore that clobbered value, collapsing the window to 60s.
+                start_val = config.get("start_time")
+                end_val = config.get("end_time")
+                if "start" in widgets and isinstance(start_val, datetime):
+                    widgets["start"].setDateTime(QDateTime(start_val))
+                if "end" in widgets and isinstance(end_val, datetime):
+                    widgets["end"].setDateTime(QDateTime(end_val))
             else:
                 # Restore delivery time (instant mode)
-                if "delivery_time" in widgets and "delivery_time" in config:
-                    delivery = config["delivery_time"]
-                    if isinstance(delivery, datetime):
-                        widgets["delivery_time"].blockSignals(True)
-                        widgets["delivery_time"].setDateTime(QDateTime(delivery))
-                        widgets["delivery_time"].blockSignals(False)
+                if "delivery_time" in widgets and isinstance(
+                    config.get("delivery_time"), datetime
+                ):
+                    widgets["delivery_time"].blockSignals(True)
+                    widgets["delivery_time"].setDateTime(QDateTime(config["delivery_time"]))
+                    widgets["delivery_time"].blockSignals(False)
 
             # Restore volume
             if "volume" in widgets and "volume" in config:
                 widgets["volume"].blockSignals(True)
                 widgets["volume"].setValue(config["volume"])
                 widgets["volume"].blockSignals(False)
+
+            # Restore cage selection (match the stored cage_id to its combo item)
+            if "cage" in widgets and config.get("cage_id") is not None:
+                combo = widgets["cage"]
+                for i in range(combo.count()):
+                    if combo.itemData(i) == config["cage_id"]:
+                        combo.blockSignals(True)
+                        combo.setCurrentIndex(i)
+                        combo.blockSignals(False)
+                        break
 
     def is_valid(self) -> bool:
         """Validate parameters."""
@@ -1578,114 +1753,13 @@ class ScheduleCreationWizard(QWidget):
 
     def _create_schedule(self, config: Dict[str, Any]) -> Optional[int]:
         """Create schedule in database using existing Schedule model and correct methods."""
-        from models.Schedule import Schedule
-
-        params = config["parameters"]
         schedule_type = config["schedule_type"]
         animals = config["animals"]
-        animal_configs = params.get("animal_configs", {})
+        animal_configs = config["parameters"].get("animal_configs", {})
 
+        # Build + validate the Schedule object (shared with the edit dialog).
         trainer = self._login_system.get_current_trainer()
-        trainer_id = trainer.get("trainer_id", 1) if trainer else 1
-        is_super = 1 if trainer and trainer.get("role") == "super" else 0
-
-        # Calculate overall schedule window from per-animal configs
-        all_starts = []
-        all_ends = []
-        total_volume = 0.0
-
-        for animal_id, cfg in animal_configs.items():
-            if schedule_type == "staggered":
-                start = cfg.get("start_time", datetime.now())
-                end = cfg.get("end_time", datetime.now() + timedelta(hours=1))
-                all_starts.append(start)
-                all_ends.append(end)
-            else:
-                delivery = cfg.get("delivery_time", datetime.now())
-                all_starts.append(delivery)
-                all_ends.append(delivery)
-            total_volume += cfg.get("volume", 1.0)
-
-        # Use earliest start and latest end as schedule bounds
-        if all_starts:
-            schedule_start = min(all_starts)
-            schedule_end = max(all_ends)
-        else:
-            schedule_start = datetime.now()
-            schedule_end = datetime.now() + timedelta(hours=1)
-
-        # Create Schedule object
-        schedule = Schedule(
-            schedule_id=None,  # Will be set by database
-            name=params.get("name", "Untitled Schedule"),
-            water_volume=total_volume,
-            start_time=schedule_start.isoformat()
-            if isinstance(schedule_start, datetime)
-            else schedule_start,
-            end_time=schedule_end.isoformat()
-            if isinstance(schedule_end, datetime)
-            else schedule_end,
-            created_by=trainer_id,
-            is_super_user=is_super,
-            delivery_mode=schedule_type,
-        )
-
-        # Get hardware limits for cage assignment validation
-        max_cages, master_relay, valid_cages = get_available_cages(self._system_controller)
-
-        # Validate we don't exceed available cages
-        if len(animals) > max_cages:
-            raise ValueError(
-                f"Schedule has {len(animals)} animals but only {max_cages} cages available. "
-                f"Relay {master_relay} is reserved for master solenoid."
-            )
-
-        # Add animals with user-selected cage assignments
-        # NEW: Uses cage_id from animal_configs (set via dropdown in Step 3)
-        # Falls back to sequential assignment if no cage selected
-        valid_cage_list = sorted(valid_cages)  # [1, 2, 3, ..., 15]
-        used_cages = set()  # Track which cages are already assigned
-
-        for idx, animal_id in enumerate(animals):
-            animal_cfg = animal_configs.get(animal_id, {})
-            volume = animal_cfg.get("volume", 1.0)
-
-            # Get user-selected cage_id, or use sequential fallback
-            cage_id = animal_cfg.get("cage_id")
-
-            if cage_id is None:
-                # Fallback: sequential assignment from remaining valid cages
-                available_cages = [c for c in valid_cage_list if c not in used_cages]
-                if not available_cages:
-                    raise ValueError(
-                        f"Cannot assign cage to animal {animal_id}: no more cages available. "
-                        f"Max cages: {max_cages}"
-                    )
-                cage_id = available_cages[0]
-
-            # Validate cage is valid and not the master relay
-            if cage_id == master_relay:
-                raise ValueError(
-                    f"Animal {animal_id} cannot be assigned to cage {cage_id} "
-                    f"(reserved for master solenoid)"
-                )
-
-            if cage_id not in valid_cages:
-                raise ValueError(
-                    f"Animal {animal_id} assigned to invalid cage {cage_id}. "
-                    f"Valid cages: {sorted(valid_cages)}"
-                )
-
-            # Check for duplicate cage assignment
-            if cage_id in used_cages:
-                raise ValueError(
-                    f"Cage {cage_id} is already assigned to another animal. "
-                    f"Each animal must have a unique cage."
-                )
-
-            used_cages.add(cage_id)
-            schedule.add_animal(animal_id, cage_id, volume)
-            print(f"[Wizard] Assigned animal {animal_id} → cage {cage_id}")
+        schedule = build_schedule_from_config(config, trainer, self._system_controller)
 
         # Save to database using the CORRECT method for each mode
         if schedule_type == "staggered":

--- a/Project/ui/schedules_hub.py
+++ b/Project/ui/schedules_hub.py
@@ -14,19 +14,16 @@ Features:
 
 from __future__ import annotations
 
+import math
 from datetime import datetime, timedelta
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from models.Schedule import Schedule
-from PyQt5.QtCore import QDateTime, QMimeData, QPoint, Qt, QTimer, pyqtSignal
+from PyQt5.QtCore import QMimeData, QPoint, Qt, QTimer, pyqtSignal
 from PyQt5.QtGui import QColor, QDrag, QFont, QLinearGradient, QPainter, QPen, QPixmap
 from PyQt5.QtWidgets import (
     QCheckBox,
-    QComboBox,
-    QCompleter,
-    QDateTimeEdit,
     QDialog,
-    QDoubleSpinBox,
     QFrame,
     QGridLayout,
     QHBoxLayout,
@@ -41,15 +38,35 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
+from .components.primary_button import PrimaryButton
+from .schedule_wizard import (
+    Step3ConfigureParameters,
+    build_schedule_from_config,
+    estimate_min_window_seconds,
+)
+
 # ============================================================================
-# SCHEDULE EDIT DIALOG (Wizard-style UI matching schedule_wizard.py Step 3)
+# SCHEDULE EDIT DIALOG (reuses schedule_wizard.Step3ConfigureParameters)
 # ============================================================================
 
 
 class ScheduleEditDialog(QDialog):
-    """
-    Dialog for editing an existing schedule using wizard-style UI.
-    Matches the look and feel of schedule_wizard.py Step 3.
+    """Modal for editing an existing schedule.
+
+    Reuses the schedule wizard's ``Step3ConfigureParameters`` widget (the
+    canonical per-animal config UI: cage dropdown, quick-apply, per-animal
+    start/end/volume, plus its validation) instead of re-implementing it, and
+    persists every change transactionally via
+    ``DatabaseHandler.update_staggered_schedule`` — including cage reassignment
+    and the ``schedule_staggered_windows`` the delivery engine reads.
+
+    Launched as a pop-up from the Schedules Hub (it never routes the user into
+    the Wizard tab). Construct on demand, ``exec_()`` modally, and react to
+    ``QDialog.Accepted``.
+
+    Instant-mode schedules are not yet editable (the instant storage path has a
+    separate, tracked bug — see Project/docs/INSTANT_SCHEDULE_BUG.md); for those
+    the dialog shows a short notice instead of a half-working form.
     """
 
     def __init__(self, schedule: Schedule, database_handler, system_controller=None, parent=None):
@@ -57,368 +74,197 @@ class ScheduleEditDialog(QDialog):
         self._schedule = schedule
         self._database_handler = database_handler
         self._system_controller = system_controller
-        self._schedule_details = None
-        self._animal_widgets = {}
-        self._cage_options = []
+        self._animals: List[Dict[str, Any]] = []
+        self._preset_configs: Dict[int, Dict[str, Any]] = {}
+        self._step3: Step3ConfigureParameters | None = None
+
+        self._delivery_mode = getattr(schedule, "delivery_mode", "staggered") or "staggered"
 
         self.setWindowTitle(f"Edit Schedule: {schedule.name}")
-        self.setMinimumSize(800, 600)
+        self.setMinimumSize(820, 600)
         self.setModal(True)
 
-        self._load_schedule_details()
-        self._load_cage_options()
-        self._init_ui()
+        if self._delivery_mode == "staggered":
+            self._load_schedule_details()
+            self._init_ui()
+        else:
+            self._init_instant_notice_ui()
+
+    @staticmethod
+    def _parse_dt(value, fallback: datetime) -> datetime:
+        try:
+            if isinstance(value, datetime):
+                return value
+            if isinstance(value, str):
+                return datetime.fromisoformat(value)
+        except (ValueError, TypeError):
+            pass
+        return fallback
 
     def _load_schedule_details(self) -> None:
+        """Pre-fetch animals + per-animal settings into the preset configs.
+
+        Done before ``_init_ui`` so the embedded Step 3 builds already-filled
+        rows. Cage assignment is stored as ``relay_unit_id`` (== the dropdown's
+        ``cage_id``) in ``schedule_animals``; desired volume in
+        ``schedule_desired_outputs``. Times use the schedule bounds.
+        """
         try:
-            details = self._database_handler.get_schedule_details(self._schedule.schedule_id)
-            if details:
-                self._schedule_details = details[0]
-            else:
-                self._schedule_details = {}
-        except Exception as e:
+            details_list = self._database_handler.get_schedule_details(self._schedule.schedule_id)
+        except Exception as e:  # pragma: no cover - defensive
             print(f"[EditDialog] Error loading details: {e}")
-            self._schedule_details = {}
+            details_list = []
+        details = details_list[0] if details_list else {}
 
-    def _load_cage_options(self) -> None:
-        """Load cage options for dropdown."""
-        try:
-            num_hats = 1
-            master_relay = 16
-            if self._system_controller and hasattr(self._system_controller, 'settings'):
-                num_hats = int(self._system_controller.settings.get('num_hats', 1))
-                master_relay = int(
-                    self._system_controller.settings.get('global_master_relay_id', 16)
-                )
+        animal_ids = details.get("animal_ids", [])
+        desired = details.get("desired_water_outputs", {})  # {str(animal_id): volume}
+        cage_by_animal = details.get("relay_unit_assignments", {})  # {str(animal_id): cage_id}
 
-            self._cage_options = self._database_handler.get_cages_for_dropdown(
-                num_hats=num_hats, master_relay=master_relay
+        start_dt = self._parse_dt(self._schedule.start_time, datetime.now())
+        end_dt = self._parse_dt(self._schedule.end_time, start_dt + timedelta(hours=1))
+        default_volume = float(self._schedule.water_volume or 1.0)
+
+        for animal_id in animal_ids:
+            try:
+                animal = self._database_handler.get_animal_by_id(animal_id)
+            except Exception:  # pragma: no cover - defensive
+                animal = None
+            self._animals.append(
+                {
+                    "id": animal_id,
+                    "lab_id": animal.lab_animal_id if animal else animal_id,
+                    "name": animal.name if animal else f"Animal {animal_id}",
+                }
             )
-        except:
-            self._cage_options = [
-                {'cage_id': i, 'display_name': f'Cage {i}'} for i in range(1, 16)
-            ]
+            self._preset_configs[animal_id] = {
+                "start_time": start_dt,
+                "end_time": end_dt,
+                "volume": float(desired.get(str(animal_id), default_volume)),
+                "cage_id": cage_by_animal.get(str(animal_id)),
+            }
 
     def _init_ui(self) -> None:
         layout = QVBoxLayout(self)
-        layout.setSpacing(12)
-        layout.setContentsMargins(24, 20, 24, 20)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(0)
 
-        # Wizard-style header (matches Step 3)
-        header = QWidget()
-        header_layout = QHBoxLayout(header)
-        header_layout.setContentsMargins(0, 0, 0, 8)
-        header_layout.setSpacing(12)
-
-        icon = QLabel("⚙")
-        icon.setStyleSheet("""
-            font-size: 20px;
-            background-color: #F0FDFA;
-            border: 2px solid #0D9488;
-            border-radius: 18px;
-            padding: 6px;
-        """)
-        icon.setFixedSize(40, 40)
-        icon.setAlignment(Qt.AlignCenter)
-        header_layout.addWidget(icon)
-
-        text_layout = QVBoxLayout()
-        text_layout.setSpacing(2)
-        title = QLabel("Configure Parameters")
-        title.setStyleSheet("font-size: 15px; font-weight: 600; color: #1F2937;")
-        text_layout.addWidget(title)
-        subtitle = QLabel("Set timing and volume for each animal")
-        subtitle.setStyleSheet("font-size: 11px; color: #6B7280;")
-        text_layout.addWidget(subtitle)
-        header_layout.addLayout(text_layout, 1)
-
-        layout.addWidget(header)
-
-        # Scroll area for content
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setFrameShape(QFrame.NoFrame)
-
-        content = QWidget()
-        content_layout = QVBoxLayout(content)
-        content_layout.setSpacing(10)
-        content_layout.setContentsMargins(0, 4, 0, 0)
-
-        # Schedule Name
-        name_container = QFrame()
-        name_container.setStyleSheet("""
-            QFrame { background: #F8FAFB; border: 1px solid #E5E7EB; border-radius: 6px; }
-        """)
-        name_layout = QHBoxLayout(name_container)
-        name_layout.setContentsMargins(10, 6, 10, 6)
-        name_label = QLabel("Name:")
-        name_label.setStyleSheet("font-weight: 500; color: #374151; font-size: 12px;")
-        name_layout.addWidget(name_label)
-        self._name_input = QLineEdit(self._schedule.name or "")
-        self._name_input.setStyleSheet("""
-            QLineEdit { border: 1px solid #D1D5DB; border-radius: 4px; padding: 5px 8px; font-size: 12px; }
-            QLineEdit:focus { border-color: #0D9488; }
-        """)
-        name_layout.addWidget(self._name_input, 1)
-        content_layout.addWidget(name_container)
-
-        # Quick Apply section (matches Step 3)
-        quick_container = QFrame()
-        quick_container.setStyleSheet("""
-            QFrame { background: #F8FAFB; border: 1px solid #E5E7EB; border-radius: 6px; }
-        """)
-        quick_layout = QVBoxLayout(quick_container)
-        quick_layout.setContentsMargins(10, 6, 10, 6)
-        quick_layout.setSpacing(6)
-
-        quick_title = QLabel("Quick Apply to All Animals")
-        quick_title.setStyleSheet("font-weight: 500; color: #374151; font-size: 11px;")
-        quick_layout.addWidget(quick_title)
-
-        quick_row = QHBoxLayout()
-        quick_row.setSpacing(6)
-
-        # Parse existing times
-        try:
-            if isinstance(self._schedule.start_time, str):
-                start_dt = datetime.fromisoformat(self._schedule.start_time)
-            else:
-                start_dt = self._schedule.start_time or datetime.now()
-        except:
-            start_dt = datetime.now()
-
-        try:
-            if isinstance(self._schedule.end_time, str):
-                end_dt = datetime.fromisoformat(self._schedule.end_time)
-            else:
-                end_dt = self._schedule.end_time or (datetime.now() + timedelta(hours=1))
-        except:
-            end_dt = datetime.now() + timedelta(hours=1)
-
-        quick_row.addWidget(QLabel("Start:"))
-        self._global_start = QDateTimeEdit()
-        self._global_start.setDateTime(QDateTime(start_dt))
-        self._global_start.setCalendarPopup(True)
-        self._global_start.setMinimumHeight(26)
-        self._global_start.setMinimumWidth(130)
-        quick_row.addWidget(self._global_start)
-
-        quick_row.addWidget(QLabel("End:"))
-        self._global_end = QDateTimeEdit()
-        self._global_end.setDateTime(QDateTime(end_dt))
-        self._global_end.setCalendarPopup(True)
-        self._global_end.setMinimumHeight(26)
-        self._global_end.setMinimumWidth(130)
-        quick_row.addWidget(self._global_end)
-
-        quick_row.addWidget(QLabel("Vol:"))
-        self._global_volume = QDoubleSpinBox()
-        self._global_volume.setRange(0.1, 50.0)
-        self._global_volume.setValue(1.0)
-        self._global_volume.setSuffix(" mL")
-        self._global_volume.setMinimumHeight(26)
-        quick_row.addWidget(self._global_volume)
-
-        apply_btn = QPushButton("Apply")
-        apply_btn.setMinimumHeight(26)
-        apply_btn.setStyleSheet("""
-            QPushButton { background-color: #E5E7EB; border: none; border-radius: 4px; padding: 4px 10px; font-weight: 500; font-size: 11px; }
-            QPushButton:hover { background-color: #D1D5DB; }
-        """)
-        apply_btn.clicked.connect(self._apply_to_all)
-        quick_row.addWidget(apply_btn)
-
-        quick_layout.addLayout(quick_row)
-        content_layout.addWidget(quick_container)
-
-        # Animal Settings (wizard-style rows matching Step 3)
-        animals_label = QLabel(
-            f"Animal Settings ({len(self._schedule_details.get('animal_ids', []))} animals)"
+        # Reuse the wizard's per-animal configuration step verbatim.
+        self._step3 = Step3ConfigureParameters(
+            database_handler=self._database_handler,
+            system_controller=self._system_controller,
         )
-        animals_label.setStyleSheet(
-            "font-weight: 500; color: #374151; font-size: 11px; margin-top: 4px;"
+        self._step3.load_for_edit(
+            self._animals, self._preset_configs, self._schedule.name or "", "staggered"
         )
-        content_layout.addWidget(animals_label)
+        layout.addWidget(self._step3, 1)
 
-        desired_outputs = (
-            self._schedule_details.get('desired_water_outputs', {})
-            if self._schedule_details
-            else {}
-        )
-        animal_ids = self._schedule_details.get('animal_ids', []) if self._schedule_details else []
-
-        for idx, animal_id in enumerate(animal_ids):
-            row = self._create_animal_row(animal_id, desired_outputs.get(str(animal_id), 1.0), idx)
-            content_layout.addWidget(row)
-
-        content_layout.addStretch()
-        scroll.setWidget(content)
-        layout.addWidget(scroll, 1)
-
-        # Footer buttons
-        footer = QHBoxLayout()
-        footer.setSpacing(10)
-        footer.addStretch()
+        footer = QWidget()
+        footer.setObjectName("DialogFooter")
+        footer_layout = QHBoxLayout(footer)
+        footer_layout.setContentsMargins(24, 12, 24, 16)
+        footer_layout.setSpacing(12)
+        footer_layout.addStretch()
 
         cancel_btn = QPushButton("Cancel")
-        cancel_btn.setMinimumHeight(32)
-        cancel_btn.setMinimumWidth(90)
-        cancel_btn.setStyleSheet("""
-            QPushButton { background-color: #F3F4F6; color: #374151; border: 1px solid #D1D5DB; border-radius: 6px; padding: 6px 16px; font-weight: 500; }
-            QPushButton:hover { background-color: #E5E7EB; }
-        """)
+        cancel_btn.setMinimumHeight(36)
+        cancel_btn.setCursor(Qt.PointingHandCursor)
         cancel_btn.clicked.connect(self.reject)
-        footer.addWidget(cancel_btn)
+        footer_layout.addWidget(cancel_btn)
 
-        save_btn = QPushButton("Save Changes")
-        save_btn.setMinimumHeight(32)
-        save_btn.setMinimumWidth(110)
-        save_btn.setStyleSheet("""
-            QPushButton { background-color: #0D9488; color: white; border: none; border-radius: 6px; padding: 6px 16px; font-weight: 600; }
-            QPushButton:hover { background-color: #0F766E; }
-        """)
+        save_btn = PrimaryButton("Save Changes")
+        save_btn.setMinimumHeight(36)
+        save_btn.setCursor(Qt.PointingHandCursor)
         save_btn.clicked.connect(self._save_changes)
-        footer.addWidget(save_btn)
+        footer_layout.addWidget(save_btn)
 
-        layout.addLayout(footer)
+        layout.addWidget(footer)
 
-    def _create_animal_row(self, animal_id, volume, idx) -> QFrame:
-        """Create wizard-style animal config row (matches Step 3)."""
-        try:
-            animal = self._database_handler.get_animal_by_id(animal_id)
-            animal_name = (
-                f"{animal.lab_animal_id} - {animal.name}" if animal else f"Animal {animal_id}"
-            )
-        except:
-            animal_name = f"Animal {animal_id}"
+    def _init_instant_notice_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 24, 24, 24)
+        layout.setSpacing(12)
 
-        container = QFrame()
-        container.setStyleSheet("""
-            QFrame { background: #F8FAFB; border: 1px solid #E5E7EB; border-radius: 6px; }
-        """)
+        title = QLabel("Editing instant schedules isn't available yet")
+        title.setObjectName("Title")
+        title.setWordWrap(True)
+        layout.addWidget(title)
 
-        layout = QHBoxLayout(container)
-        layout.setContentsMargins(8, 5, 8, 5)
-        layout.setSpacing(8)
-
-        label = QLabel(f"<b>{animal_name}</b>")
-        label.setMinimumWidth(100)
-        label.setStyleSheet("font-size: 11px;")
-        layout.addWidget(label)
-
-        # Cage dropdown (matches Step 3)
-        layout.addWidget(QLabel("Cage:"))
-        cage_combo = QComboBox()
-        cage_combo.setEditable(True)
-        cage_combo.setInsertPolicy(QComboBox.NoInsert)
-        cage_combo.setMinimumWidth(100)
-        cage_combo.setMinimumHeight(24)
-
-        display_names = []
-        for cage_opt in self._cage_options:
-            cage_combo.addItem(cage_opt['display_name'], cage_opt['cage_id'])
-            display_names.append(cage_opt['display_name'])
-
-        completer = QCompleter(display_names)
-        completer.setCaseSensitivity(Qt.CaseInsensitive)
-        completer.setFilterMode(Qt.MatchContains)
-        cage_combo.setCompleter(completer)
-
-        # Set default cage
-        if idx < len(self._cage_options):
-            cage_combo.setCurrentIndex(idx)
-
-        layout.addWidget(cage_combo)
-
-        layout.addWidget(QLabel("Start:"))
-        start_dt = QDateTimeEdit()
-        start_dt.setDateTime(
-            self._global_start.dateTime()
-            if hasattr(self, '_global_start')
-            else QDateTime.currentDateTime()
+        body = QLabel(
+            "This schedule uses Instant delivery. Editing instant schedules is "
+            "coming in a future release. For now, delete it and recreate it with "
+            "the wizard if you need to change it."
         )
-        start_dt.setCalendarPopup(True)
-        start_dt.setMinimumWidth(120)
-        start_dt.setMinimumHeight(24)
-        layout.addWidget(start_dt)
-
-        layout.addWidget(QLabel("End:"))
-        end_dt = QDateTimeEdit()
-        end_dt.setDateTime(
-            self._global_end.dateTime()
-            if hasattr(self, '_global_end')
-            else QDateTime.currentDateTime().addSecs(3600)
-        )
-        end_dt.setCalendarPopup(True)
-        end_dt.setMinimumWidth(120)
-        end_dt.setMinimumHeight(24)
-        layout.addWidget(end_dt)
-
-        layout.addWidget(QLabel("Vol:"))
-        volume_spin = QDoubleSpinBox()
-        volume_spin.setRange(0.1, 50.0)
-        volume_spin.setValue(float(volume) if volume else 1.0)
-        volume_spin.setSuffix(" mL")
-        volume_spin.setDecimals(2)
-        volume_spin.setMinimumHeight(24)
-        layout.addWidget(volume_spin)
-
+        body.setWordWrap(True)
+        layout.addWidget(body)
         layout.addStretch()
 
-        self._animal_widgets[animal_id] = {
-            "cage": cage_combo,
-            "start": start_dt,
-            "end": end_dt,
-            "volume": volume_spin,
-        }
-
-        return container
-
-    def _apply_to_all(self) -> None:
-        """Apply global settings to all animals."""
-        for animal_id, widgets in self._animal_widgets.items():
-            widgets["start"].setDateTime(self._global_start.dateTime())
-            widgets["end"].setDateTime(self._global_end.dateTime())
-            widgets["volume"].setValue(self._global_volume.value())
+        footer = QHBoxLayout()
+        footer.addStretch()
+        close_btn = QPushButton("Close")
+        close_btn.setMinimumHeight(36)
+        close_btn.setCursor(Qt.PointingHandCursor)
+        close_btn.clicked.connect(self.reject)
+        footer.addWidget(close_btn)
+        layout.addLayout(footer)
 
     def _save_changes(self) -> None:
-        try:
-            new_name = self._name_input.text().strip()
-            if not new_name:
-                QMessageBox.warning(self, "Validation Error", "Schedule name cannot be empty.")
-                return
-
-            if self._animal_widgets:
-                first_widgets = list(self._animal_widgets.values())[0]
-                new_start = first_widgets["start"].dateTime().toPyDateTime()
-                new_end = first_widgets["end"].dateTime().toPyDateTime()
-            else:
-                new_start = self._global_start.dateTime().toPyDateTime()
-                new_end = self._global_end.dateTime().toPyDateTime()
-
-            if new_start >= new_end:
-                QMessageBox.warning(self, "Validation Error", "End time must be after start time.")
-                return
-
-            new_volumes = {}
-            for animal_id, widgets in self._animal_widgets.items():
-                new_volumes[str(animal_id)] = widgets["volume"].value()
-
-            self._database_handler.update_schedule(
-                schedule_id=self._schedule.schedule_id,
-                name=new_name,
-                start_time=new_start.isoformat(),
-                end_time=new_end.isoformat(),
-                desired_outputs=new_volumes,
+        # Field-level validation (name, volumes > 0, end after start) is shared
+        # with the wizard via Step 3.
+        if not self._step3.is_valid():
+            QMessageBox.warning(
+                self,
+                "Invalid schedule",
+                "Check that the schedule has a name, every animal has a volume "
+                "greater than 0 mL, and each end time is after its start time.",
             )
+            return
 
+        # Animal-safety check shared with the wizard: a staggered window must be
+        # long enough to deliver every cage sequentially (one valve at a time).
+        animal_configs = self._step3.get_animal_configs()
+        need = estimate_min_window_seconds(animal_configs)
+        windows = [
+            (cfg["end_time"] - cfg["start_time"]).total_seconds()
+            for cfg in animal_configs.values()
+            if cfg.get("start_time") and cfg.get("end_time")
+        ]
+        if windows and min(windows) < need:
+            minutes = max(1, math.ceil(need / 60))
+            QMessageBox.warning(
+                self,
+                "Delivery window too short",
+                f"{len(animal_configs)} cage(s) need at least about {minutes} "
+                "minute(s) to deliver safely — valves fire one at a time. "
+                "Extend the end time.",
+            )
+            return
+
+        config = {
+            "schedule_type": "staggered",
+            "animals": [a["id"] for a in self._animals],
+            "parameters": self._step3.get_parameters(),
+        }
+        try:
+            # trainer=None: update_staggered_schedule does not rewrite
+            # created_by / is_super_user, so the original owner is preserved.
+            schedule = build_schedule_from_config(
+                config,
+                trainer=None,
+                system_controller=self._system_controller,
+                schedule_id=self._schedule.schedule_id,
+            )
+        except ValueError as e:
+            QMessageBox.warning(self, "Invalid cage assignment", str(e))
+            return
+
+        if self._database_handler.update_staggered_schedule(schedule):
             self.accept()
-
-        except Exception as e:
-            QMessageBox.critical(self, "Error", f"Failed to save changes: {e}")
-            import traceback
-
-            traceback.print_exc()
+        else:
+            QMessageBox.critical(
+                self,
+                "Error",
+                "Failed to save changes to the database. The schedule was not modified.",
+            )
 
 
 # ============================================================================

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.10.1"
+__version__ = "1.11.0"


### PR DESCRIPTION
 (v1.11.0)

The edit-schedule modal (Schedules Hub → right-click card → Edit Schedule) was a bespoke, inline-styled reimplementation of the wizard's Step 3 whose edits silently did not persist: update_schedule wrote a non-existent column (desired_water_output vs desired_output), the cage dropdown was decorative, and schedule_staggered_windows (read by the delivery engine) was never updated, so a "saved" edit never reached the runtime.

Frontend: ScheduleEditDialog now embeds the wizard's Step3ConfigureParameters verbatim (cage dropdown, quick-apply, per-animal start/end/volume, validation, and the window-fits-delivery safety check) as a pop-up modal launched from the hub, it does not route the user into the Wizard tab. Per-widget inline styles are gone; chrome uses PrimaryButton + global QSS.

Backend: add DatabaseHandler.update_staggered_schedule(), a single transaction that updates the schedules row and replaces all child rows (schedule_animals, schedule_desired_outputs, schedule_staggered_windows) and clears stale cycle_tracking, so cage reassignment, volumes, times and the runtime windows all persist. Also fix the desired_output column name in update_schedule.

Shared: extract build_schedule_from_config() (Schedule build + cage-uniqueness validation) so the wizard create path and the edit dialog use one code path. Fix Step3._restore_widget_values (wrong widget keys made staggered time-restore dead; snapshot times before setting widgets to avoid the end-clamp collapsing the window) and add a preset_configs path to set_animals for pre-filled edits.

Instant schedules are not editable yet (separate, tracked storage bug, see Project/docs/INSTANT_SCHEDULE_BUG.md); the dialog shows a notice for them.

Tests: test_update_staggered_schedule.py (Qt-free regression for the column and windows bugs + cage reassignment + animal removal) and test_edit_schedule_dialog.py (offscreen Qt: pre-fill, save persistence, instant notice). Bump to 1.11.0 (MINOR, user-visible behavior now works).