### PR TITLE
feat(ui): add 'Edit Schedule' button to Schedules Hub select mode (v1…

### DIFF
--- a/Project/tests/unit/test_schedules_hub_select_edit.py
+++ b/Project/tests/unit/test_schedules_hub_select_edit.py
@@ -1,0 +1,95 @@
+"""The Schedules Hub "Edit Schedule" button in multi-select mode.
+
+It appears next to "Delete Selected" while selecting, stays disabled unless
+exactly one schedule is selected (editing is single-schedule), and hides again
+when select mode is cancelled. Skips cleanly without PyQt5.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PyQt5.QtWidgets import QApplication  # noqa: PLC0415
+
+    return QApplication.instance() or QApplication([])
+
+
+def _make_hub(database_handler):
+    from PyQt5.QtCore import QObject, pyqtSignal  # noqa: PLC0415
+    from ui.schedules_hub import SchedulesHub  # noqa: PLC0415
+
+    class StubLogin(QObject):
+        login_status_changed = pyqtSignal()
+
+        def get_current_trainer(self):
+            return None
+
+        def is_logged_in(self):
+            return True
+
+    return SchedulesHub(
+        settings={},
+        print_to_terminal=lambda *_: None,
+        database_handler=database_handler,
+        login_system=StubLogin(),
+        system_controller=None,
+    )
+
+
+def _seed(database_handler, name):
+    from models.Schedule import Schedule  # noqa: PLC0415
+
+    start = datetime.now() + timedelta(days=1)
+    end = start + timedelta(hours=1)
+    sched = Schedule(None, name, 1.0, start.isoformat(), end.isoformat(), 1, 0, "staggered")
+    sched.add_animal(animal_id=1, relay_unit_id=1, desired_volume=1.0)
+    database_handler.add_staggered_schedule(sched)
+
+
+def test_edit_button_enabled_only_for_single_selection(qapp, database_handler):
+    _seed(database_handler, "A")
+    _seed(database_handler, "B")
+    hub = _make_hub(database_handler)
+    hub.load_schedules()
+    assert len(hub._all_schedules) == 2
+
+    # Hidden until select mode is entered.
+    assert hub._edit_selected_btn.isHidden()
+
+    hub._toggle_select_mode()
+    assert not hub._edit_selected_btn.isHidden()
+    assert not hub._edit_selected_btn.isEnabled()  # nothing selected yet
+
+    first, second = hub._all_schedules[0], hub._all_schedules[1]
+
+    hub._on_selection_toggled(first, True)
+    assert hub._edit_selected_btn.isEnabled()  # exactly one
+
+    hub._on_selection_toggled(second, True)
+    assert not hub._edit_selected_btn.isEnabled()  # two selected -> disabled
+
+    hub._on_selection_toggled(second, False)
+    assert hub._edit_selected_btn.isEnabled()  # back to one
+
+    hub._toggle_select_mode()  # cancel
+    assert hub._edit_selected_btn.isHidden()
+
+
+def test_edit_selected_is_noop_without_single_selection(qapp, database_handler):
+    _seed(database_handler, "A")
+    hub = _make_hub(database_handler)
+    hub.load_schedules()
+    hub._toggle_select_mode()
+    # No selection: must not raise or open anything.
+    hub._edit_selected()
+    assert hub._select_mode is True

--- a/Project/ui/schedules_hub.py
+++ b/Project/ui/schedules_hub.py
@@ -747,6 +747,22 @@ class SchedulesHub(QWidget):
         self._select_btn.clicked.connect(self._toggle_select_mode)
         header.addWidget(self._select_btn)
 
+        # Edit selected button (hidden by default; shown in select mode).
+        # Editing is single-schedule, so it stays disabled unless exactly one
+        # schedule is selected.
+        self._edit_selected_btn = QPushButton("Edit Schedule")
+        self._edit_selected_btn.setMinimumHeight(28)
+        self._edit_selected_btn.setVisible(False)
+        self._edit_selected_btn.setCursor(Qt.PointingHandCursor)
+        self._edit_selected_btn.setToolTip("Select exactly one schedule to edit")
+        self._edit_selected_btn.setStyleSheet("""
+            QPushButton { background-color: #0D9488; color: white; border: none; border-radius: 6px; padding: 5px 12px; font-weight: 500; font-size: 11px; }
+            QPushButton:hover { background-color: #0F766E; }
+            QPushButton:disabled { background-color: #CBD5E1; color: #F8FAFC; }
+        """)
+        self._edit_selected_btn.clicked.connect(self._edit_selected)
+        header.addWidget(self._edit_selected_btn)
+
         # Delete selected button (hidden by default)
         self._delete_selected_btn = QPushButton("Delete Selected")
         self._delete_selected_btn.setMinimumHeight(28)
@@ -842,6 +858,8 @@ class SchedulesHub(QWidget):
             """)
             self._delete_selected_btn.setVisible(True)
             self._delete_selected_btn.setEnabled(False)
+            self._edit_selected_btn.setVisible(True)
+            self._edit_selected_btn.setEnabled(False)
         else:
             self._select_btn.setText("Select")
             self._select_btn.setStyleSheet("""
@@ -849,6 +867,7 @@ class SchedulesHub(QWidget):
                 QPushButton:hover { background-color: #E5E7EB; }
             """)
             self._delete_selected_btn.setVisible(False)
+            self._edit_selected_btn.setVisible(False)
 
         for card in self._schedule_cards:
             card.set_select_mode(self._select_mode)
@@ -864,6 +883,17 @@ class SchedulesHub(QWidget):
         count = len(self._selected_schedules)
         self._delete_selected_btn.setEnabled(count > 0)
         self._delete_selected_btn.setText(f"Delete ({count})" if count > 0 else "Delete Selected")
+        # Editing acts on a single schedule, so only enable for exactly one.
+        self._edit_selected_btn.setEnabled(count == 1)
+
+    def _edit_selected(self) -> None:
+        if len(self._selected_schedules) != 1:
+            return
+        schedule = self._selected_schedules[0]
+        # Leave select mode before opening the editor so the post-save reload
+        # returns to the normal card view (mirrors the delete flow).
+        self._toggle_select_mode()
+        self._on_edit_schedule(schedule)
 
     def _delete_selected(self) -> None:
         if not self._selected_schedules:
@@ -897,7 +927,8 @@ class SchedulesHub(QWidget):
             "Welcome to the Schedules Hub!\n\n"
             "• Drag a card to the Run/Stop section to execute it\n"
             "• Right-click a card for Edit/Delete options\n"
-            "• Click 'Select' for bulk deletion mode\n"
+            "• Click 'Select', pick one schedule, then 'Edit Schedule'\n"
+            "• Click 'Select' to choose schedules for bulk deletion\n"
             "• Use the search bar to filter by name\n"
             "• Click '+ New Schedule' to create via wizard",
         )

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.11.1"
+__version__ = "1.12.0"


### PR DESCRIPTION
….12.0)

In multi-select mode the toolbar now offers 'Edit Schedule' next to 'Delete Selected'. Editing is single-schedule, so the button stays greyed out unless exactly one schedule is selected (disabled for zero or many). Clicking it leaves select mode and opens the existing ScheduleEditDialog for that schedule.

This complements the right-click → Edit path with a discoverable button. MINOR bump (new user-facing control).