### PR TITLE
fix(schedules): make instant delivery create/run/edit work (v1.13.0)

### DIFF
--- a/Project/docs/INSTANT_SCHEDULE_BUG.md
+++ b/Project/docs/INSTANT_SCHEDULE_BUG.md
@@ -1,8 +1,14 @@
 # Instant-delivery schedules: storage inconsistency (tracked)
 
-**Status:** open. Discovered while refactoring the edit-schedule flow (v1.11.0).
-This is a **separate concern** from edit-schedule and is intentionally *not*
-fixed in that PR (one concern per PR — see [CLAUDE.md](../../CLAUDE.md)).
+**Status:** FIXED in v1.13.0 (create + run + edit). The create path now writes
+`schedule_instant_deliveries` (the table the runtime reads), and instant
+schedules are editable in `ScheduleEditDialog`. **Remaining:** a follow-up
+cleanup PR should delete the dead `schedule_time_instants` cluster
+(`add_schedule_instant`, `get_pending_schedule_instants`,
+`mark_instant_completed`, `add_instant_schedule`) and the never-instantiated
+`ScheduleController` / `DeliveryQueueController` that reference it.
+
+The original diagnosis (from v1.11.0) is kept below for context.
 
 ## Symptom
 

--- a/Project/models/database_handler.py
+++ b/Project/models/database_handler.py
@@ -1465,6 +1465,105 @@ class DatabaseHandler:
             traceback.print_exc()
             return False
 
+    def update_instant_schedule(self, schedule):
+        """Persist edits to an existing instant schedule, transactionally.
+
+        Instant counterpart of :meth:`update_staggered_schedule`. Updates the
+        parent ``schedules`` row and **replaces** every child row for this
+        ``schedule_id``: ``schedule_animals`` (cage assignments) and
+        ``schedule_instant_deliveries`` (the per-animal delivery times the
+        runtime reads via ``get_schedule_instant_deliveries``). Any stale
+        staggered-mode rows for the id are cleared too.
+
+        Args:
+            schedule: a :class:`~models.Schedule.Schedule` with
+                ``delivery_mode == 'instant'``, populated ``animals`` /
+                ``relay_unit_assignments`` and ``instant_deliveries`` (each
+                ``{'animal_id','datetime','volume','relay_unit_id'}`` with
+                ``datetime`` an ISO string). ``schedule_id`` must be set.
+
+        Returns:
+            True on success, False on error (single rolled-back transaction).
+        """
+        schedule_id = schedule.schedule_id
+        if schedule_id is None:
+            print("update_instant_schedule called with no schedule_id")
+            return False
+        try:
+            with self.connect() as conn:
+                cursor = conn.cursor()
+
+                cursor.execute(
+                    '''
+                    UPDATE schedules
+                    SET name = ?, water_volume = ?, start_time = ?,
+                        end_time = ?, delivery_mode = 'instant'
+                    WHERE schedule_id = ?
+                ''',
+                    (
+                        schedule.name,
+                        schedule.water_volume,
+                        schedule.start_time,
+                        schedule.end_time,
+                        schedule_id,
+                    ),
+                )
+
+                # Replace all child rows for this schedule.
+                cursor.execute(
+                    'DELETE FROM schedule_animals WHERE schedule_id = ?', (schedule_id,)
+                )
+                cursor.execute(
+                    'DELETE FROM schedule_instant_deliveries WHERE schedule_id = ?',
+                    (schedule_id,),
+                )
+                # Clear any stale staggered-mode rows for this id (defensive).
+                cursor.execute(
+                    'DELETE FROM schedule_desired_outputs WHERE schedule_id = ?',
+                    (schedule_id,),
+                )
+                cursor.execute(
+                    'DELETE FROM schedule_staggered_windows WHERE schedule_id = ?',
+                    (schedule_id,),
+                )
+                cursor.execute('DELETE FROM cycle_tracking WHERE schedule_id = ?', (schedule_id,))
+
+                for animal_id in schedule.animals:
+                    relay_unit_id = schedule.relay_unit_assignments.get(str(animal_id))
+                    cursor.execute(
+                        '''
+                        INSERT INTO schedule_animals
+                        (schedule_id, animal_id, relay_unit_id)
+                        VALUES (?, ?, ?)
+                    ''',
+                        (schedule_id, animal_id, relay_unit_id),
+                    )
+
+                for delivery in schedule.instant_deliveries:
+                    cursor.execute(
+                        '''
+                        INSERT INTO schedule_instant_deliveries
+                        (schedule_id, animal_id, delivery_datetime, water_volume, relay_unit_id)
+                        VALUES (?, ?, ?, ?, ?)
+                    ''',
+                        (
+                            schedule_id,
+                            delivery['animal_id'],
+                            delivery['datetime'],
+                            delivery['volume'],
+                            delivery['relay_unit_id'],
+                        ),
+                    )
+
+                conn.commit()
+                print(f"Schedule {schedule_id} updated successfully (instant).")
+                return True
+
+        except sqlite3.Error as e:
+            print(f"Database error when updating instant schedule: {e}")
+            traceback.print_exc()
+            return False
+
     def get_active_staggered_windows(self):
         """Get all active staggered delivery windows"""
         try:

--- a/Project/tests/unit/test_edit_schedule_dialog.py
+++ b/Project/tests/unit/test_edit_schedule_dialog.py
@@ -130,20 +130,89 @@ def test_change_summary_lists_what_changed(qapp, database_handler):
     assert "4 mL" in summary  # new volume formatted
 
 
-def test_instant_schedule_shows_notice_not_form(qapp, database_handler):
+def _seed_instant(database_handler, deliveries):
+    """Create an instant schedule. ``deliveries`` is ``[(animal_id, cage, vol, datetime)]``."""
     from models.Schedule import Schedule  # noqa: PLC0415
+
+    total = sum(v for _, _, v, _ in deliveries)
+    times = [d for *_, d in deliveries]
+    sched = Schedule(
+        None,
+        "Instant ration",
+        total,
+        min(times).isoformat(),
+        max(times).isoformat(),
+        1,
+        0,
+        "instant",
+    )
+    seen = set()
+    for aid, cage, vol, when in deliveries:
+        if aid not in seen:
+            sched.add_animal(aid, cage, vol)
+            seen.add(aid)
+        sched.add_instant_delivery(aid, when.isoformat(), vol, cage)
+    sid = database_handler.add_schedule(sched)
+    return next(s for s in database_handler.get_all_schedules() if s.schedule_id == sid)
+
+
+def test_build_schedule_from_config_populates_instant_deliveries(qapp):
+    from ui.schedule_wizard import build_schedule_from_config  # noqa: PLC0415
+
+    dt = datetime(2026, 6, 5, 9, 0, 0)
+    config = {
+        "schedule_type": "instant",
+        "animals": [1],
+        "parameters": {
+            "name": "x",
+            "animal_configs": {1: {"delivery_time": dt, "volume": 1.5, "cage_id": 2}},
+        },
+    }
+    sched = build_schedule_from_config(config, trainer=None, system_controller=None)
+    assert len(sched.instant_deliveries) == 1
+    d = sched.instant_deliveries[0]
+    assert (d["animal_id"], d["volume"], d["relay_unit_id"]) == (1, 1.5, 2)
+    assert d["datetime"] == dt.isoformat()  # stored as ISO string for add_schedule
+
+
+def test_instant_dialog_prefills_and_saves(qapp, database_handler):
+    from PyQt5.QtCore import QDateTime  # noqa: PLC0415
+    from PyQt5.QtWidgets import QDialog  # noqa: PLC0415
     from ui.schedules_hub import ScheduleEditDialog  # noqa: PLC0415
 
-    instant = Schedule(
-        schedule_id=999,
-        name="Instant one",
-        water_volume=1.0,
-        start_time=datetime.now().isoformat(),
-        end_time=datetime.now().isoformat(),
-        created_by=1,
-        is_super_user=0,
-        delivery_mode="instant",
-    )
-    dlg = ScheduleEditDialog(instant, database_handler, system_controller=None)
-    # Instant mode renders the notice path, not the Step-3 form.
+    d1 = datetime(2026, 6, 5, 9, 0, 0)
+    schedule = _seed_instant(database_handler, [(1, 1, 1.0, d1)])
+    dlg = ScheduleEditDialog(schedule, database_handler, system_controller=None)
+
+    assert dlg._step3 is not None
+    cfg = dlg._step3.get_animal_configs()[1]
+    assert cfg["volume"] == 1.0
+    assert cfg["cage_id"] == 1
+    assert cfg["delivery_time"].replace(microsecond=0) == d1
+
+    # Change the delivery time via the (authoritative) Quick Apply row, save.
+    nd = (datetime.now() + timedelta(days=2)).replace(second=0, microsecond=0)
+    dlg._step3._global_delivery_time.setDateTime(QDateTime(nd))
+    dlg._save_changes()
+    assert dlg.result() == QDialog.Accepted
+
+    with database_handler.connect() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT delivery_datetime FROM schedule_instant_deliveries WHERE schedule_id = ?",
+            (schedule.schedule_id,),
+        )
+        got = cur.fetchone()[0]
+    assert datetime.fromisoformat(got).replace(microsecond=0) == nd
+
+
+def test_instant_multi_delivery_shows_guard_notice(qapp, database_handler):
+    from ui.schedules_hub import ScheduleEditDialog  # noqa: PLC0415
+
+    d1 = datetime(2026, 6, 5, 9, 0, 0)
+    d2 = datetime(2026, 6, 5, 12, 0, 0)
+    # Two deliveries for the SAME animal — not representable one-row-per-animal.
+    schedule = _seed_instant(database_handler, [(1, 1, 1.0, d1), (1, 1, 1.0, d2)])
+    dlg = ScheduleEditDialog(schedule, database_handler, system_controller=None)
     assert dlg._step3 is None
+    assert dlg._blocked_reason

--- a/Project/tests/unit/test_instant_schedule.py
+++ b/Project/tests/unit/test_instant_schedule.py
@@ -1,0 +1,83 @@
+"""Instant-delivery create + update round-trips (Qt-free).
+
+Regression for the bug where instant schedules wrote to a non-existent
+``schedule_time_instants`` table (and so delivered nothing): create now writes
+``schedule_instant_deliveries`` — the table the runtime reads — and
+``update_instant_schedule`` replaces those rows transactionally.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from models.database_handler import DatabaseHandler  # noqa: F401 (fixture import path)
+from models.Schedule import Schedule
+
+
+def _instant(name, deliveries, schedule_id=None) -> Schedule:
+    """Build an instant Schedule. ``deliveries`` is ``[(animal_id, cage, vol, datetime)]``."""
+    total = sum(v for _, _, v, _ in deliveries)
+    times = [d for *_, d in deliveries]
+    sched = Schedule(
+        schedule_id=schedule_id,
+        name=name,
+        water_volume=total,
+        start_time=min(times).isoformat(),
+        end_time=max(times).isoformat(),
+        created_by=1,
+        is_super_user=0,
+        delivery_mode="instant",
+    )
+    for animal_id, cage, vol, when in deliveries:
+        sched.add_animal(animal_id, cage, vol)
+        sched.add_instant_delivery(animal_id, when.isoformat(), vol, cage)
+    return sched
+
+
+def _rows(database_handler, schedule_id):
+    """Read schedule_instant_deliveries directly (avoids the animals JOIN)."""
+    with database_handler.connect() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT animal_id, delivery_datetime, water_volume, relay_unit_id
+            FROM schedule_instant_deliveries
+            WHERE schedule_id = ?
+            ORDER BY animal_id
+            """,
+            (schedule_id,),
+        )
+        return cur.fetchall()
+
+
+def test_add_schedule_writes_instant_delivery_rows(database_handler):
+    d1 = datetime(2026, 6, 5, 9, 0, 0)
+    d2 = datetime(2026, 6, 5, 10, 30, 0)
+    sid = database_handler.add_schedule(_instant("inst", [(1, 1, 1.0, d1), (2, 2, 2.0, d2)]))
+    assert sid is not None
+
+    rows = _rows(database_handler, sid)
+    assert rows == [
+        (1, d1.isoformat(), 1.0, 1),
+        (2, d2.isoformat(), 2.0, 2),
+    ]
+
+
+def test_update_instant_schedule_replaces_rows(database_handler):
+    d1 = datetime(2026, 6, 5, 9, 0, 0)
+    sid = database_handler.add_schedule(_instant("inst", [(1, 1, 1.0, d1)]))
+
+    # Edit: new delivery time, volume, and cage reassignment 1 -> 3.
+    nd = datetime(2026, 6, 6, 14, 15, 0)
+    updated = _instant("inst-edited", [(1, 3, 2.5, nd)], schedule_id=sid)
+    assert database_handler.update_instant_schedule(updated) is True
+
+    assert _rows(database_handler, sid) == [(1, nd.isoformat(), 2.5, 3)]
+
+    # Parent row + animal/cage assignment also updated.
+    details = database_handler.get_schedule_details(sid)[0]
+    assert details["relay_unit_assignments"] == {"1": 3}
+    with database_handler.connect() as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT name, delivery_mode FROM schedules WHERE schedule_id = ?", (sid,))
+        assert cur.fetchone() == ("inst-edited", "instant")

--- a/Project/ui/schedule_wizard.py
+++ b/Project/ui/schedule_wizard.py
@@ -292,6 +292,18 @@ def build_schedule_from_config(
         used_cages.add(cage_id)
         schedule.add_animal(animal_id, cage_id, volume)
 
+        # Instant mode: also record the per-animal delivery so add_schedule
+        # writes schedule_instant_deliveries (the table the runtime reads).
+        # Store the time as an ISO string — add_schedule inserts delivery
+        # ['datetime'] verbatim, and a datetime would trip the deprecated
+        # sqlite3 timestamp adapter (a hard error under filterwarnings=error).
+        if schedule_type == "instant":
+            delivery_time = animal_cfg.get("delivery_time") or datetime.now()
+            delivery_iso = (
+                delivery_time.isoformat() if isinstance(delivery_time, datetime) else delivery_time
+            )
+            schedule.add_instant_delivery(animal_id, delivery_iso, volume, cage_id)
+
     return schedule
 
 
@@ -1253,44 +1265,56 @@ class Step3ConfigureParameters(QWidget):
         if hasattr(self, "_name_input") and self._name_input is not None:
             self._name_input.setText(name or "")
         self._restore_widget_values()
-        if schedule_type == "staggered":
-            self._make_quick_apply_authoritative()
+        self._make_quick_apply_authoritative()
 
     def _make_quick_apply_authoritative(self) -> None:
         """Edit-mode: pre-fill the "Quick Apply to All" row and make it live.
 
         In the creation wizard, Quick Apply only takes effect when the operator
         clicks "Apply to All". When *editing* a schedule that is the wrong
-        default: the prominent top Start/End/Volume showed "now" (not the
-        schedule's real values) and changing them did nothing on Save unless the
-        button was clicked — so time edits silently appeared to do nothing.
+        default: the prominent top fields showed "now" (not the schedule's real
+        values) and changing them did nothing on Save unless the button was
+        clicked — so time edits silently appeared to do nothing.
 
-        Staggered schedules store a single shared window for every animal
-        (see add_staggered_schedule), so "apply to all" is exactly the right
-        semantic. Here we pre-fill the Quick Apply row from the schedule and
-        wire it so any change flows straight to every animal row (the per-animal
-        rows remain available for fine-tuning afterwards).
+        Both modes effectively share their timing across animals (staggered
+        stores one window per schedule; instant here is one delivery per
+        animal), so "apply to all" is the right semantic. We pre-fill the Quick
+        Apply row from the schedule and wire it so any change flows straight to
+        every animal row (the per-animal rows remain available for fine-tuning).
         """
-        if not (hasattr(self, "_global_start") and self._animal_configs):
+        if not self._animal_configs:
             return
         first = next(iter(self._animal_configs.values()))
-        start = first.get("start_time")
-        end = first.get("end_time")
         volume = first.get("volume", 1.0)
 
         # Pre-fill BEFORE connecting auto-apply so seeding the widgets doesn't
-        # clobber the per-animal presets. Setting start first lets the existing
-        # min-constraint handler bump the end's minimum so a real end isn't
-        # clamped.
-        if isinstance(start, datetime):
-            self._global_start.setDateTime(QDateTime(start))
-        if isinstance(end, datetime):
-            self._global_end.setDateTime(QDateTime(end))
-        self._global_volume.setValue(float(volume))
+        # clobber the per-animal presets.
+        if self._schedule_type == "staggered":
+            if not hasattr(self, "_global_start"):
+                return
+            start = first.get("start_time")
+            end = first.get("end_time")
+            # Setting start first lets the existing min-constraint handler bump
+            # the end's minimum so a real end isn't clamped.
+            if isinstance(start, datetime):
+                self._global_start.setDateTime(QDateTime(start))
+            if isinstance(end, datetime):
+                self._global_end.setDateTime(QDateTime(end))
+            self._global_volume.setValue(float(volume))
+            apply_all = self._apply_to_all_staggered
+            self._global_start.dateTimeChanged.connect(lambda *_: apply_all())
+            self._global_end.dateTimeChanged.connect(lambda *_: apply_all())
+        else:
+            if not hasattr(self, "_global_delivery_time"):
+                return
+            delivery = first.get("delivery_time")
+            if isinstance(delivery, datetime):
+                self._global_delivery_time.setDateTime(QDateTime(delivery))
+            self._global_volume.setValue(float(volume))
+            apply_all = self._apply_to_all_instant
+            self._global_delivery_time.dateTimeChanged.connect(lambda *_: apply_all())
 
-        self._global_start.dateTimeChanged.connect(lambda *_: self._apply_to_all_staggered())
-        self._global_end.dateTimeChanged.connect(lambda *_: self._apply_to_all_staggered())
-        self._global_volume.valueChanged.connect(lambda *_: self._apply_to_all_staggered())
+        self._global_volume.valueChanged.connect(lambda *_: apply_all())
 
     def _restore_widget_values(self) -> None:
         """
@@ -1793,7 +1817,6 @@ class ScheduleCreationWizard(QWidget):
         """Create schedule in database using existing Schedule model and correct methods."""
         schedule_type = config["schedule_type"]
         animals = config["animals"]
-        animal_configs = config["parameters"].get("animal_configs", {})
 
         # Build + validate the Schedule object (shared with the edit dialog).
         trainer = self._login_system.get_current_trainer()
@@ -1807,25 +1830,12 @@ class ScheduleCreationWizard(QWidget):
             print(f"[Wizard] Created staggered schedule {schedule_id} with {len(animals)} animals")
             print(f"[Wizard] desired_water_outputs: {schedule.desired_water_outputs}")
         else:
-            # For instant mode, use add_schedule and then add instant deliveries
+            # Instant mode: build_schedule_from_config already populated
+            # schedule.instant_deliveries, so add_schedule writes both
+            # schedule_animals and schedule_instant_deliveries in one go.
             self._database_handler.add_schedule(schedule)
             schedule_id = schedule.schedule_id  # add_schedule sets this on the object
-
-            if schedule_id:
-                for animal_id in animals:
-                    animal_cfg = animal_configs.get(animal_id, {})
-                    delivery_time = animal_cfg.get("delivery_time", datetime.now())
-                    volume = animal_cfg.get("volume", 1.0)
-
-                    self._database_handler.add_schedule_instant(
-                        schedule_id=schedule_id,
-                        animal_id=animal_id,
-                        delivery_time=delivery_time,
-                        water_volume=volume,
-                    )
-                print(
-                    f"[Wizard] Created instant schedule {schedule_id} with {len(animals)} animals"
-                )
+            print(f"[Wizard] Created instant schedule {schedule_id} with {len(animals)} animals")
 
         return schedule_id
 

--- a/Project/ui/schedules_hub.py
+++ b/Project/ui/schedules_hub.py
@@ -77,6 +77,9 @@ class ScheduleEditDialog(QDialog):
         self._animals: List[Dict[str, Any]] = []
         self._preset_configs: Dict[int, Dict[str, Any]] = {}
         self._step3: Step3ConfigureParameters | None = None
+        # Set to a message string when the schedule can't be edited with the
+        # one-row-per-animal form (e.g. >1 instant delivery per animal).
+        self._blocked_reason: str | None = None
 
         self._delivery_mode = getattr(schedule, "delivery_mode", "staggered") or "staggered"
 
@@ -90,11 +93,11 @@ class ScheduleEditDialog(QDialog):
         self.setModal(True)
         self.change_summary: List[str] = []
 
-        if self._delivery_mode == "staggered":
-            self._load_schedule_details()
-            self._init_ui()
+        self._load_schedule_details()
+        if self._blocked_reason:
+            self._init_notice_ui(self._blocked_reason)
         else:
-            self._init_instant_notice_ui()
+            self._init_ui()
 
     @staticmethod
     def _parse_dt(value, fallback: datetime) -> datetime:
@@ -112,8 +115,9 @@ class ScheduleEditDialog(QDialog):
 
         Done before ``_init_ui`` so the embedded Step 3 builds already-filled
         rows. Cage assignment is stored as ``relay_unit_id`` (== the dropdown's
-        ``cage_id``) in ``schedule_animals``; desired volume in
-        ``schedule_desired_outputs``. Times use the schedule bounds.
+        ``cage_id``) in ``schedule_animals``. Staggered volume comes from
+        ``schedule_desired_outputs`` and times from the schedule bounds; instant
+        delivery time + volume come from ``schedule_instant_deliveries``.
         """
         try:
             details_list = self._database_handler.get_schedule_details(self._schedule.schedule_id)
@@ -123,9 +127,24 @@ class ScheduleEditDialog(QDialog):
         details = details_list[0] if details_list else {}
 
         animal_ids = details.get("animal_ids", [])
-        desired = details.get("desired_water_outputs", {})  # {str(animal_id): volume}
         cage_by_animal = details.get("relay_unit_assignments", {})  # {str(animal_id): cage_id}
 
+        instant_by_animal: Dict[int, list] = {}
+        if self._delivery_mode == "instant":
+            for d in details.get("delivery_schedule", []):
+                instant_by_animal.setdefault(d["animal_id"], []).append(d)
+            # The form is one delivery per animal (matching what the wizard
+            # creates). If any animal has several deliveries we can't represent
+            # it without silently dropping data — fall back to a read-only note.
+            if any(len(v) > 1 for v in instant_by_animal.values()):
+                self._blocked_reason = (
+                    "This instant schedule has more than one delivery time for an "
+                    "animal, which the editor can't show yet without losing data. "
+                    "Delete and recreate it with the wizard to change it."
+                )
+                return
+
+        desired = details.get("desired_water_outputs", {})  # {str(animal_id): volume}
         start_dt = self._parse_dt(self._schedule.start_time, datetime.now())
         end_dt = self._parse_dt(self._schedule.end_time, start_dt + timedelta(hours=1))
         default_volume = float(self._schedule.water_volume or 1.0)
@@ -142,12 +161,23 @@ class ScheduleEditDialog(QDialog):
                     "name": animal.name if animal else f"Animal {animal_id}",
                 }
             )
-            self._preset_configs[animal_id] = {
-                "start_time": start_dt,
-                "end_time": end_dt,
-                "volume": float(desired.get(str(animal_id), default_volume)),
-                "cage_id": cage_by_animal.get(str(animal_id)),
-            }
+            if self._delivery_mode == "instant":
+                d = (instant_by_animal.get(animal_id) or [None])[0]
+                self._preset_configs[animal_id] = {
+                    "delivery_time": self._parse_dt(
+                        d["datetime"] if d else None, datetime.now() + timedelta(minutes=5)
+                    ),
+                    "volume": float(d["volume"]) if d else default_volume,
+                    "cage_id": cage_by_animal.get(str(animal_id))
+                    or (d["relay_unit_id"] if d else None),
+                }
+            else:
+                self._preset_configs[animal_id] = {
+                    "start_time": start_dt,
+                    "end_time": end_dt,
+                    "volume": float(desired.get(str(animal_id), default_volume)),
+                    "cage_id": cage_by_animal.get(str(animal_id)),
+                }
 
     def _init_ui(self) -> None:
         layout = QVBoxLayout(self)
@@ -160,7 +190,7 @@ class ScheduleEditDialog(QDialog):
             system_controller=self._system_controller,
         )
         self._step3.load_for_edit(
-            self._animals, self._preset_configs, self._schedule.name or "", "staggered"
+            self._animals, self._preset_configs, self._schedule.name or "", self._delivery_mode
         )
         layout.addWidget(self._step3, 1)
 
@@ -185,21 +215,17 @@ class ScheduleEditDialog(QDialog):
 
         layout.addWidget(footer)
 
-    def _init_instant_notice_ui(self) -> None:
+    def _init_notice_ui(self, message: str) -> None:
         layout = QVBoxLayout(self)
         layout.setContentsMargins(24, 24, 24, 24)
         layout.setSpacing(12)
 
-        title = QLabel("Editing instant schedules isn't available yet")
+        title = QLabel("This schedule can't be edited here")
         title.setObjectName("Title")
         title.setWordWrap(True)
         layout.addWidget(title)
 
-        body = QLabel(
-            "This schedule uses Instant delivery. Editing instant schedules is "
-            "coming in a future release. For now, delete it and recreate it with "
-            "the wizard if you need to change it."
-        )
+        body = QLabel(message)
         body.setWordWrap(True)
         layout.addWidget(body)
         layout.addStretch()
@@ -214,45 +240,47 @@ class ScheduleEditDialog(QDialog):
         layout.addLayout(footer)
 
     def _save_changes(self) -> None:
-        # Field-level validation (name, volumes > 0, end after start) is shared
-        # with the wizard via Step 3.
+        # Field-level validation (name, volumes > 0, staggered end after start,
+        # instant delivery time present) is shared with the wizard via Step 3.
         if not self._step3.is_valid():
             QMessageBox.warning(
                 self,
                 "Invalid schedule",
                 "Check that the schedule has a name, every animal has a volume "
-                "greater than 0 mL, and each end time is after its start time.",
+                "greater than 0 mL, and the timing for each animal is set.",
             )
             return
 
-        # Animal-safety check shared with the wizard: a staggered window must be
-        # long enough to deliver every cage sequentially (one valve at a time).
-        animal_configs = self._step3.get_animal_configs()
-        need = estimate_min_window_seconds(animal_configs)
-        windows = [
-            (cfg["end_time"] - cfg["start_time"]).total_seconds()
-            for cfg in animal_configs.values()
-            if cfg.get("start_time") and cfg.get("end_time")
-        ]
-        if windows and min(windows) < need:
-            minutes = max(1, math.ceil(need / 60))
-            QMessageBox.warning(
-                self,
-                "Delivery window too short",
-                f"{len(animal_configs)} cage(s) need at least about {minutes} "
-                "minute(s) to deliver safely — valves fire one at a time. "
-                "Extend the end time.",
-            )
-            return
+        # Staggered-only animal-safety check: a window must be long enough to
+        # deliver every cage sequentially (one valve at a time). Instant
+        # deliveries are single moments, so there's no window to validate.
+        if self._delivery_mode == "staggered":
+            animal_configs = self._step3.get_animal_configs()
+            need = estimate_min_window_seconds(animal_configs)
+            windows = [
+                (cfg["end_time"] - cfg["start_time"]).total_seconds()
+                for cfg in animal_configs.values()
+                if cfg.get("start_time") and cfg.get("end_time")
+            ]
+            if windows and min(windows) < need:
+                minutes = max(1, math.ceil(need / 60))
+                QMessageBox.warning(
+                    self,
+                    "Delivery window too short",
+                    f"{len(animal_configs)} cage(s) need at least about {minutes} "
+                    "minute(s) to deliver safely — valves fire one at a time. "
+                    "Extend the end time.",
+                )
+                return
 
         config = {
-            "schedule_type": "staggered",
+            "schedule_type": self._delivery_mode,
             "animals": [a["id"] for a in self._animals],
             "parameters": self._step3.get_parameters(),
         }
         try:
-            # trainer=None: update_staggered_schedule does not rewrite
-            # created_by / is_super_user, so the original owner is preserved.
+            # trainer=None: the update_* methods don't rewrite created_by /
+            # is_super_user, so the original owner is preserved.
             schedule = build_schedule_from_config(
                 config,
                 trainer=None,
@@ -266,7 +294,12 @@ class ScheduleEditDialog(QDialog):
         # Diff old vs new BEFORE the write so the hub can log what changed.
         self.change_summary = self._build_change_summary(schedule)
 
-        if self._database_handler.update_staggered_schedule(schedule):
+        if self._delivery_mode == "instant":
+            saved = self._database_handler.update_instant_schedule(schedule)
+        else:
+            saved = self._database_handler.update_staggered_schedule(schedule)
+
+        if saved:
             self.accept()
         else:
             QMessageBox.critical(
@@ -300,29 +333,43 @@ class ScheduleEditDialog(QDialog):
         if (self._schedule.name or "") != (new_schedule.name or ""):
             changes.append(f"Name: '{self._schedule.name}' → '{new_schedule.name}'")
 
-        old_start = self._parse_dt(self._schedule.start_time, None)
-        new_start = self._parse_dt(new_schedule.start_time, None)
-        if old_start != new_start:
-            changes.append(
-                f"Start time: {self._fmt_time(self._schedule.start_time)} "
-                f"→ {self._fmt_time(new_schedule.start_time)}"
-            )
-        old_end = self._parse_dt(self._schedule.end_time, None)
-        new_end = self._parse_dt(new_schedule.end_time, None)
-        if old_end != new_end:
-            changes.append(
-                f"End time: {self._fmt_time(self._schedule.end_time)} "
-                f"→ {self._fmt_time(new_schedule.end_time)}"
-            )
-
         old_ids = set(self._preset_configs.keys())
         new_ids = set(new_schedule.animals)
+
+        if self._delivery_mode == "instant":
+            # Per-animal delivery time (instant has no schedule-wide window).
+            new_dt = {d["animal_id"]: d["datetime"] for d in new_schedule.instant_deliveries}
+            for animal_id in sorted(old_ids & new_ids):
+                old_d = self._preset_configs.get(animal_id, {}).get("delivery_time")
+                new_d = new_dt.get(animal_id)
+                if self._parse_dt(old_d, None) != self._parse_dt(new_d, None):
+                    changes.append(
+                        f"{self._animal_label(animal_id)} delivery time: "
+                        f"{self._fmt_time(old_d)} → {self._fmt_time(new_d)}"
+                    )
+        else:
+            old_start = self._parse_dt(self._schedule.start_time, None)
+            new_start = self._parse_dt(new_schedule.start_time, None)
+            if old_start != new_start:
+                changes.append(
+                    f"Start time: {self._fmt_time(self._schedule.start_time)} "
+                    f"→ {self._fmt_time(new_schedule.start_time)}"
+                )
+            old_end = self._parse_dt(self._schedule.end_time, None)
+            new_end = self._parse_dt(new_schedule.end_time, None)
+            if old_end != new_end:
+                changes.append(
+                    f"End time: {self._fmt_time(self._schedule.end_time)} "
+                    f"→ {self._fmt_time(new_schedule.end_time)}"
+                )
+
         for animal_id in sorted(new_ids - old_ids):
             changes.append(f"Animal added: {self._animal_label(animal_id)}")
         for animal_id in sorted(old_ids - new_ids):
             changes.append(f"Animal removed: {self._animal_label(animal_id)}")
 
         # Per-animal volume / cage changes for animals present before and after.
+        # desired_water_outputs is populated for both modes by Schedule.add_animal.
         for animal_id in sorted(old_ids & new_ids):
             preset = self._preset_configs.get(animal_id, {})
             old_vol = preset.get("volume")

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.12.0"
+__version__ = "1.13.0"


### PR DESCRIPTION
Instant schedules previously dispensed nothing: the wizard wrote deliveries to a phantom schedule_time_instants table (never created), while the runtime reads schedule_instant_deliveries. Now fixed end to end.

- Create: build_schedule_from_config populates schedule.instant_deliveries (delivery time stored as an ISO string so add_schedule's raw insert doesn't trip the deprecated sqlite3 datetime adapter). The wizard's instant branch just calls add_schedule, which already writes schedule_animals + schedule_instant_deliveries, the table run_stop_section/RelayWorker read.
- Edit: ScheduleEditDialog now supports instant schedules (pre-fill from delivery_schedule, save via the new transactional update_instant_schedule). The staggered window-fits check is skipped for instant; the change log shows per-animal delivery-time changes. Quick Apply is authoritative for instant too (generalized _make_quick_apply_authoritative). Guard: a schedule with
  >1 delivery for one animal (not creatable today) shows a read-only notice
  rather than silently collapsing to one row.

Validated headless on the Pi (Python 3.11/PyQt5, temp DB): create writes schedule_instant_deliveries and editing persists. Physical valve-fire on the device is the remaining manual check.

Dead schedule_time_instants cluster (add_schedule_instant, get_pending_schedule_instants, mark_instant_completed, add_instant_schedule) and the unwired Schedule/DeliveryQueue controllers are left for a separate cleanup PR (see Project/docs/INSTANT_SCHEDULE_BUG.md).