### PR TITLE
fix(schedules): show correct animal count for instant schedule cards …

### DIFF
--- a/Project/models/database_handler.py
+++ b/Project/models/database_handler.py
@@ -662,6 +662,14 @@ class DatabaseHandler:
                             }
                             for row in cursor.fetchall()
                         ]
+                        # Populate the animal roster (distinct, in order) so UIs
+                        # that read schedule.animals — e.g. the schedule card's
+                        # animal count — are correct for instant schedules too.
+                        for d in schedule.instant_deliveries:
+                            aid = d['animal_id']
+                            if aid not in schedule.animals:
+                                schedule.animals.append(aid)
+                                schedule.relay_unit_assignments[str(aid)] = d['relay_unit_id']
                     else:
                         # Get animals and desired outputs for staggered mode
                         cursor.execute(
@@ -741,6 +749,14 @@ class DatabaseHandler:
                             }
                             for row in cursor.fetchall()
                         ]
+                        # Populate the animal roster (distinct, in order) so UIs
+                        # that read schedule.animals — e.g. the schedule card's
+                        # animal count — are correct for instant schedules too.
+                        for d in schedule.instant_deliveries:
+                            aid = d['animal_id']
+                            if aid not in schedule.animals:
+                                schedule.animals.append(aid)
+                                schedule.relay_unit_assignments[str(aid)] = d['relay_unit_id']
                     else:
                         # Get animals and relay unit assignments for staggered mode
                         cursor.execute(

--- a/Project/tests/unit/test_instant_schedule.py
+++ b/Project/tests/unit/test_instant_schedule.py
@@ -63,6 +63,24 @@ def test_add_schedule_writes_instant_delivery_rows(database_handler):
     ]
 
 
+def test_loaded_instant_schedule_reports_its_animals(database_handler):
+    """Regression: the card showed "0 animals" for instant schedules because
+    get_all_schedules / get_schedules_by_trainer didn't populate .animals for
+    instant mode (only instant_deliveries). The roster must now be filled."""
+    d1 = datetime(2026, 6, 5, 9, 0, 0)
+    d2 = datetime(2026, 6, 5, 10, 0, 0)
+    sid = database_handler.add_schedule(_instant("inst", [(1, 1, 1.0, d1), (2, 2, 2.0, d2)]))
+
+    loaded = next(s for s in database_handler.get_all_schedules() if s.schedule_id == sid)
+    assert sorted(loaded.animals) == [1, 2]
+    assert loaded.relay_unit_assignments == {"1": 1, "2": 2}
+
+    by_trainer = next(
+        s for s in database_handler.get_schedules_by_trainer(1) if s.schedule_id == sid
+    )
+    assert sorted(by_trainer.animals) == [1, 2]
+
+
 def test_update_instant_schedule_replaces_rows(database_handler):
     d1 = datetime(2026, 6, 5, 9, 0, 0)
     sid = database_handler.add_schedule(_instant("inst", [(1, 1, 1.0, d1)]))

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.13.0"
+__version__ = "1.13.1"


### PR DESCRIPTION
…(v1.13.1)

get_all_schedules / get_schedules_by_trainer only populated Schedule.animals for staggered schedules; for instant they filled instant_deliveries and left .animals empty. The Schedules Hub card reads len(schedule.animals), so instant cards showed "0 animals" even though the schedule had animals (the create log correctly said "1 animals"). Populate the animal roster (distinct, in order)
+ relay_unit_assignments from the instant deliveries in both loaders, so the card, and anything else reading schedule.animals, is correct for instant too.

Validated on the Pi: an instant card now reads "1 animal". PATCH.