### PR TITLE
fix(delivery): run instant deliveries through the strategy, like stagered (v1.14.0)

### DIFF
--- a/Project/gpio/relay_worker.py
+++ b/Project/gpio/relay_worker.py
@@ -447,14 +447,24 @@ class RelayWorker(QObject):
                             f"Scheduling delivery in {total_delay/1000:.2f} seconds"
                         )
 
+                        # Route instant deliveries through the same handler as
+                        # staggered so they use the active DeliveryStrategy
+                        # (SolenoidFlowStrategy pulse mode + per-cage
+                        # valve_calibration + flow-sensor metering), not the
+                        # legacy pump-trigger path. _handle_delivery is
+                        # window-optional, so the one-shot instant volume is used
+                        # directly.
+                        delivery_data = {
+                            'schedule_id': self.schedule_id,
+                            'animal_id': instant['animal_id'],
+                            'relay_unit_id': instant['relay_unit_id'],
+                            'water_volume': instant['water_volume'],
+                            'instant_time': delivery_time,
+                            'triggers': None,
+                        }
                         timer = QTimer(self)
                         timer.setSingleShot(True)
-                        timer.timeout.connect(
-                            lambda i=instant: self.trigger_relay(
-                                i['relay_unit_id'],
-                                i['water_volume'],  # Changed from 'volume' to 'water_volume'
-                            )
-                        )
+                        timer.timeout.connect(partial(self._handle_delivery, delivery_data.copy()))
                         timer.start(int(total_delay))
                         self.timers.append(timer)
                         scheduled_count += 1
@@ -646,18 +656,22 @@ class RelayWorker(QObject):
                 return False
             animal_id = delivery_data['animal_id']
             current_delivered = self.delivered_volumes.get(animal_id, 0)
-            target_volume = self.animal_windows[animal_id]['target_volume']
-
-            if current_delivered >= target_volume:
-                return True
-
             failed_count = self.failed_deliveries.get(animal_id, 0)
-            if failed_count > 0:
-                volume_increase = min(failed_count * 0.05, 0.2)
-                adjusted_volume = delivery_data['water_volume'] * (1 + volume_increase)
-                delivery_data['water_volume'] = min(
-                    adjusted_volume, target_volume - current_delivered
-                )
+            # Window-optional (same as _handle_delivery): staggered has a
+            # cumulative window target + guard + compensation; instant retries
+            # are one-shot and use the delivery's own volume.
+            window = getattr(self, 'animal_windows', None)
+            window = window.get(animal_id) if window else None
+            if window is not None:
+                target_volume = window['target_volume']
+                if current_delivered >= target_volume:
+                    return True
+                if failed_count > 0:
+                    volume_increase = min(failed_count * 0.05, 0.2)
+                    adjusted_volume = delivery_data['water_volume'] * (1 + volume_increase)
+                    delivery_data['water_volume'] = min(
+                        adjusted_volume, target_volume - current_delivered
+                    )
 
             success = await self.strategy.deliver(
                 relay_unit_id=delivery_data['relay_unit_id'],
@@ -1295,16 +1309,24 @@ class RelayWorker(QObject):
                 delivery_data['schedule_id'] = self.schedule_id
             animal_id = delivery_data['animal_id']
             current_delivered = self.delivered_volumes.get(animal_id, 0)
-            target_volume = self.animal_windows[animal_id]['target_volume']
-            if current_delivered >= target_volume:
-                return True
             failed_count = self.failed_deliveries.get(animal_id, 0)
-            if failed_count > 0:
-                volume_increase = min(failed_count * 0.05, 0.2)
-                adjusted_volume = delivery_data['water_volume'] * (1 + volume_increase)
-                delivery_data['water_volume'] = min(
-                    adjusted_volume, target_volume - current_delivered
-                )
+            # Staggered deliveries carry a cumulative per-animal window with a
+            # target volume + over-delivery guard + failed-retry compensation.
+            # Instant deliveries (run_instant_cycle reuses this method) are
+            # one-shot events with no window — deliver the delivery's own volume
+            # and skip the cumulative guard/compensation.
+            window = getattr(self, 'animal_windows', None)
+            window = window.get(animal_id) if window else None
+            if window is not None:
+                target_volume = window['target_volume']
+                if current_delivered >= target_volume:
+                    return True
+                if failed_count > 0:
+                    volume_increase = min(failed_count * 0.05, 0.2)
+                    adjusted_volume = delivery_data['water_volume'] * (1 + volume_increase)
+                    delivery_data['water_volume'] = min(
+                        adjusted_volume, target_volume - current_delivered
+                    )
             # In pump mode, keep legacy synchronous path via trigger_relay to avoid behavior change.
             # For other modes, delivery is handled asynchronously by strategy at schedule time.
             if self.hardware_mode == 'pump':

--- a/Project/tests/unit/test_instant_delivery_routing.py
+++ b/Project/tests/unit/test_instant_delivery_routing.py
@@ -1,0 +1,109 @@
+"""Instant deliveries route through the DeliveryStrategy, not the legacy path.
+
+Before v1.14.0, ``run_instant_cycle`` fired ``trigger_relay`` →
+``relay_handler.trigger_relays`` (legacy pump-trigger model), so on solenoid
+hardware instant deliveries ignored pulse width / valve calibration / the flow
+sensor and ran far slower than staggered. Now instant reuses ``_handle_delivery``
+(the same path as staggered), which dispatches per ``hardware_mode``:
+solenoid → ``strategy.deliver``, pump → ``trigger_relay``. ``_handle_delivery``
+is also window-optional so the one-shot instant volume is used directly.
+
+We exercise the real ``RelayWorker._handle_delivery`` by calling it with a
+lightweight stand-in ``self`` (a SimpleNamespace) — no QObject construction, so
+only a real ``QMutex`` is needed. Skips cleanly without PyQt5.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(autouse=True)
+def _restore_event_loop():
+    """_handle_delivery's solenoid branch calls asyncio.set_event_loop(None)
+    (correct in the worker thread). Running it on the test's MainThread leaves
+    no current loop, which would break later tests that use
+    asyncio.get_event_loop(). Restore one after each test."""
+    import asyncio
+
+    yield
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+def _self(hardware_mode, *, animal_windows=None):
+    from PyQt5.QtCore import QMutex  # noqa: PLC0415
+
+    ns = SimpleNamespace(
+        _cancel_requested=threading.Event(),
+        schedule_id=42,
+        delivered_volumes={},
+        failed_deliveries={},
+        mutex=QMutex(),
+        hardware_mode=hardware_mode,
+        strategy=MagicMock(deliver=AsyncMock(return_value=True)),
+        trigger_relay=MagicMock(return_value=True),
+        database_handler=MagicMock(),
+        progress=MagicMock(),
+        volume_updated=MagicMock(),
+        schedule_retry=MagicMock(),
+    )
+    if animal_windows is not None:
+        ns.animal_windows = animal_windows
+    return ns
+
+
+def _delivery(vol=0.5):
+    return {
+        "schedule_id": 42,
+        "animal_id": 1,
+        "relay_unit_id": 1,
+        "water_volume": vol,
+        "instant_time": datetime(2026, 6, 5, 9, 0, 0),
+        "triggers": None,
+    }
+
+
+def test_instant_solenoid_routes_to_strategy():
+    from gpio.relay_worker import RelayWorker  # noqa: PLC0415
+
+    me = _self("solenoid")  # no animal_windows -> instant (window-optional)
+    assert RelayWorker._handle_delivery(me, _delivery(0.5)) is True
+
+    me.strategy.deliver.assert_awaited_once()
+    kwargs = me.strategy.deliver.await_args.kwargs
+    assert kwargs["relay_unit_id"] == 1
+    assert kwargs["target_volume_ml"] == 0.5
+    me.trigger_relay.assert_not_called()
+
+
+def test_instant_pump_uses_trigger_relay():
+    from gpio.relay_worker import RelayWorker  # noqa: PLC0415
+
+    me = _self("pump")  # no animal_windows
+    assert RelayWorker._handle_delivery(me, _delivery(0.5)) is True
+
+    me.trigger_relay.assert_called_once_with(1, 0.5)
+    me.strategy.deliver.assert_not_called()
+
+
+def test_staggered_window_guard_still_holds():
+    """Window-optional refactor must not weaken the staggered over-delivery guard."""
+    from gpio.relay_worker import RelayWorker  # noqa: PLC0415
+
+    me = _self("solenoid", animal_windows={1: {"target_volume": 0.5}})
+    me.delivered_volumes = {1: 0.5}  # already at target
+    assert RelayWorker._handle_delivery(me, _delivery(0.5)) is True
+    me.strategy.deliver.assert_not_called()  # guard short-circuits, no delivery

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.13.1"
+__version__ = "1.14.0"


### PR DESCRIPTION


Instant deliveries went through the legacy pump-trigger path (run_instant_cycle -> trigger_relay -> relay_handler.trigger_relays), so on solenoid hardware they ignored pulse width, per-cage valve_calibration and the flow sensor, and ran much slower than staggered. Staggered already routes through _handle_delivery -> SolenoidFlowStrategy.deliver().

- run_instant_cycle now builds a delivery_data dict and wires each timer to _handle_delivery (via functools.partial), the same path staggered uses, so instant honors hardware_mode dispatch: solenoid -> strategy.deliver (20 ms pulse mode + calibration + flow metering), pump -> trigger_relay (preserved).
- _handle_delivery and execute_delivery are now window-optional: staggered keeps its cumulative window target + over-delivery guard + retry compensation; instant (no window) uses the delivery's own one-shot volume. Purely additive — staggered behavior is unchanged.
- trigger_relay / volume_calculator stay (pump mode still uses them).

Test: test_instant_delivery_routing.py asserts instant routes to strategy.deliver (solenoid) / trigger_relay (pump) and that the staggered window guard still short-circuits. Routing verified headless on the Pi (Python 3.11). MINOR: runtime delivery behavior change on real hardware.

The physical valve-cadence check on the device (instant should now pulse like staggered) is the remaining manual validation.