### PR TITLE
fix(schedules): restore get_schedule_instant_deliveries (v1.14.2)

### DIFF
--- a/Project/models/database_handler.py
+++ b/Project/models/database_handler.py
@@ -1029,6 +1029,35 @@ class DatabaseHandler:
         """
         await self.execute(query, (timestamp, volume, animal_id))
 
+    def get_schedule_instant_deliveries(self, schedule_id):
+        """Get all instant deliveries for a schedule with animal details.
+
+        Live runtime read used by run_stop_section + schedule_drop_area to
+        execute/drop instant schedules. (Wrongly removed in v1.14.1 with the
+        dead schedule_time_instants cluster — it reads schedule_instant_deliveries,
+        which IS the canonical instant table — and restored in v1.14.2.)
+        """
+        try:
+            with self.connect() as conn:
+                cursor = conn.cursor()
+                cursor.execute(
+                    '''
+                    SELECT sid.animal_id, a.lab_animal_id, a.name,
+                           sid.delivery_datetime, sid.water_volume, sid.completed,
+                           sid.relay_unit_id
+                    FROM schedule_instant_deliveries sid
+                    JOIN animals a ON sid.animal_id = a.animal_id
+                    WHERE sid.schedule_id = ?
+                    ORDER BY sid.delivery_datetime
+                ''',
+                    (schedule_id,),
+                )
+                return cursor.fetchall()
+        except sqlite3.Error as e:
+            print(f"Database error: {e}")
+            traceback.print_exc()
+            return []
+
     def add_staggered_schedule(self, schedule):
         """Add a new staggered delivery schedule"""
         try:

--- a/Project/tests/unit/test_instant_schedule.py
+++ b/Project/tests/unit/test_instant_schedule.py
@@ -63,6 +63,38 @@ def test_add_schedule_writes_instant_delivery_rows(database_handler):
     ]
 
 
+def _seed_animal(database_handler, animal_id, lab_id, name):
+    with database_handler.connect() as conn:
+        conn.execute(
+            "INSERT INTO animals (animal_id, lab_animal_id, name) VALUES (?, ?, ?)",
+            (animal_id, lab_id, name),
+        )
+        conn.commit()
+
+
+def test_get_schedule_instant_deliveries_returns_joined_rows(database_handler):
+    """The runtime read that run_stop_section / schedule_drop_area call to
+    execute or drop an instant schedule.
+
+    Regression for v1.14.1: this LIVE method was wrongly removed with the dead
+    schedule_time_instants cluster, so pressing Run on an instant schedule raised
+    'DatabaseHandler has no attribute get_schedule_instant_deliveries'. Restored
+    in v1.14.2. (It JOINs animals, so animals must exist.)
+    """
+    _seed_animal(database_handler, 1, "A1", "Mouse A")
+    _seed_animal(database_handler, 2, "A2", "Mouse B")
+    d1 = datetime(2026, 6, 9, 9, 0, 0)
+    d2 = datetime(2026, 6, 9, 10, 0, 0)
+    sid = database_handler.add_schedule(_instant("inst", [(1, 1, 1.0, d1), (2, 2, 2.0, d2)]))
+
+    rows = database_handler.get_schedule_instant_deliveries(sid)
+    # (animal_id, lab_animal_id, name, delivery_datetime, water_volume, completed, relay_unit_id)
+    assert len(rows) == 2
+    assert rows[0][0] == 1 and rows[0][1] == "A1" and rows[0][3] == d1.isoformat()
+    assert rows[0][4] == 1.0 and rows[0][6] == 1
+    assert rows[1][0] == 2 and rows[1][1] == "A2" and rows[1][4] == 2.0
+
+
 def test_loaded_instant_schedule_reports_its_animals(database_handler):
     """Regression: the card showed "0 animals" for instant schedules because
     get_all_schedules / get_schedules_by_trainer didn't populate .animals for

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.14.1"
+__version__ = "1.14.2"


### PR DESCRIPTION
Regression from v1.14.1: the dead-code cleanup removed get_schedule_instant_deliveries along with the genuinely-dead schedule_time_instants cluster. But this method is LIVE — run_stop_section and schedule_drop_area call it to execute/drop instant schedules — so pressing Run on an instant schedule raised "'DatabaseHandler' object has no attribute 'get_schedule_instant_deliveries'". The contiguous line-range delete swallowed it because it sat between the dead add_instant_schedule and add_staggered_schedule, and the boundary check didn't grep for it.

- Restore the method verbatim (reads schedule_instant_deliveries — the canonical instant table — JOINed to animals). The other 5 removed methods stay removed (verified dead).
- Add a regression test exercising the runtime read (the coverage gap that let this slip): seed animals + an instant schedule, assert the joined rows return.

Staggered was unaffected. No data was lost (the delivery rows exist); only the read method was missing. Validated against a copy of the live Pi DB: the operator's instant schedules ('test', 'fh') read back their delivery rows. Full suite 193 green; ruff clean.