### PR TITLE
Feat/hardware operation lock

### DIFF
--- a/Project/tests/unit/test_operation_gating.py
+++ b/Project/tests/unit/test_operation_gating.py
@@ -1,0 +1,93 @@
+"""Guard-layer integration: priming refuses/holds the OperationLock correctly.
+
+Proves the guard pattern end to end on the priming path (constructible with just
+a settings dict). The schedule and calibration paths use the identical
+acquire/release pattern against the same lock (unit-tested in
+test_operation_lock.py) and are validated on the Pi.
+
+Skips cleanly without PyQt5.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+_SETTINGS = {"num_hats": 1, "global_master_relay_id": 16}
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PyQt5.QtWidgets import QApplication  # noqa: PLC0415
+
+    return QApplication.instance() or QApplication([])
+
+
+@pytest.fixture(autouse=True)
+def _reset_lock(qapp):
+    # Force a fresh singleton bound to the live QApplication for each test
+    # (a stale QObject leaked across test modules otherwise).
+    import utils.operation_lock as ol  # noqa: PLC0415
+
+    ol._singleton = None
+    yield
+    ol._singleton = None
+
+
+@pytest.fixture(autouse=True)
+def _silence_msgbox(monkeypatch):
+    from PyQt5.QtWidgets import QMessageBox  # noqa: PLC0415
+
+    for name in ("warning", "critical", "information"):
+        monkeypatch.setattr(QMessageBox, name, staticmethod(lambda *a, **k: QMessageBox.Ok))
+
+
+def test_priming_refused_while_schedule_active(qapp):
+    from ui.PrimingControlWidget import PrimingControlWidget  # noqa: PLC0415
+    from utils.operation_lock import SCHEDULE, get_operation_lock  # noqa: PLC0415
+
+    lock = get_operation_lock()
+    assert lock.try_acquire(SCHEDULE) is True  # a schedule is running
+
+    w = PrimingControlWidget(_SETTINGS, lambda *_: None)
+    w._on_open_master_clicked()
+
+    # Refused before touching hardware; the schedule still owns the lock.
+    assert w._solenoid_controller is None
+    assert lock.held_by(SCHEDULE) is True
+
+
+def test_priming_acquires_on_open_and_releases_on_close(qapp, monkeypatch):
+    from ui.PrimingControlWidget import PrimingControlWidget  # noqa: PLC0415
+    from utils.operation_lock import PRIMING, get_operation_lock  # noqa: PLC0415
+
+    w = PrimingControlWidget(_SETTINGS, lambda *_: None)
+    ctrl = MagicMock()
+    ctrl.open_master.return_value = True
+    ctrl.close_master.return_value = True
+    ctrl.get_open_cages = MagicMock(return_value=set())
+    monkeypatch.setattr(w, "_get_solenoid_controller", lambda: ctrl)
+
+    w._on_open_master_clicked()
+    assert get_operation_lock().held_by(PRIMING) is True
+    ctrl.open_master.assert_called_once()
+
+    w._on_close_master_clicked()
+    assert get_operation_lock().is_busy() is False
+
+
+def test_priming_releases_when_hardware_unavailable(qapp, monkeypatch):
+    from ui.PrimingControlWidget import PrimingControlWidget  # noqa: PLC0415
+    from utils.operation_lock import get_operation_lock  # noqa: PLC0415
+
+    w = PrimingControlWidget(_SETTINGS, lambda *_: None)
+    monkeypatch.setattr(w, "_get_solenoid_controller", lambda: None)  # init failed
+    w._on_open_master_clicked()
+    # Acquired then released on the graceful abort — no stale lock.
+    assert get_operation_lock().is_busy() is False

--- a/Project/tests/unit/test_operation_lock.py
+++ b/Project/tests/unit/test_operation_lock.py
@@ -1,0 +1,113 @@
+"""Unit tests for the hardware OperationLock.
+
+Exactly one of schedule/priming/calibration may hold the lock (shared master
+valve + single flow sensor). These pin the acquire/refuse/re-entrant/release
+semantics and the state_changed signal. A fresh OperationLock() is used per test
+(not the singleton) for isolation.
+
+Needs PyQt5 for the QObject signal; skips cleanly without it.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytest.importorskip("PyQt5")
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from PyQt5.QtWidgets import QApplication  # noqa: PLC0415
+
+    return QApplication.instance() or QApplication([])
+
+
+def _lock():
+    from utils.operation_lock import OperationLock  # noqa: PLC0415
+
+    return OperationLock()
+
+
+def test_acquire_then_conflict_is_refused(qapp):
+    from utils.operation_lock import CALIBRATION, PRIMING, SCHEDULE  # noqa: PLC0415
+
+    lock = _lock()
+    assert lock.try_acquire(SCHEDULE) is True
+    assert lock.is_busy() is True
+    assert lock.held_by(SCHEDULE) is True
+    # A different operation cannot acquire while SCHEDULE holds it.
+    assert lock.try_acquire(PRIMING) is False
+    assert lock.try_acquire(CALIBRATION) is False
+    assert lock.active_operation() == SCHEDULE
+
+
+def test_reentrant_same_operation(qapp):
+    from utils.operation_lock import SCHEDULE  # noqa: PLC0415
+
+    lock = _lock()
+    assert lock.try_acquire(SCHEDULE) is True
+    # Same op re-acquires freely (schedule fires many deliveries).
+    assert lock.try_acquire(SCHEDULE) is True
+    assert lock.active_operation() == SCHEDULE
+
+
+def test_release_frees_for_next_operation(qapp):
+    from utils.operation_lock import CALIBRATION, SCHEDULE  # noqa: PLC0415
+
+    lock = _lock()
+    lock.try_acquire(SCHEDULE)
+    lock.release(SCHEDULE)
+    assert lock.is_busy() is False
+    assert lock.try_acquire(CALIBRATION) is True
+
+
+def test_release_by_non_holder_is_noop(qapp):
+    from utils.operation_lock import PRIMING, SCHEDULE  # noqa: PLC0415
+
+    lock = _lock()
+    lock.try_acquire(SCHEDULE)
+    lock.release(PRIMING)  # not the holder
+    assert lock.held_by(SCHEDULE) is True
+
+
+def test_force_release_clears_any_holder(qapp):
+    from utils.operation_lock import SCHEDULE  # noqa: PLC0415
+
+    lock = _lock()
+    lock.try_acquire(SCHEDULE)
+    lock.force_release()
+    assert lock.is_busy() is False
+
+
+def test_state_changed_fires_on_transitions_only(qapp):
+    from utils.operation_lock import SCHEDULE  # noqa: PLC0415
+
+    lock = _lock()
+    seen = []
+    lock.state_changed.connect(lambda: seen.append(lock.active_operation()))
+
+    lock.try_acquire(SCHEDULE)  # free -> held  (emit)
+    lock.try_acquire(SCHEDULE)  # re-entrant    (no emit)
+    lock.release(SCHEDULE)  # held -> free  (emit)
+    lock.release(SCHEDULE)  # already free  (no emit)
+
+    assert seen == [SCHEDULE, None]
+
+
+def test_active_label_is_human_readable(qapp):
+    from utils.operation_lock import PRIMING  # noqa: PLC0415
+
+    lock = _lock()
+    assert lock.active_label() == ""
+    lock.try_acquire(PRIMING)
+    assert "priming" in lock.active_label().lower()
+
+
+def test_singleton_is_stable(qapp):
+    from utils.operation_lock import get_operation_lock  # noqa: PLC0415
+
+    assert get_operation_lock() is get_operation_lock()

--- a/Project/ui/CalibrationWizard.py
+++ b/Project/ui/CalibrationWizard.py
@@ -27,6 +27,7 @@ from PyQt5.QtWidgets import (
     QTextEdit,
     QVBoxLayout,
 )
+from utils.operation_lock import CALIBRATION, get_operation_lock
 
 
 class CalibrationWizard(QDialog):
@@ -304,6 +305,18 @@ class CalibrationWizard(QDialog):
         - Robust error handling
         - Safe cleanup on failure
         """
+        # Hardware mutual-exclusion: calibration drives the master valve + flow
+        # sensor shared with schedules/priming. Hold the lock for the pulse run
+        # and release in finally (the later measure/results steps use no hardware).
+        lock = get_operation_lock()
+        if not lock.try_acquire(CALIBRATION):
+            QMessageBox.warning(
+                self,
+                "Hardware busy",
+                f"Cannot calibrate while {lock.active_label()} is in progress.",
+            )
+            self._safe_cancel()
+            return
         try:
             # Import required modules
             import time
@@ -379,6 +392,11 @@ class CalibrationWizard(QDialog):
             )
             # Use safe cancel instead of direct reject()
             self._safe_cancel()
+        finally:
+            # Hardware work is done after this method returns (valves closed
+            # above); release so schedule/priming can run during the manual
+            # measure/results steps.
+            lock.release(CALIBRATION)
 
     def _show_measurement(self):
         """Step 4: User measures output"""
@@ -538,6 +556,9 @@ class CalibrationWizard(QDialog):
                 f.write(f"{ts} [RRR] Wizard closeEvent (X button)\n")
         except Exception:
             pass
+        # Defensive: ensure the operation lock isn't left held if the dialog is
+        # closed mid-flow (idempotent — no-op if not held by calibration).
+        get_operation_lock().release(CALIBRATION)
         # Just accept the close - dialog will be marked as rejected automatically
         # by Qt when closed via X button (not accept() or reject())
         event.accept()
@@ -565,6 +586,9 @@ class CalibrationWizard(QDialog):
             self.log("User cancelled - calibration data will NOT be saved")
         else:
             self.log("User cancelled calibration wizard")
+
+        # Defensive: release the operation lock on cancel (idempotent).
+        get_operation_lock().release(CALIBRATION)
 
         # Close dialog immediately - user pressed cancel, they mean it
         # Use simple reject() - Qt will handle cleanup

--- a/Project/ui/PrimingControlWidget.py
+++ b/Project/ui/PrimingControlWidget.py
@@ -29,6 +29,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from utils.operation_lock import PRIMING, get_operation_lock
 
 
 class RelayControlModel(QObject):
@@ -331,15 +332,28 @@ class PrimingControlWidget(QWidget):
 
     def _on_open_master_clicked(self):
         """Handle master open button click."""
+        # Hardware mutual-exclusion: priming holds the lock for the whole
+        # session (master open → all closed), since the master valve is shared
+        # with schedules and calibration. Acquire before opening anything.
+        lock = get_operation_lock()
+        if not lock.try_acquire(PRIMING):
+            QMessageBox.warning(
+                self,
+                "Hardware busy",
+                f"Cannot prime while {lock.active_label()} is in progress.",
+            )
+            return
         try:
             controller = self._get_solenoid_controller()
             if not controller:
+                lock.release(PRIMING)
                 return
 
             if controller.open_master():
                 self._model.set_master_open(True)
                 self._log_success("Master solenoid OPENED")
             else:
+                lock.release(PRIMING)
                 QMessageBox.warning(
                     self,
                     "Hardware Error",
@@ -347,6 +361,7 @@ class PrimingControlWidget(QWidget):
                 )
 
         except Exception as e:
+            lock.release(PRIMING)
             self._log_error(f"Error opening master: {e}")
             QMessageBox.critical(self, "Error", f"Failed to open master:\n{str(e)}")
 
@@ -364,6 +379,8 @@ class PrimingControlWidget(QWidget):
 
             if controller.close_master():
                 self._model.set_master_open(False)
+                # All valves closed — end the priming session, release the lock.
+                get_operation_lock().release(PRIMING)
                 self._log_success("Master solenoid CLOSED, all cages closed")
             else:
                 QMessageBox.warning(self, "Hardware Error", "Failed to close master solenoid.")
@@ -440,6 +457,10 @@ class PrimingControlWidget(QWidget):
 
             # Reset model state
             self._model.reset()
+
+            # Emergency stop is the universal hardware failsafe: force-clear the
+            # operation lock so a stuck/stale holder can't lock out the app.
+            get_operation_lock().force_release()
 
             self._log_warning("⛔ EMERGENCY STOP - All relays closed")
             QMessageBox.information(self, "Emergency Stop", "All relays have been closed.")

--- a/Project/ui/SettingsTab.py
+++ b/Project/ui/SettingsTab.py
@@ -26,6 +26,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from utils.operation_lock import CALIBRATION, get_operation_lock
 
 from ui.PrimingControlWidget import PrimingControlWidget
 from ui.UpdatesTab import UpdatesTab
@@ -881,16 +882,17 @@ class SettingsTab(QWidget):
             )
             return
 
-        # Check if schedule is running
-        if self.run_stop_section and hasattr(self.run_stop_section, 'worker'):
-            if self.run_stop_section.worker and self.run_stop_section.worker.isRunning():
-                QMessageBox.warning(
-                    self,
-                    "Schedule Running",
-                    "Cannot calibrate while a schedule is running.\n\n"
-                    "Please stop the schedule first.",
-                )
-                return
+        # Hardware mutual-exclusion: no calibration while another hardware
+        # operation (schedule run / priming) holds the lock. Authoritative check
+        # (the per-cage / Calibrate-All buttons are also greyed out in Phase 2).
+        _lock = get_operation_lock()
+        if _lock.is_busy() and not _lock.held_by(CALIBRATION):
+            QMessageBox.warning(
+                self,
+                "Hardware busy",
+                f"Cannot calibrate while {_lock.active_label()} is in progress.",
+            )
+            return
 
         # Import and create wizard dialog
         from ui.CalibrationWizard import CalibrationWizard

--- a/Project/ui/run_stop_section.py
+++ b/Project/ui/run_stop_section.py
@@ -10,6 +10,7 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from utils.operation_lock import SCHEDULE, get_operation_lock
 
 from .schedule_drop_area import ScheduleDropArea
 
@@ -252,6 +253,19 @@ class RunStopSection(QWidget):
 
         if not self.schedule_drop_area.current_schedule:
             QMessageBox.warning(self, "No Schedule", "Please drop a schedule to run")
+            return
+
+        # Hardware mutual-exclusion: only one of schedule/priming/calibration may
+        # run at a time (shared master valve + single flow sensor). Acquire here,
+        # before any hardware work; release on every exit path (reset_ui /
+        # _reset_run_button / stop_program force-release).
+        lock = get_operation_lock()
+        if not lock.try_acquire(SCHEDULE):
+            QMessageBox.warning(
+                self,
+                "Hardware busy",
+                f"Cannot run the schedule while {lock.active_label()} is in progress.",
+            )
             return
 
         # ═══════════════════════════════════════════════════════════════════
@@ -498,6 +512,7 @@ class RunStopSection(QWidget):
     def _reset_run_button(self):
         """Reset run button to initial state after error or cancellation."""
         self.job_in_progress = False
+        get_operation_lock().release(SCHEDULE)
         self.run_button.setText("Run")
         self.update_button_states()
 
@@ -525,6 +540,7 @@ class RunStopSection(QWidget):
         except Exception as e:
             # Reset to initial state on error
             self.job_in_progress = False
+            get_operation_lock().release(SCHEDULE)
             self.run_button.setText("Run")
             self.update_button_states()
             QMessageBox.critical(self, "Error", f"Failed to run program: {str(e)}")
@@ -546,6 +562,7 @@ class RunStopSection(QWidget):
 
         except Exception as e:
             self.job_in_progress = False
+            get_operation_lock().release(SCHEDULE)
             self.update_button_states()
             QMessageBox.critical(self, "Error", f"Failed to stop schedule: {str(e)}")
 
@@ -583,6 +600,7 @@ class RunStopSection(QWidget):
                 self.progress_dialog = None
             QMessageBox.critical(self, "Error", f"Failed to stop schedule: {str(e)}")
             self.job_in_progress = False
+            get_operation_lock().release(SCHEDULE)
             self.update_button_states()
 
     def reset_ui(self):
@@ -593,6 +611,9 @@ class RunStopSection(QWidget):
         Reference: Qt State Management - https://doc.qt.io/qt-5/qabstractbutton.html
         """
         self.job_in_progress = False
+        # Schedule no longer running (natural completion or stop) — release the
+        # hardware lock so priming/calibration can run again.
+        get_operation_lock().release(SCHEDULE)
         # Reset both button texts to initial state
         self.run_button.setText("Run")
         self.stop_button.setText("Stop")

--- a/Project/utils/operation_lock.py
+++ b/Project/utils/operation_lock.py
@@ -1,0 +1,134 @@
+"""Process-wide hardware operation lock.
+
+Exactly one hardware operation may be active at a time: running a **schedule**,
+**priming**, or **calibration**. All three open the *single shared master
+solenoid*, and schedule + calibration both consume the *single flow sensor*, so
+they cannot physically overlap. This is operation-level mutual exclusion,
+sitting ABOVE the per-transaction :class:`drivers.i2c_coordinator.I2CCoordinator`
+(which only serialises ~50 ms I²C writes and force-releases — not enough to keep
+two long operations apart).
+
+It is exposed as a ``QObject`` process-wide singleton via
+:func:`get_operation_lock` (mirroring ``get_i2c_coordinator``) so every UI entry
+point can use it without dependency-injection plumbing — notably
+``PrimingControlWidget``, which has no ``system_controller``. ``state_changed``
+lets widgets enable/disable their controls.
+
+Two enforcement layers use this:
+- **Guard (authoritative):** each path calls :meth:`try_acquire` at start
+  (refusing on conflict) and releases on every exit path.
+- **UI (usability):** widgets subscribe to :attr:`state_changed` and disable the
+  controls belonging to the other operations.
+
+The lock is *advisory*: it gates the three known user entry points, not the I²C
+bus itself. Those three are the only initiators of hardware operations.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Optional
+
+from PyQt5.QtCore import QObject, pyqtSignal
+
+# Operation identifiers.
+SCHEDULE = "schedule"
+PRIMING = "priming"
+CALIBRATION = "calibration"
+
+_LABELS = {
+    SCHEDULE: "a schedule run",
+    PRIMING: "a priming session",
+    CALIBRATION: "a calibration",
+}
+
+
+class OperationLock(QObject):
+    """Single-holder, re-entrant-per-owner hardware operation lock."""
+
+    # Emitted whenever the busy/idle state changes (free→held or held→free).
+    state_changed = pyqtSignal()
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._mutex = threading.RLock()
+        self._active: Optional[str] = None
+        self._log = logging.getLogger(self.__class__.__name__)
+
+    def try_acquire(self, operation: str, label: str = "") -> bool:
+        """Acquire for ``operation``. Non-blocking.
+
+        Returns True if the lock was free (now held by ``operation``) or is
+        already held by the *same* ``operation`` (re-entrant — a schedule fires
+        many deliveries, priming opens several valves). Returns False, without
+        side effects, if a *different* operation holds it.
+        """
+        became_busy = False
+        with self._mutex:
+            if self._active is not None and self._active != operation:
+                self._log.info(
+                    "Operation '%s' refused: '%s' already active", operation, self._active
+                )
+                return False
+            became_busy = self._active is None
+            self._active = operation
+        if became_busy:
+            self.state_changed.emit()
+        return True
+
+    def release(self, operation: str) -> None:
+        """Release iff ``operation`` currently holds the lock (idempotent)."""
+        changed = False
+        with self._mutex:
+            if self._active == operation:
+                self._active = None
+                changed = True
+        if changed:
+            self.state_changed.emit()
+
+    def force_release(self) -> None:
+        """Unconditionally clear the lock — the stop/emergency failsafe path."""
+        changed = False
+        with self._mutex:
+            if self._active is not None:
+                self._log.warning("Force-releasing operation lock held by '%s'", self._active)
+                self._active = None
+                changed = True
+        if changed:
+            self.state_changed.emit()
+
+    def active_operation(self) -> Optional[str]:
+        with self._mutex:
+            return self._active
+
+    def active_label(self) -> str:
+        """Human-readable description of the active operation (for messages)."""
+        with self._mutex:
+            if self._active is None:
+                return ""
+            return _LABELS.get(self._active, self._active)
+
+    def is_busy(self) -> bool:
+        with self._mutex:
+            return self._active is not None
+
+    def held_by(self, operation: str) -> bool:
+        with self._mutex:
+            return self._active == operation
+
+    def reset(self) -> None:
+        """Test seam: clear state silently (use in test setup/teardown)."""
+        with self._mutex:
+            self._active = None
+
+
+_singleton: Optional[OperationLock] = None
+
+
+def get_operation_lock() -> OperationLock:
+    """Return the process-wide :class:`OperationLock` (lazily created)."""
+    global _singleton
+    if _singleton is None:
+        _singleton = OperationLock()
+    return _singleton

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.14.1"
+__version__ = "1.15.0"


### PR DESCRIPTION
Run a schedule → priming valves + Calibrate refuse.
Run a schedule to completion, then run again (proves no stale lock → no lockout).
Open a priming valve → Run + Calibrate refuse; "Close Master" re-enables.
Start a calibration → Run + priming refuse; finish re-enables.
Emergency "CLOSE ALL RELAYS" clears the lock.