### PR TITLE
feat(ui): grey out controls locked by another hardware operation (v1.15.1)

### DIFF
--- a/Project/tests/unit/test_operation_gating.py
+++ b/Project/tests/unit/test_operation_gating.py
@@ -91,3 +91,24 @@ def test_priming_releases_when_hardware_unavailable(qapp, monkeypatch):
     w._on_open_master_clicked()
     # Acquired then released on the graceful abort — no stale lock.
     assert get_operation_lock().is_busy() is False
+
+
+def test_priming_open_buttons_grey_out_when_locked_elsewhere(qapp):
+    """Phase 2 UI gating: when a schedule (or calibration) holds the lock, the
+    priming Open buttons are visibly disabled via the state_changed signal;
+    releasing re-enables them per valve state."""
+    from ui.PrimingControlWidget import PrimingControlWidget  # noqa: PLC0415
+    from utils.operation_lock import SCHEDULE, get_operation_lock  # noqa: PLC0415
+
+    w = PrimingControlWidget(_SETTINGS, lambda *_: None)
+    # Idle: master closed -> Open Master enabled.
+    assert w.master_open_btn.isEnabled() is True
+
+    # Another operation acquires -> state_changed fires -> Open buttons disabled.
+    get_operation_lock().try_acquire(SCHEDULE)
+    assert w.master_open_btn.isEnabled() is False
+    assert w.cage_open_btn.isEnabled() is False
+
+    # Release -> Open Master re-enabled (master still closed).
+    get_operation_lock().force_release()
+    assert w.master_open_btn.isEnabled() is True

--- a/Project/ui/PrimingControlWidget.py
+++ b/Project/ui/PrimingControlWidget.py
@@ -142,6 +142,11 @@ class PrimingControlWidget(QWidget):
         self._model.master_state_changed.connect(self._on_master_state_changed)
         self._model.cage_state_changed.connect(self._on_cage_state_changed)
 
+        # Grey out the Open controls when another hardware operation (schedule
+        # or calibration) holds the lock; refresh on every lock state change.
+        get_operation_lock().state_changed.connect(self._refresh_lock_state)
+        self._refresh_lock_state()
+
     def _init_ui(self):
         """Initialize user interface following Material Design principles."""
         layout = QVBoxLayout(self)
@@ -497,6 +502,28 @@ class PrimingControlWidget(QWidget):
     def _on_cage_state_changed(self, cage_id: int, is_open: bool):
         """Handle cage state changes from model."""
         self._update_cage_button_states()
+
+    def _refresh_lock_state(self):
+        """Grey out the Open controls while another hardware operation (a
+        schedule run or calibration) holds the operation lock; restore the
+        normal valve/selection-driven state otherwise.
+
+        Close + Emergency are intentionally left to their normal logic so the
+        operator can always shut valves. The Phase-1 guard still refuses on
+        click regardless — this is purely the visual layer.
+        """
+        lock = get_operation_lock()
+        if lock.is_busy() and not lock.held_by(PRIMING):
+            tip = f"Unavailable while {lock.active_label()} is in progress"
+            self.master_open_btn.setEnabled(False)
+            self.master_open_btn.setToolTip(tip)
+            self.cage_open_btn.setEnabled(False)
+            self.cage_open_btn.setToolTip(tip)
+        else:
+            # Restore enable state from the current valve/selection state.
+            self._on_master_state_changed(self._model.is_master_open)
+            self.master_open_btn.setToolTip("")
+            self.cage_open_btn.setToolTip("")
 
     # ==================== UI Helper Methods ====================
 

--- a/Project/ui/SettingsTab.py
+++ b/Project/ui/SettingsTab.py
@@ -708,6 +708,10 @@ class SettingsTab(QWidget):
         )
         calibrate_all_btn.clicked.connect(self._calibrate_all_uncalibrated)
         button_row.addWidget(calibrate_all_btn)
+        self._calibrate_all_btn = calibrate_all_btn
+        # Grey out calibration launch buttons while another hardware operation
+        # (schedule run / priming) holds the lock; the launcher also refuses.
+        get_operation_lock().state_changed.connect(self._apply_calibration_lock_state)
 
         export_btn = QPushButton("Export Report")
         export_btn.setObjectName("CompactButton")
@@ -745,6 +749,10 @@ class SettingsTab(QWidget):
         from PyQt5.QtWidgets import QPushButton
 
         self.calibration_table.setRowCount(15)  # 15 cages
+
+        # Per-row launch buttons are recreated here; track them fresh so the
+        # operation-lock gating can grey them out (see _apply_calibration_lock_state).
+        self._calibrate_buttons = []
 
         # Get all calibrations from database
         calibrations = {}
@@ -823,6 +831,7 @@ class SettingsTab(QWidget):
                 btn.setToolTip(f"Recalibrate cage {cage_id}")
                 btn.clicked.connect(lambda checked, c=cage_id: self._launch_calibration_wizard(c))
                 self.calibration_table.setCellWidget(row, 5, btn)
+                self._calibrate_buttons.append(btn)
 
             else:
                 # Not calibrated - show warning
@@ -856,6 +865,27 @@ class SettingsTab(QWidget):
                 btn.setToolTip(f"Calibrate cage {cage_id} (250 pulses)")
                 btn.clicked.connect(lambda checked, c=cage_id: self._launch_calibration_wizard(c))
                 self.calibration_table.setCellWidget(row, 5, btn)
+                self._calibrate_buttons.append(btn)
+
+        # Reflect the current operation-lock state on the freshly-built buttons.
+        self._apply_calibration_lock_state()
+
+    def _apply_calibration_lock_state(self):
+        """Grey out the calibration launch buttons while another hardware
+        operation (a schedule run / priming) holds the operation lock. Purely
+        visual — _launch_calibration_wizard also refuses. Tolerates being called
+        before the table is first populated."""
+        lock = get_operation_lock()
+        busy = lock.is_busy() and not lock.held_by(CALIBRATION)
+        tip = f"Unavailable while {lock.active_label()} is in progress" if busy else ""
+        buttons = list(getattr(self, "_calibrate_buttons", []))
+        all_btn = getattr(self, "_calibrate_all_btn", None)
+        if all_btn is not None:
+            buttons.append(all_btn)
+        for btn in buttons:
+            btn.setEnabled(not busy)
+            if busy:
+                btn.setToolTip(tip)
 
     # Size-only stylesheet for the calibration-table action buttons. Cell-widget
     # buttons do not match the `QTableWidget QPushButton` compact rule in the

--- a/Project/ui/run_stop_section.py
+++ b/Project/ui/run_stop_section.py
@@ -71,6 +71,10 @@ class RunStopSection(QWidget):
             # Set initial state
             self._update_controls_access()
 
+        # Refresh Run / Change-Relay-Hats enablement when another hardware
+        # operation (priming/calibration) acquires or releases the lock.
+        get_operation_lock().state_changed.connect(self.update_button_states)
+
         print("RunStopSection initialized")
 
     def init_ui(self):
@@ -159,10 +163,21 @@ class RunStopSection(QWidget):
         """
         is_logged_in = self.login_system.is_logged_in() if self.login_system else False
 
+        # Disable Run/Relay-Hats when another hardware operation holds the lock
+        # (priming/calibration). NOTE: this run/relay gating is intentionally
+        # duplicated in update_button_states; keep the two in sync (a follow-up
+        # could consolidate them, but not in this UX PR — it's the run path).
+        lock = get_operation_lock()
+        lock_elsewhere = lock.is_busy() and not lock.held_by(SCHEDULE)
+
         # Update button states based on login
-        self.run_button.setEnabled(is_logged_in and not self.job_in_progress)
+        self.run_button.setEnabled(
+            is_logged_in and not self.job_in_progress and not lock_elsewhere
+        )
         self.stop_button.setEnabled(is_logged_in and self.job_in_progress)
-        self.relay_hats_button.setEnabled(is_logged_in and not self.job_in_progress)
+        self.relay_hats_button.setEnabled(
+            is_logged_in and not self.job_in_progress and not lock_elsewhere
+        )
 
         # Update schedule drop area
         self.schedule_drop_area.setEnabled(is_logged_in)
@@ -174,6 +189,11 @@ class RunStopSection(QWidget):
             self.stop_button.setToolTip(disabled_tooltip)
             self.relay_hats_button.setToolTip(disabled_tooltip)
             self.schedule_drop_area.setToolTip("Please log in to drop schedules")
+        elif lock_elsewhere:
+            busy_tip = f"Unavailable while {lock.active_label()} is in progress"
+            self.run_button.setToolTip(busy_tip)
+            self.relay_hats_button.setToolTip(busy_tip)
+            self.schedule_drop_area.setToolTip("Drag and drop a schedule here to load it")
         else:
             # Restore normal tooltips
             self.run_button.setToolTip("Start the loaded schedule")
@@ -195,10 +215,16 @@ class RunStopSection(QWidget):
             f"[SEC] update_button_states: login_system={self.login_system is not None}, is_logged_in={is_logged_in}, job_in_progress={self.job_in_progress}"
         )
 
+        # Also disable Run/Relay-Hats when another hardware operation holds the
+        # lock (priming/calibration). Mirrors the term in _update_controls_access
+        # — keep both in sync (see the note there).
+        lock = get_operation_lock()
+        lock_elsewhere = lock.is_busy() and not lock.held_by(SCHEDULE)
+
         # Buttons require both: logged in AND appropriate job state
-        run_enabled = is_logged_in and not self.job_in_progress
+        run_enabled = is_logged_in and not self.job_in_progress and not lock_elsewhere
         stop_enabled = is_logged_in and self.job_in_progress
-        relay_enabled = is_logged_in and not self.job_in_progress
+        relay_enabled = is_logged_in and not self.job_in_progress and not lock_elsewhere
 
         print(
             f"[SEC] Button states: run={run_enabled}, stop={stop_enabled}, relay={relay_enabled}"
@@ -219,6 +245,10 @@ class RunStopSection(QWidget):
             self.run_button.setToolTip("Job in progress")
             self.relay_hats_button.setToolTip("Cannot change relay hats during a job")
             self.stop_button.setToolTip("Click to stop the current job")
+        elif lock_elsewhere:
+            busy_tip = f"Unavailable while {lock.active_label()} is in progress"
+            self.run_button.setToolTip(busy_tip)
+            self.relay_hats_button.setToolTip(busy_tip)
         else:
             self.run_button.setToolTip("Start the loaded schedule")
             self.relay_hats_button.setToolTip("Configure relay HAT hardware")

--- a/Project/version.py
+++ b/Project/version.py
@@ -5,4 +5,4 @@ docs/UPDATE_SYSTEM.md. A release is the git tag ``v<__version__>``; the
 release CI workflow rejects any tag whose name does not match this value.
 """
 
-__version__ = "1.15.0"
+__version__ = "1.15.1"


### PR DESCRIPTION


Phase 2 of the hardware operation lock (Phase 1 = v1.15.0). The guard already refuses conflicting operations; this makes the disabled ones *look* disabled by subscribing each surface to OperationLock.state_changed and greying the controls that belong to the other operations. Rule: a control for op X is disabled when lock.is_busy() and not lock.held_by(X); X's own Close/Stop/Emergency stay enabled so the operator can always finish/stop.

- run_stop_section: connect state_changed -> update_button_states; add a lock_elsewhere term to update_button_states + _update_controls_access so Run and Change-Relay-Hats grey out (with tooltip) while priming/calibration hold the lock. (Term duplicated across the two methods per the existing pattern; flagged for a future consolidation — not refactoring the run path here.)
- PrimingControlWidget: _refresh_lock_state() greys Open Master / Open Selected when locked elsewhere and otherwise delegates to the existing valve-state slots; Close + Emergency are never disabled. Wired via state_changed.
- SettingsTab: per-row Calibrate/Recalibrate + Calibrate-All grey out via _apply_calibration_lock_state(); buttons re-collected each table repopulate.

Purely the visual layer — the Phase 1 guard remains authoritative, so a missed refresh only makes a button look enabled, never permits an unsafe overlap.

Test: test_operation_gating.py asserts the priming Open buttons grey out on state_changed and re-enable on release. Full suite 205 green; ruff clean; validated visually on the Pi (Open greyed, Close/Emergency enabled). PATCH.